### PR TITLE
Allow rendering all quest markers on minimap

### DIFF
--- a/GWToolboxdll/Widgets/Minimap/Minimap.cpp
+++ b/GWToolboxdll/Widgets/Minimap/Minimap.cpp
@@ -351,6 +351,14 @@ void Minimap::OnUIMessage(GW::HookStatus*, const GW::UI::UIMessage msgid, void* 
                 SetWindowVisible(GW::UI::WindowID_Compass, true);
             }
             instance.is_observing = GW::Map::GetIsObserving();
+            // Cycle active quests to cache their markers
+            auto active_quest_id = GW::QuestMgr::GetActiveQuestId();
+            if (const GW::QuestLog* questLog = GW::QuestMgr::GetQuestLog(); questLog != nullptr) {
+                for (auto& quest : *questLog) {
+                    GW::QuestMgr::SetActiveQuestId(quest.quest_id);
+                }
+            }
+            GW::QuestMgr::SetActiveQuestId(active_quest_id);
         }
         break;
         case GW::UI::UIMessage::kSkillActivated: {

--- a/GWToolboxdll/Widgets/Minimap/Minimap.cpp
+++ b/GWToolboxdll/Widgets/Minimap/Minimap.cpp
@@ -220,6 +220,15 @@ namespace {
             }
         });
     }
+    void CycleActiveQuests() {
+        auto active_quest_id = GW::QuestMgr::GetActiveQuestId();
+        if (const GW::QuestLog* questLog = GW::QuestMgr::GetQuestLog(); questLog != nullptr) {
+            for (auto& quest : *questLog) {
+                GW::QuestMgr::SetActiveQuestId(quest.quest_id);
+            }
+        }
+        GW::QuestMgr::SetActiveQuestId(active_quest_id);
+    }
 }
 
 void Minimap::DrawHelp()
@@ -329,6 +338,10 @@ void Minimap::Initialize()
         RegisterUIMessageCallback(&UIMsg_Entry, message_id, OnUIMessage);
     }
 
+    if (GW::Map::GetInstanceType() != GW::Constants::InstanceType::Loading) {
+        GW::GameThread::Enqueue(CycleActiveQuests);
+    }
+
     last_moved = TIMER_INIT();
 
     pmap_renderer.Invalidate();
@@ -352,13 +365,7 @@ void Minimap::OnUIMessage(GW::HookStatus*, const GW::UI::UIMessage msgid, void* 
             }
             instance.is_observing = GW::Map::GetIsObserving();
             // Cycle active quests to cache their markers
-            auto active_quest_id = GW::QuestMgr::GetActiveQuestId();
-            if (const GW::QuestLog* questLog = GW::QuestMgr::GetQuestLog(); questLog != nullptr) {
-                for (auto& quest : *questLog) {
-                    GW::QuestMgr::SetActiveQuestId(quest.quest_id);
-                }
-            }
-            GW::QuestMgr::SetActiveQuestId(active_quest_id);
+            CycleActiveQuests();
         }
         break;
         case GW::UI::UIMessage::kSkillActivated: {

--- a/GWToolboxdll/Widgets/Minimap/SymbolsRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/SymbolsRenderer.cpp
@@ -183,9 +183,7 @@ void SymbolsRenderer::Render(IDirect3DDevice9* device)
 
     if (render_all_quests)
     {
-        const GW::QuestLog* questLog = GW::QuestMgr::GetQuestLog();
-
-        if (questLog) {
+        if (const GW::QuestLog* questLog = GW::QuestMgr::GetQuestLog()) {
             for (const auto& quest : *questLog) {
                 drawQuestMarker(quest);
             }

--- a/GWToolboxdll/Widgets/Minimap/SymbolsRenderer.h
+++ b/GWToolboxdll/Widgets/Minimap/SymbolsRenderer.h
@@ -20,6 +20,8 @@ private:
     Color color_north = 0;
     Color color_modifier = 0;
 
+    bool render_all_quests = false;
+
     const DWORD star_ntriangles = 16;
     DWORD star_offset = 0;
 

--- a/GWToolboxdll/Windows/InfoWindow.cpp
+++ b/GWToolboxdll/Windows/InfoWindow.cpp
@@ -586,18 +586,6 @@ namespace {
         ImGui::Checkbox("Show message in chat when you're the last player to resign", &show_last_to_resign_message);
     }
 
-    using GetQuestInfo_pt = void(__cdecl*)(GW::Constants::QuestID);
-    GetQuestInfo_pt RequestQuestInfo_Func = nullptr;
-
-    bool RequestQuestInfo(const GW::Constants::QuestID quest_id)
-    {
-        if (!RequestQuestInfo_Func) {
-            const uintptr_t address = GW::Scanner::Find("\x68\x4a\x01\x00\x10\xff\x77\x04", "xxxxxxxx", 0x7a);
-            RequestQuestInfo_Func = (GetQuestInfo_pt)GW::Scanner::FunctionFromNearCall(address);
-        }
-        return RequestQuestInfo_Func ? RequestQuestInfo_Func(quest_id), true : false;
-    }
-
     bool GetQuestEntryGroupName(const GW::Constants::QuestID quest_id, wchar_t* out, const size_t out_len)
     {
         const auto quest = GW::QuestMgr::GetQuest(quest_id);
@@ -981,7 +969,7 @@ void InfoWindow::Draw(IDirect3DDevice9*)
             ImGui::SameLine();
             if (ImGui::SmallButton("Request quest info")) {
                 for (const auto& quest : quests_missing_info) {
-                    RequestQuestInfo(quest->quest_id);
+                    GW::QuestMgr::RequestQuestInfo(quest);
                 }
             }
 #endif


### PR DESCRIPTION
Adds an option to render all quest markers on the minimap rather than just the active quest

Closes #803

