### PR TITLE
Fix crashes from GetRemainingArgsWStr

### DIFF
--- a/GWToolboxdll/Modules/ChatCommands.cpp
+++ b/GWToolboxdll/Modules/ChatCommands.cpp
@@ -2002,6 +2002,10 @@ const wchar_t* ChatCommands::GetRemainingArgsWstr(const wchar_t* message, const 
             out++;
         }
     }
+
+    if(!out) {
+        return L"";
+    }
     return out;
 };
 


### PR DESCRIPTION
GetRemainingArgsWstr previously returned nullptr when there was no space within the input string, causing crashes if e.g. the chat command "/show" was used with no parameter given.

This adds an extra check so GetRemainingArgsWstr instead returns an empty string in that case.  Depending on intended behaviour, it may instead be preferable to add null checks to every call site of GetRemainingArgsWStr.