### PR TITLE
987 fix crashes

### DIFF
--- a/GWToolboxdll/Modules/ChatCommands.cpp
+++ b/GWToolboxdll/Modules/ChatCommands.cpp
@@ -2002,6 +2002,10 @@ const wchar_t* ChatCommands::GetRemainingArgsWstr(const wchar_t* message, const 
             out++;
         }
     }
+
+    if(!out) {
+        return L"";
+    }
     return out;
 };
 

--- a/GWToolboxdll/Widgets/TimerWidget.cpp
+++ b/GWToolboxdll/Widgets/TimerWidget.cpp
@@ -682,7 +682,7 @@ void TimerWidget::Draw(IDirect3DDevice9*)
             ImGui::SetCursorPos(ImVec2(cur2.x + 1, cur2.y + 1));
             ImGui::TextColored(ImColor(0, 0, 0), buffer);
             ImGui::SetCursorPos(cur2);
-            if (extra_color) {
+            if (_extra_color) {
                 ImGui::TextColored(*_extra_color, buffer);
             }
             else {


### PR DESCRIPTION
GetRemainingArgsWstr previously returned nullptr when there was no space within
the input string, causing crashes if e.g. the chat command "/show" was used with
no parameter given.

This adds an extra check so GetRemainingArgsWstr instead returns an empty string
in that case.

----

Fix null pointer crash in timer widget following refactor