### PR TITLE
Fix 'hide city pcons in explorable area' not loading

### DIFF
--- a/GWToolboxdll/Windows/PconsWindow.cpp
+++ b/GWToolboxdll/Windows/PconsWindow.cpp
@@ -667,6 +667,7 @@ void PconsWindow::LoadSettings(ToolboxIni* ini)
     Pcon::suppress_drunk_emotes = ini->GetBoolValue(Name(), VAR_NAME(suppress_drunk_emotes), Pcon::suppress_drunk_emotes);
     Pcon::suppress_lunar_skills = ini->GetBoolValue(Name(), VAR_NAME(suppress_lunar_skills), Pcon::suppress_lunar_skills);
     Pcon::pcons_by_character = ini->GetBoolValue(Name(), VAR_NAME(pcons_by_character), Pcon::pcons_by_character);
+    Pcon::hide_city_pcons_in_explorable_areas = ini->GetBoolValue(Name(), VAR_NAME(hide_city_pcons_in_explorable_areas), Pcon::hide_city_pcons_in_explorable_areas);
     Pcon::refill_if_below_threshold = ini->GetBoolValue(Name(), VAR_NAME(refill_if_below_threshold), Pcon::refill_if_below_threshold);
     LOAD_BOOL(show_auto_refill_pcons_tickbox);
     LOAD_BOOL(show_auto_disable_pcons_tickbox);


### PR DESCRIPTION
`hide_city_pcons_in_explorable_areas` was missing from PconsWindow::LoadSettings.