### PR TITLE
Refactor item description hook into its own module

### DIFF
--- a/GWToolboxdll/GWToolbox.cpp
+++ b/GWToolboxdll/GWToolbox.cpp
@@ -30,6 +30,7 @@
 #include "Modules/GwDatTextureModule.h"
 #include "Modules/HallOfMonumentsModule.h"
 #include "Modules/InventoryManager.h"
+#include "Modules/ItemDescriptionHandler.h"
 #include "Modules/LoginModule.h"
 #include "Modules/Updater.h"
 #include "Modules/PriceCheckerModule.h"
@@ -864,6 +865,7 @@ void GWToolbox::UpdateInitialising(float) {
     ToggleModule(CrashHandler::Instance());
     ToggleModule(Resources::Instance());
     ToggleModule(ToolboxTheme::Instance());
+    ToggleModule(ItemDescriptionHandler::Instance());
     ToggleModule(ToolboxSettings::Instance());
     ToggleModule(MainWindow::Instance());
     ToggleModule(DialogModule::Instance());

--- a/GWToolboxdll/Modules/GameSettings.h
+++ b/GWToolboxdll/Modules/GameSettings.h
@@ -4,6 +4,8 @@
 
 #include <GWCA/Utilities/Hook.h>
 
+#include <Modules/ItemDescriptionHandler.h>
+
 #include <Color.h>
 #include <ToolboxModule.h>
 
@@ -62,7 +64,7 @@ public:
     bool WndProc(UINT Message, WPARAM wParam, LPARAM lParam) override;
 
     // callback functions
-    static void OnGetItemDescription(const uint32_t item_id, const uint32_t flags, const uint32_t quantity, const uint32_t unk, wchar_t** name_out, wchar_t** description_out);
+    static void OnGetItemDescription(ItemDescriptionEventArgs&);
     static void OnPingWeaponSet(GW::HookStatus*, GW::UI::UIMessage, void*, void*);
     static void OnAgentLoopingAnimation(GW::HookStatus*, const GW::Packet::StoC::GenericValue*);
     static void OnAgentMarker(GW::HookStatus* status, GW::Packet::StoC::GenericValue* pak);

--- a/GWToolboxdll/Modules/ItemDescriptionHandler.cpp
+++ b/GWToolboxdll/Modules/ItemDescriptionHandler.cpp
@@ -97,3 +97,20 @@ void ItemDescriptionHandler::OnGetItemDescription(const uint32_t item_id, const 
 
     GW::Hook::LeaveHook();
 }
+
+// Unregisters all instance of the provided callback
+void ItemDescriptionHandler::UnregisterDescriptionCallback(ItemDescriptionCallback callback)
+{
+    erase_if(this->callbacks, [callback](const auto& cb) {
+        return cb.callback == callback;
+    });
+}
+
+// Unregisters all instances of the provided callback at the provided altitude.  Leaves all instances at other
+// altitudes registered.
+void ItemDescriptionHandler::UnregisterDescriptionCallback(ItemDescriptionCallback callback, unsigned int altitude)
+{
+    erase_if(this->callbacks, [callback, altitude](const auto& cb) {
+        return cb.callback == callback && cb.altitude == altitude;
+    });
+}

--- a/GWToolboxdll/Modules/ItemDescriptionHandler.cpp
+++ b/GWToolboxdll/Modules/ItemDescriptionHandler.cpp
@@ -1,0 +1,99 @@
+#include <Modules/ItemDescriptionHandler.h>
+
+#include <GWCA/Utilities/Hooker.h>
+#include <GWCA/Utilities/Scanner.h>
+
+void __cdecl ItemDescriptionHandler::OnGetItemDescription_Wrapper(const uint32_t item_id, const uint32_t flags, const uint32_t quantity, const uint32_t unk, wchar_t** out_name, wchar_t** out_description)
+{
+    ItemDescriptionHandler::Instance().OnGetItemDescription(item_id, flags, quantity, unk, out_name, out_description);
+}
+
+void ItemDescriptionHandler::Initialize()
+{
+    GetItemDescription_Func = (GetItemDescription_pt)GW::Scanner::Find("\x8b\xc3\x25\xfd\x00\x00\x00\x3c\xfd", "xxxxxxxxx", -0x5f);
+    if (GetItemDescription_Func) {
+        GW::HookBase::CreateHook(
+            reinterpret_cast<void**>(&GetItemDescription_Func),
+            reinterpret_cast<void*>(&OnGetItemDescription_Wrapper),
+            reinterpret_cast<void**>(&GetItemDescription_Ret));
+        GW::HookBase::EnableHooks(GetItemDescription_Func);
+    }
+}
+
+void ItemDescriptionHandler::SignalTerminate()
+{
+    if (GetItemDescription_Func) {
+        GW::HookBase::RemoveHook(GetItemDescription_Func);
+        GetItemDescription_Func = nullptr;
+    }
+
+    ToolboxModule::SignalTerminate();
+}
+
+void ItemDescriptionHandler::RegisterDescriptionCallback(ItemDescriptionCallback callback, unsigned int altitude)
+{
+    auto it = this->callbacks.cbegin();
+    while (it != this->callbacks.cend()) {
+        if (it->altitude > altitude) {
+            break;
+        }
+
+        it++;
+    }
+
+    this->callbacks.insert(it, ItemDescriptionHandler::CallbackEntry { altitude, callback });
+}
+
+void ItemDescriptionHandler::OnGetItemDescription(const uint32_t item_id, const uint32_t flags, const uint32_t quantity, const uint32_t unk, wchar_t** out_name, wchar_t** out_desc) {
+    GW::Hook::EnterHook();
+
+    {
+        std::lock_guard<std::mutex> guard(this->modified_strings_mutex);
+
+        this->modified_name.clear();
+        this->modified_description.clear();
+
+        GetItemDescription_Ret(item_id, flags, quantity, unk, out_name, out_desc);
+
+        if (out_name != nullptr && *out_name != nullptr) {
+            this->modified_name = *out_name;
+        }
+        if (out_desc != nullptr && *out_desc != nullptr) {
+            this->modified_description = *out_desc;
+        }
+
+        auto args = ItemDescriptionEventArgs {
+            .item_id =  item_id,
+            .flags = flags,
+            .quantity = quantity,
+            .unk = unk,
+            .block_name = false,
+            .block_description = false,
+            .name = this->modified_name,
+            .description = this->modified_description,
+        };
+
+        for (auto& cb : this->callbacks) {
+            cb.callback(args);
+        }
+
+        if (out_name != nullptr) {
+            if (args.block_name) {
+                *out_name = nullptr;
+            }
+            else {
+                *out_name = modified_name.data();
+            }
+        }
+        if (out_desc != nullptr) {
+            if (args.block_description) {
+                *out_desc = nullptr;
+            }
+            else {
+                *out_desc = modified_description.data();
+            }
+        }
+    }
+
+    GW::Hook::LeaveHook();
+}

--- a/GWToolboxdll/Modules/ItemDescriptionHandler.cpp
+++ b/GWToolboxdll/Modules/ItemDescriptionHandler.cpp
@@ -78,7 +78,7 @@ void ItemDescriptionHandler::OnGetItemDescription(const uint32_t item_id, const 
         }
 
         if (out_name != nullptr) {
-            if (args.block_name) {
+            if (args.block_name || modified_name.c_str()[0] == L'\0') {
                 *out_name = nullptr;
             }
             else {
@@ -86,7 +86,7 @@ void ItemDescriptionHandler::OnGetItemDescription(const uint32_t item_id, const 
             }
         }
         if (out_desc != nullptr) {
-            if (args.block_description) {
+            if (args.block_description || modified_description.c_str()[0] == L'\0') {
                 *out_desc = nullptr;
             }
             else {

--- a/GWToolboxdll/Modules/ItemDescriptionHandler.h
+++ b/GWToolboxdll/Modules/ItemDescriptionHandler.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "ToolboxModule.h"
+
+struct ItemDescriptionEventArgs {
+    const uint32_t item_id;
+    const uint32_t flags;
+    const uint32_t quantity;
+    const uint32_t unk;
+
+    bool block_name;
+    bool block_description;
+
+    std::wstring& name;
+    std::wstring& description;
+};
+
+using ItemDescriptionCallback = void(*)(ItemDescriptionEventArgs& eventArgs);
+
+class ItemDescriptionHandler final : public ToolboxModule {
+private:
+    using GetItemDescription_pt = void(__cdecl*)(uint32_t item_id, uint32_t flags, uint32_t quantity, uint32_t unk, wchar_t** out_name, wchar_t** out_desc);
+    GetItemDescription_pt GetItemDescription_Func = nullptr, GetItemDescription_Ret = nullptr;
+
+    struct CallbackEntry {
+        unsigned int altitude;
+        ItemDescriptionCallback callback;
+    };
+    std::vector<CallbackEntry> callbacks;
+
+    std::mutex modified_strings_mutex;
+    std::wstring modified_name;
+    std::wstring modified_description;
+
+    static void __cdecl OnGetItemDescription_Wrapper(const uint32_t item_id, const uint32_t flags, const uint32_t quantity, const uint32_t unk, wchar_t** out_name, wchar_t** out_desc);
+    void OnGetItemDescription(const uint32_t item_id, const uint32_t flags, const uint32_t quantity, const uint32_t unk, wchar_t** out_name, wchar_t** out_desc);
+public:
+    static ItemDescriptionHandler& Instance() {
+        static ItemDescriptionHandler instance;
+
+        return instance;
+    }
+
+    [[nodiscard]] const char* Name() const override { return "Item Description Handler"; }
+    [[nodiscard]] const char* Description() const override { return "Allows dynamic modification of inventory item descriptions"; }
+
+    void RegisterDescriptionCallback(ItemDescriptionCallback callback, unsigned int altitude = 0);
+
+    void Initialize() override;
+    void SignalTerminate() override;
+};
+

--- a/GWToolboxdll/Modules/ItemDescriptionHandler.h
+++ b/GWToolboxdll/Modules/ItemDescriptionHandler.h
@@ -45,6 +45,8 @@ public:
     [[nodiscard]] const char* Description() const override { return "Allows dynamic modification of inventory item descriptions"; }
 
     void RegisterDescriptionCallback(ItemDescriptionCallback callback, unsigned int altitude = 0);
+    void UnregisterDescriptionCallback(ItemDescriptionCallback callback);
+    void UnregisterDescriptionCallback(ItemDescriptionCallback callback, unsigned int altitude);
 
     void Initialize() override;
     void SignalTerminate() override;

--- a/GWToolboxdll/Modules/PriceCheckerModule.cpp
+++ b/GWToolboxdll/Modules/PriceCheckerModule.cpp
@@ -15,8 +15,9 @@
 #include <GWCA/Utilities/Hooker.h>
 #include <GWCA/Utilities/Scanner.h>
 
-#include <Modules/Resources.h>
 #include <Modules/GameSettings.h>
+#include <Modules/ItemDescriptionHandler.h>
+#include <Modules/Resources.h>
 #include <Modules/PriceCheckerModule.h>
 
 #include <Timer.h>
@@ -26,7 +27,6 @@ using nlohmann::json;
 
 namespace {
     float high_price_threshold = 1000;
-    std::wstring modified_description;
     bool fetching_prices;
     const char* trader_quotes_url = "https://kamadan.gwtoolbox.com/trader_quotes";
     clock_t last_request_time = 0;
@@ -465,17 +465,13 @@ namespace {
         return std::format(L"\x2\x108\x107\n<c={}>{}: {:.4g}{}</c>\x1", color, name && *name ? GuiUtils::StringToWString(name) : L"Item price", price, unit);
     }
 
-    void UpdateDescription(const uint32_t item_id, wchar_t** description_out)
+    void UpdateDescription(const uint32_t item_id, std::wstring& description)
     {
-        if (!(description_out && *description_out))
-            return;
-
         const auto item = GW::Items::GetItemById(item_id);
         if (!item)
             return;
         
         std::vector<uint32_t> mod_matches;
-        modified_description = *description_out;
         for (size_t i = 0; i < item->mod_struct_size; i++) {
             const auto found = mod_to_id.find(item->mod_struct[i].mod);
             if (found == mod_to_id.end())
@@ -486,7 +482,7 @@ namespace {
             const auto name = mod_to_name.find(found->first);
             if (name == mod_to_name.end())
                 continue;
-            modified_description.append(PrintPrice(price, name->second));
+            description.append(PrintPrice(price, name->second));
         }
         if (item->type == GW::Constants::ItemType::Materials_Zcoins) {
             const auto model_id_str = std::to_string(item->model_id);
@@ -495,27 +491,15 @@ namespace {
                 if (IsCommonMaterial(item)) {
                     price = price / 10;
                 }
-                modified_description += PrintPrice(price);
+                description += PrintPrice(price);
             }
         }
-
-        *description_out = modified_description.data();
     }
 
-    using GetItemDescription_pt = void(__cdecl*)(uint32_t item_id, uint32_t flags, uint32_t quantity, uint32_t unk, wchar_t** out, wchar_t** out2);
-    GetItemDescription_pt GetItemDescription_Func = nullptr, GetItemDescription_Ret = nullptr;
-    // Block full item descriptions
-    void OnGetItemDescription(const uint32_t item_id, const uint32_t flags, const uint32_t quantity, const uint32_t unk, wchar_t** name_out, wchar_t** description_out)
+    void OnGetItemDescription(ItemDescriptionEventArgs& args)
     {
-        GW::Hook::EnterHook();
-        wchar_t** tmp_name_out = nullptr;
-        if (!name_out)
-            name_out = tmp_name_out; // Ensure name_out is valid; we're going to piggy back on it.
-        GetItemDescription_Ret(item_id, flags, quantity, unk, name_out, description_out);
-        UpdateDescription(item_id, description_out);
-        GW::Hook::LeaveHook();
+        UpdateDescription(args.item_id, args.description);
     }
-
 }
 
 
@@ -523,25 +507,11 @@ void PriceCheckerModule::Initialize()
 {
     ToolboxModule::Initialize();
 
-    // Copied from GameSettings.cpp
-    GetItemDescription_Func = (GetItemDescription_pt)GameSettings::OnGetItemDescription;
-    if (GetItemDescription_Func) {
-        ASSERT(GW::HookBase::CreateHook((void**)&GetItemDescription_Func, OnGetItemDescription, (void**)&GetItemDescription_Ret) == 0);
-        GW::HookBase::EnableHooks(GetItemDescription_Func);
-    }
+    ItemDescriptionHandler::Instance().RegisterDescriptionCallback(OnGetItemDescription, 100);
 
     FetchPrices();
 }
 
-void PriceCheckerModule::Terminate()
-{
-    ToolboxModule::Terminate();
-
-    if (GetItemDescription_Func) {
-        GW::HookBase::DisableHooks(GetItemDescription_Func);
-        GW::HookBase::RemoveHook(GetItemDescription_Func);
-    }
-}
 
 void PriceCheckerModule::SaveSettings(ToolboxIni* ini)
 {

--- a/GWToolboxdll/Modules/PriceCheckerModule.cpp
+++ b/GWToolboxdll/Modules/PriceCheckerModule.cpp
@@ -512,6 +512,13 @@ void PriceCheckerModule::Initialize()
     FetchPrices();
 }
 
+void PriceCheckerModule::Terminate()
+{
+    ToolboxModule::Terminate();
+
+    ItemDescriptionHandler::Instance().UnregisterDescriptionCallback(OnGetItemDescription);
+}
+
 
 void PriceCheckerModule::SaveSettings(ToolboxIni* ini)
 {

--- a/GWToolboxdll/Modules/PriceCheckerModule.h
+++ b/GWToolboxdll/Modules/PriceCheckerModule.h
@@ -21,7 +21,6 @@ public:
     [[nodiscard]] const char* SettingsName() const override { return "Inventory Settings"; }
 
     void Initialize() override;
-    void Terminate() override;
     void LoadSettings(ToolboxIni* ini) override;
     void RegisterSettingsContent() override;
     void SaveSettings(ToolboxIni* ini) override;

--- a/GWToolboxdll/Modules/PriceCheckerModule.h
+++ b/GWToolboxdll/Modules/PriceCheckerModule.h
@@ -21,6 +21,7 @@ public:
     [[nodiscard]] const char* SettingsName() const override { return "Inventory Settings"; }
 
     void Initialize() override;
+    void Terminate() override;
     void LoadSettings(ToolboxIni* ini) override;
     void RegisterSettingsContent() override;
     void SaveSettings(ToolboxIni* ini) override;

--- a/GWToolboxdll/Modules/SalvageInfoModule.cpp
+++ b/GWToolboxdll/Modules/SalvageInfoModule.cpp
@@ -415,6 +415,8 @@ void SalvageInfoModule::Terminate()
 {
     ToolboxModule::Terminate();
 
+    ItemDescriptionHandler::Instance().UnregisterDescriptionCallback(OnGetItemDescription);
+
     for (auto m : materials) {
         delete m;
     }


### PR DESCRIPTION
Adds a mandatory module that provides a hook to modify the generation of item names and descriptions.
Refactors the existing disparate hooks to use the new functionality.