### PR TITLE
ItemDescriptionHandler improvements

### DIFF
--- a/GWToolboxdll/Modules/GameSettings.cpp
+++ b/GWToolboxdll/Modules/GameSettings.cpp
@@ -1013,7 +1013,9 @@ void GameSettings::OnGetItemDescription(ItemDescriptionEventArgs& args)
     bool block_description = disable_item_descriptions_in_outpost && IsOutpost() || disable_item_descriptions_in_explorable && IsExplorable();
     block_description = block_description && GetKeyState(modifier_key_item_descriptions) >= 0;
 
-    args.block_description = block_description;
+    if (block_description) {
+        args.description.clear();
+    }
 }
 
 bool GameSettings::GetSettingBool(const char* setting)

--- a/GWToolboxdll/Modules/ItemDescriptionHandler.cpp
+++ b/GWToolboxdll/Modules/ItemDescriptionHandler.cpp
@@ -67,8 +67,6 @@ void ItemDescriptionHandler::OnGetItemDescription(const uint32_t item_id, const 
             .flags = flags,
             .quantity = quantity,
             .unk = unk,
-            .block_name = false,
-            .block_description = false,
             .name = this->modified_name,
             .description = this->modified_description,
         };
@@ -78,7 +76,7 @@ void ItemDescriptionHandler::OnGetItemDescription(const uint32_t item_id, const 
         }
 
         if (out_name != nullptr) {
-            if (args.block_name || modified_name.empty()) {
+            if (modified_name.empty()) {
                 *out_name = nullptr;
             }
             else {
@@ -86,7 +84,7 @@ void ItemDescriptionHandler::OnGetItemDescription(const uint32_t item_id, const 
             }
         }
         if (out_desc != nullptr) {
-            if (args.block_description || modified_description.empty()) {
+            if (modified_description.empty()) {
                 *out_desc = nullptr;
             }
             else {

--- a/GWToolboxdll/Modules/ItemDescriptionHandler.h
+++ b/GWToolboxdll/Modules/ItemDescriptionHandler.h
@@ -8,9 +8,6 @@ struct ItemDescriptionEventArgs {
     const uint32_t quantity;
     const uint32_t unk;
 
-    bool block_name;
-    bool block_description;
-
     std::wstring& name;
     std::wstring& description;
 };

--- a/GWToolboxdll/Modules/PriceCheckerModule.cpp
+++ b/GWToolboxdll/Modules/PriceCheckerModule.cpp
@@ -462,7 +462,7 @@ namespace {
             price /= 1000.f;
             unit = L'k';
         }
-        return std::format(L"\x2\x108\x107\n<c={}>{}: {:.4g}{}</c>\x1", color, name && *name ? GuiUtils::StringToWString(name) : L"Item price", price, unit);
+        return std::format(L"\x108\x107\n<c={}>{}: {:.4g}{}</c>\x1", color, name && *name ? GuiUtils::StringToWString(name) : L"Item price", price, unit);
     }
 
     void UpdateDescription(const uint32_t item_id, std::wstring& description)
@@ -482,7 +482,7 @@ namespace {
             const auto name = mod_to_name.find(found->first);
             if (name == mod_to_name.end())
                 continue;
-            description.append(PrintPrice(price, name->second));
+            GuiUtils::EncString_append(description, PrintPrice(price, name->second));
         }
         if (item->type == GW::Constants::ItemType::Materials_Zcoins) {
             const auto model_id_str = std::to_string(item->model_id);
@@ -491,7 +491,7 @@ namespace {
                 if (IsCommonMaterial(item)) {
                     price = price / 10;
                 }
-                description += PrintPrice(price);
+                GuiUtils::EncString_append(description, PrintPrice(price));
             }
         }
     }

--- a/GWToolboxdll/Modules/SalvageInfoModule.cpp
+++ b/GWToolboxdll/Modules/SalvageInfoModule.cpp
@@ -314,6 +314,12 @@ namespace {
         return salvage_info_by_single_item_name[single_item_name];
     }
 
+    void AppendLineIfNonEmpty(std::wstring& encstr) {
+        if(!encstr.empty()) {
+            GuiUtils::EncString_append(encstr, L"\x102");
+        }
+    }
+
     void AppendSalvageInfoDescription(const uint32_t item_id, std::wstring& description) {
         const auto item = static_cast<InventoryManager::Item*>(GW::Items::GetItemById(item_id));
 
@@ -334,7 +340,8 @@ namespace {
             return;
 
         if (salvage_info->loading) {
-            description += L"\x2\x102\x2\x108\x107" L"Fetching salvage info...\x1";
+            AppendLineIfNonEmpty(description);
+            GuiUtils::EncString_append(description, L"\x108\x107" L"Fetching salvage info...\x1");
         }
 
         if (!salvage_info->common_crafting_materials.empty()) {
@@ -345,7 +352,8 @@ namespace {
                 items += i->en_name.encoded();
             }
 
-            description += std::format(L"\x2\x102\x2\x108\x107<c=@ItemCommon>Common Materials:</c> \x1\x2{}", items);
+            AppendLineIfNonEmpty(description);
+            GuiUtils::EncString_append(description, std::format(L"\x108\x107<c=@ItemCommon>Common Materials:</c> \x1\x2{}", items));
         }
         if (!salvage_info->rare_crafting_materials.empty()) {
             std::wstring items;
@@ -355,7 +363,8 @@ namespace {
                 items += i->en_name.encoded();
             }
 
-            description += std::format(L"\x2\x102\x2\x108\x107<c=@ItemRare>Rare Materials:</c> \x1\x2{}", items);
+            AppendLineIfNonEmpty(description);
+            GuiUtils::EncString_append(description, std::format(L"\x108\x107<c=@ItemRare>Rare Materials:</c> \x1\x2{}", items));
         }
     }
 

--- a/GWToolboxdll/Utils/GuiUtils.cpp
+++ b/GWToolboxdll/Utils/GuiUtils.cpp
@@ -1004,4 +1004,15 @@ namespace GuiUtils {
         }
         return decoded_s;
     }
+
+    void EncString_append(std::wstring& encstr, const wchar_t* to_append) {
+        if(!encstr.empty()) {
+            encstr.append(L"\x02");
+        }
+        encstr.append(to_append);
+    }
+
+    void EncString_append(std::wstring& encstr, const std::wstring& to_append) {
+        EncString_append(encstr, to_append.c_str());
+    }
 }

--- a/GWToolboxdll/Utils/GuiUtils.h
+++ b/GWToolboxdll/Utils/GuiUtils.h
@@ -136,6 +136,9 @@ namespace GuiUtils {
     // Same as std::format, but use printf formatting
     std::wstring format(const wchar_t* msg, ...);
 
+    void EncString_append(std::wstring& encstr, const wchar_t* to_append);
+    void EncString_append(std::wstring& encstr, const std::wstring& to_append);
+
     class EncString {
     protected:
         std::wstring encoded_ws;


### PR DESCRIPTION
* Remove block_name and block_description in favour of clearing the wstring
* Refactor encstring appending to its own method to prevent crashes due to incorrect encstrings

Question: should `EncString_append` instead be a member of the `EncString` class?  I erred towards "no" as it was not related to decoding EncStrings but it would make some sense to use that as a utility class and wrapper for encoded strings.