### PR TITLE
Salvage Info Module Fixes

### DIFF
--- a/GWToolboxdll/Modules/Resources.cpp
+++ b/GWToolboxdll/Modules/Resources.cpp
@@ -617,7 +617,9 @@ void Resources::Download(const std::string& url, AsyncLoadMbCallback callback, v
         }
         std::string response;
         bool ok = Download(url, response);
-        save_to_cache(cache_path, response);
+        if (ok) {
+            save_to_cache(cache_path, response);
+        }
         EnqueueMainTask([callback, ok, response, context] {
             callback(ok, response, context);
         });

--- a/GWToolboxdll/Modules/Resources.cpp
+++ b/GWToolboxdll/Modules/Resources.cpp
@@ -518,10 +518,17 @@ void Resources::Download(const std::filesystem::path& path_to_file, const std::s
 
 bool Resources::Download(const std::string& url, std::string& response)
 {
+    int statusCode = 0;
+    return Download(url, response, statusCode);
+}
+
+bool Resources::Download(const std::string& url, std::string& response, int& statusCode)
+{
     RestClient r;
     InitRestClient(&r);
     r.SetUrl(url.c_str());
     r.Execute();
+    statusCode = r.GetStatusCode();
     if (!r.IsSuccessful()) {
         StrSprintf(response, "Failed to download %s, curl status %d %s", url.c_str(), r.GetStatusCode(), r.GetStatusStr());
         return false;
@@ -534,7 +541,8 @@ void Resources::Download(const std::string& url, AsyncLoadMbCallback callback, v
 {
     EnqueueWorkerTask([url, callback, context] {
         std::string response;
-        bool ok = Download(url, response);
+        int statusCode = 0;
+        bool ok = Download(url, response, statusCode);
         EnqueueMainTask([callback, ok, response, context] {
             callback(ok, response, context);
         });
@@ -616,8 +624,10 @@ void Resources::Download(const std::string& url, AsyncLoadMbCallback callback, v
             }
         }
         std::string response;
-        bool ok = Download(url, response);
-        if (ok) {
+        int statusCode = 0;
+        bool ok = Download(url, response, statusCode);
+        if (ok ||
+            (statusCode >= 300 && statusCode < 500)) {
             save_to_cache(cache_path, response);
         }
         EnqueueMainTask([callback, ok, response, context] {

--- a/GWToolboxdll/Modules/Resources.h
+++ b/GWToolboxdll/Modules/Resources.h
@@ -121,6 +121,8 @@ public:
     void Download(const std::filesystem::path& path_to_file, const std::string& url, AsyncLoadCallback callback) const;
     // download to memory, blocking. If an error occurs, details are held in response string
     static bool Download(const std::string& url, std::string& response);
+    // download to memory, blocking. If an error occurs, details are held in response string
+    static bool Download(const std::string& url, std::string& response, int& statusCode);
     // download to memory, async, calls callback on completion. If an error occurs, details are held in response string
     static void Download(const std::string& url, AsyncLoadMbCallback callback, void* wparam = nullptr);
     // download to memory, async, calls callback on completion and caches the response locally for the duration specified. If an error occurs, details are held in response string

--- a/GWToolboxdll/Modules/SalvageInfoModule.cpp
+++ b/GWToolboxdll/Modules/SalvageInfoModule.cpp
@@ -328,7 +328,7 @@ namespace {
         }
         const auto url = GuiUtils::WikiUrl(info->en_name.string());
         info->retry_after = std::chrono::steady_clock::now() + std::chrono::seconds(30);
-        Resources::Download(url, OnWikiContentDownloaded, info, std::chrono::days(30));
+        Resources::Download(url, OnWikiContentDownloaded, info, std::chrono::days(1));
     }
 
     SalvageInfo* GetSalvageInfo(const wchar_t* single_item_name) {

--- a/GWToolboxdll/Modules/SalvageInfoModule.cpp
+++ b/GWToolboxdll/Modules/SalvageInfoModule.cpp
@@ -191,7 +191,7 @@ namespace {
     void OnWikiContentDownloaded(bool success, const std::string& response, void* wparam) {
         auto* info = (SalvageInfo*)wparam;
         if (!success) {
-            Log::Error(std::format("Failed to download wiki content for item. Response: {}", response).c_str());
+            Log::Error(std::format("Failed to fetch salvage info. Response: {}", response).c_str());
             info->loading = false;
             info->failed = true;
             SignalItemDescriptionUpdated(info->en_name.encoded().c_str());


### PR DESCRIPTION
Add missing Scale material
Add timeout logic for failed fetches
Added failure message on request failures
Add a more lax string comparison, to match on plurals, case-insensitive and special handling for Ruby/Rubies
Adjusted response caching to cache in the case of non-transient failures (codes from 300 to 499)
Lowered cache duration for salvage info to 1 day. This way the users can get fresh info once I add new wiki redirects for problematic items