### PR TITLE
Updated get_next_bag_slot() to account for a PR in GWCA

### DIFF
--- a/GWToolboxdll/Modules/InventoryManager.cpp
+++ b/GWToolboxdll/Modules/InventoryManager.cpp
@@ -1502,7 +1502,8 @@ bool get_next_bag_slot(const InventoryManager::Item* item, GW::Constants::Bag* b
     if (slot >= bag->items.size()) {
         bag_id = GW::Constants::Bag::Max;
         slot = 0;
-        for (auto it_bag_id = ++bag->bag_id(); it_bag_id < GW::Constants::Bag::Max; it_bag_id++) {
+        auto bag_start = bag->bag_id();
+        for (auto it_bag_id = ++bag_start; it_bag_id < GW::Constants::Bag::Max; it_bag_id++) {
             const auto it_bag = GW::Items::GetBag(it_bag_id);
             if (it_bag) {
                 bag_id = it_bag_id;


### PR DESCRIPTION
Updated get_next_bag_slot() to account for a PR in GWCA which fixes a bug in the GW::Constants::Bag prefix increment operator overload. This PR can be pulled prior to the GWCA PR, as the behavior is unchanged. The prefix increment simply had to be moved to a non-const object, as the increment operator now returns a reference (as expected) instead of a copy. The prefix operator is expected to modify the variable is it being used upon, which is invalid for a const object.
