### PR TITLE
Do not block /tb commands from reaching TB

### DIFF
--- a/plugins/Base/ToolboxUIPlugin.cpp
+++ b/plugins/Base/ToolboxUIPlugin.cpp
@@ -11,6 +11,7 @@
 namespace {
     void CmdTB(GW::HookStatus* status, const wchar_t*, const int argc, const LPWSTR* argv)
     {
+        status->blocked = false;
         const auto instance = static_cast<ToolboxUIPlugin*>(ToolboxPluginInstance());
         if (!instance) {
             status->blocked = false;
@@ -43,8 +44,9 @@ namespace {
             // /tb PluginName hide
             *instance->GetVisiblePtr() = !*instance->GetVisiblePtr();
         }
-        if (arg1 != pluginname) {
-            status->blocked = false;
+
+        if (arg1 == pluginname) {
+            status->blocked = true;
         }
     }
 }

--- a/plugins/Base/ToolboxUIPlugin.cpp
+++ b/plugins/Base/ToolboxUIPlugin.cpp
@@ -14,21 +14,15 @@ namespace {
         status->blocked = false;
         const auto instance = static_cast<ToolboxUIPlugin*>(ToolboxPluginInstance());
         if (!instance) {
-            status->blocked = false;
             return;
-        }
-        if (argc < 3) {
-            status->blocked = false;
         }
         const std::wstring arg1 = PluginUtils::ToLower(argv[1]);
         auto pluginname = PluginUtils::ToLower(PluginUtils::StringToWString(instance->Name()));
         pluginname.erase(std::ranges::remove_if(pluginname, [](const wchar_t x) { return std::isspace(x); }).begin(), pluginname.end());
         if (arg1.empty()) {
-            status->blocked = false;
             return;
         }
         if (!(arg1 == L"all" || arg1 == L"plugins" || pluginname.find(arg1) == 0)) {
-            status->blocked = false;
             return;
         }
         const std::wstring arg2 = PluginUtils::ToLower(argv[2]);


### PR DESCRIPTION
Currently if any UI plugin is injected and the user sends a `/tb` chat command, this command is blocked by the plugin and does not reach toolbox.
To fix this, chat commands are now only blocked if they start with `/tb <pluginname>`