### PR TITLE
Do not block /tb commands from reaching TB

### DIFF
--- a/plugins/Base/ToolboxUIPlugin.cpp
+++ b/plugins/Base/ToolboxUIPlugin.cpp
@@ -11,23 +11,21 @@
 namespace {
     void CmdTB(GW::HookStatus* status, const wchar_t*, const int argc, const LPWSTR* argv)
     {
+        status->blocked = false;
         const auto instance = static_cast<ToolboxUIPlugin*>(ToolboxPluginInstance());
         if (!instance) {
-            status->blocked = false;
             return;
         }
         if (argc < 3) {
-            status->blocked = false;
+            return;
         }
         const std::wstring arg1 = PluginUtils::ToLower(argv[1]);
         auto pluginname = PluginUtils::ToLower(PluginUtils::StringToWString(instance->Name()));
         pluginname.erase(std::ranges::remove_if(pluginname, [](const wchar_t x) { return std::isspace(x); }).begin(), pluginname.end());
         if (arg1.empty()) {
-            status->blocked = false;
             return;
         }
         if (!(arg1 == L"all" || arg1 == L"plugins" || pluginname.find(arg1) == 0)) {
-            status->blocked = false;
             return;
         }
         const std::wstring arg2 = PluginUtils::ToLower(argv[2]);
@@ -43,8 +41,8 @@ namespace {
             // /tb PluginName hide
             *instance->GetVisiblePtr() = !*instance->GetVisiblePtr();
         }
-        if (arg1 != pluginname) {
-            status->blocked = false;
+        if (arg1 == pluginname) {
+            status->blocked = true;
         }
     }
 }


### PR DESCRIPTION
Currently if any UI plugin is injected and the user sends a `/tb` chat command (for example `/tb settings`) this command is blocked by the plugin and does not reach toolbox. That is because the default `blocked` state of the hook is `true`, meaning all the existing early-return cases of `CmdTB` block the chat command.

To fix this the behaviour is inverted: By default, plugins let the chat commands through. The only chat commands that are blocked are those that start with `/tb <pluginname>`.