### PR TITLE
feat: transmo subcommand to load supplied npc model id

### DIFF
--- a/GWToolboxdll/Modules/ChatCommands.cpp
+++ b/GWToolboxdll/Modules/ChatCommands.cpp
@@ -2719,6 +2719,42 @@ void CHAT_CMD_FUNC(ChatCommands::CmdTransmo)
         if (wcsncmp(argv[1], L"reset", 5) == 0) {
             transmo.npc_id = std::numeric_limits<int>::max();
         }
+        else if (wcsncmp(argv[1], L"model", 5) == 0) {
+            bool invalid_data = argc < 6;
+            int npc_id = transmo.npc_id;
+            if (!invalid_data && argc > 2 && !TextUtils::ParseInt(argv[3], &npc_id)) {
+                Log::Error("Transmo model: invalid NPC ID '%ls', expected an integer. Example: 4581", argv[3]);
+                invalid_data = true;
+            }
+            int model_file_id = transmo.npc_model_file_id;
+            if (!invalid_data && argc > 3 && !TextUtils::ParseInt(argv[3], &model_file_id)) {
+                Log::Error("Transmo model: invalid NPC ModelFileID '%ls', expected an integer. Example: 204020", argv[3]);
+                invalid_data = true;
+            }
+            int model_file_data = transmo.npc_model_file_data;
+            if (!invalid_data && argc > 4 && !TextUtils::ParseInt(argv[4], &model_file_data)) {
+                Log::Error("Transmo model: invalid NPC ModelFile'%ls', expected an integer. Example: 245127", argv[4]);
+                invalid_data = true;
+            }
+            int flags = transmo.flags;
+            if (!invalid_data && argc > 5 && !TextUtils::ParseInt(argv[5], &flags)) {
+                Log::Error("Transmo model: invalid NPC Flags '%ls', expected an integer. Example: 540", argv[5]);
+                invalid_data = true;
+            }
+
+            if (invalid_data) {
+                Log::Info("HELP for /transmo model");
+                Log::Info("Usage: /transmo model NPC_ID MODEL_FILE_ID MODEL_FILE FLAGS");
+                Log::Info("Example, transfo as Gehraz: /transmo model 4581 204020 245127 540");
+                Log::Info("The numbers required by the command can be obtained from the GWToolbox 'Info' window, in the 'Advanced' section under the 'Target' menu. Note: the numbers must be converted from hexadecimal to decimal.");
+                return;
+            }
+
+            transmo.npc_id = npc_id;
+            transmo.npc_model_file_id = model_file_id;
+            transmo.npc_model_file_data = model_file_data;
+            transmo.flags = flags;
+        }
         else if (TextUtils::ParseInt(argv[1], &iscale)) {
             if (!ParseScale(iscale, transmo)) {
                 return;
@@ -2728,7 +2764,7 @@ void CHAT_CMD_FUNC(ChatCommands::CmdTransmo)
             Log::Error("unknown transmo '%ls'", argv[1]);
             return;
         }
-        if (argc > 2 && TextUtils::ParseInt(argv[2], &iscale)) {
+        else if (argc > 2 && TextUtils::ParseInt(argv[2], &iscale)) {
             if (!ParseScale(iscale, transmo)) {
                 return;
             }

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -58,6 +58,7 @@ GWToolbox++ supports a variety of chat commands that enhance your gameplay exper
 - `/transmo`: Change your character model to that of the target NPC (only visible to you).
   - `/transmo [size (6-255)]`: Set the size of your model.
   - `/transmo <npc_name> [size (6-255)]`: Change your appearance into a specific NPC.
+  - `/transmo model <npc_id> <npc_model_file_id> <npc_model_file> <flags>`: Change your appearance into a specific NPC model.
   - `/transmo reset`: Reset your appearance.
 - `/transmotarget <npc_name> [size (6-255)]`: Change your target's appearance into an NPC (only visible to you).
   - `/transmotarget reset`: Reset your target's appearance.


### PR DESCRIPTION
As mentioned in #1326, the current list of NPCs to transmo into is quite limited, and manually adding NPC models to the hardcoded list can be a complicated task for those without cpp knowledge. This PR aims to add a subcommand to the transmo command: `/transmo model`. This subcommand accepts every parameter needed by the `PendingTransmo` struct, allowing anyone to transmo into the NPC model of their choice without having to edit the source code.

The command asks for specific IDs to function correctly which is pretty verbose to type, so it is mostly here to be used through chat command aliases or hotkeys.

Examples:
```sh
# transmo as Gehraz
/transmo model 4581 204020 245127 540

# transmo as Herta
/transmo model 4537 16258 245122 540

# transmo as Anzhaer
/transmo model 7985 16271 373574 520
```

Also as the command requires a lot of parameters it felt adequate to add a lot of error handling and logs, but if it's too much feel free to tell me!