### PR TITLE
Keyboard shortcuts for salvage all item list modal

### DIFF
--- a/GWToolboxdll/Modules/InventoryManager.cpp
+++ b/GWToolboxdll/Modules/InventoryManager.cpp
@@ -2018,9 +2018,17 @@ void InventoryManager::Draw(IDirect3DDevice9*)
                 }
                 ImGui::SameLine();
             }
-            if (ImGui::Button("Cancel", btn_width) || ImGui::IsKeyDown(ImGuiKey_Escape)) {
+            // Pressing [Escape] when no item is selected results in the window being closed.
+            // Or pressing [Escape] when some items are selected results in everything being unselected.
+            if (ImGui::Button("Cancel", btn_width) || ImGui::IsKeyPressed(ImGuiKey_Escape) && !has_items_to_salvage) {
                 CancelSalvage();
                 ImGui::CloseCurrentPopup();
+            }
+            else if (check_all_items && ImGui::IsKeyPressed(ImGuiKey_Escape)) {
+                check_all_items = false;
+                for (size_t i = 0; i < potential_salvage_all_items.size(); i++) {
+                    potential_salvage_all_items[i]->proceed = false;
+                }
             }
         }
         ImGui::EndPopup();

--- a/GWToolboxdll/Modules/InventoryManager.cpp
+++ b/GWToolboxdll/Modules/InventoryManager.cpp
@@ -1941,7 +1941,7 @@ void InventoryManager::Draw(IDirect3DDevice9*)
         else if (is_salvaging_all) {
             // Salvage in progress
             ImGui::Text("Salvaging items...");
-            if (ImGui::Button("Cancel", ImVec2(120, 0))) {
+            if (ImGui::Button("Cancel", ImVec2(120, 0)) || ImGui::IsKeyPressed(ImGuiKey_Escape)) {
                 pending_cancel_salvage = true;
                 ImGui::CloseCurrentPopup();
             }

--- a/GWToolboxdll/Modules/InventoryManager.cpp
+++ b/GWToolboxdll/Modules/InventoryManager.cpp
@@ -2024,8 +2024,9 @@ void InventoryManager::Draw(IDirect3DDevice9*)
                 CancelSalvage();
                 ImGui::CloseCurrentPopup();
             }
-            else if (check_all_items && ImGui::IsKeyPressed(ImGuiKey_Escape)) {
+            else if (has_items_to_salvage && ImGui::IsKeyPressed(ImGuiKey_Escape)) {
                 check_all_items = false;
+                has_items_to_salvage = false;
                 for (size_t i = 0; i < potential_salvage_all_items.size(); i++) {
                     potential_salvage_all_items[i]->proceed = false;
                 }

--- a/GWToolboxdll/Modules/InventoryManager.cpp
+++ b/GWToolboxdll/Modules/InventoryManager.cpp
@@ -1009,6 +1009,13 @@ bool InventoryManager::WndProc(const UINT message, const WPARAM, const LPARAM)
             }
         }
         break;
+        case WM_KEYDOWN:
+        case WM_SYSKEYDOWN: {
+            if (ImGui::GetIO().WantCaptureKeyboard) {
+                return true;
+            }
+        }
+        break;
     }
     return false;
 }

--- a/GWToolboxdll/Modules/InventoryManager.cpp
+++ b/GWToolboxdll/Modules/InventoryManager.cpp
@@ -2013,12 +2013,12 @@ void InventoryManager::Draw(IDirect3DDevice9*)
             auto btn_width = ImVec2(ImGui::GetContentRegionAvail().x - ImGui::GetStyle().ItemSpacing.x, 0);
             if (has_items_to_salvage) {
                 btn_width.x /= 2;
-                if (ImGui::Button("OK", btn_width)) {
+                if (ImGui::Button("OK", btn_width) || ImGui::IsKeyDown(ImGuiKey_Space) || ImGui::IsKeyDown(ImGuiKey_Enter)) {
                     is_salvaging_all = true;
                 }
                 ImGui::SameLine();
             }
-            if (ImGui::Button("Cancel", btn_width)) {
+            if (ImGui::Button("Cancel", btn_width) || ImGui::IsKeyDown(ImGuiKey_Escape)) {
                 CancelSalvage();
                 ImGui::CloseCurrentPopup();
             }


### PR DESCRIPTION
Hi again, I hope you don't mind these small and very focused PRs as I try to make things easy for you to review.

Related to #1355, adds keyboard shortcuts to the item selection modal that appears while trying to _Salvage All_.

- The `Ok` button can now be triggered by pressing either `Space` or `Enter`
- `Escape` can perform two actions:
  - if there is one or more items selected then pressing the key will deselect them all as if the `Select all` checkbox was clicked
  - if there is no item selected then pressing the key will close the modal as if the `Cancel` button was clicked


These shortcuts help for the following use cases:
- quickly salvaging everything without filtering ~> Press `Space` as soon as the modal appears
- salvaging only a few select items ~> Press `Escape` to unselect all, select the right items then press `Space` to confirm
- closing the modal to cancel ~> Press `Escape` once to unselect all, press a second time to simulate a click on `Cancel`


**Note:** _(solved, see commits below)_
I didn't find an easy way to suppress the keypress events for the Guild Wars client, so pressing `Space` to confirm the salvage will also cause the player to run towards or attack its target, or pressing `Escape` to cancel will also close the inventory panel. In my opinion it's an acceptable flaw, but if there is a simple way to do it for this piece of code then i'll gladly implement it.
