### PR TITLE
feat(notepad) add font size to notepad

### DIFF
--- a/GWToolboxdll/Windows/NotePadWindow.cpp
+++ b/GWToolboxdll/Windows/NotePadWindow.cpp
@@ -2,8 +2,12 @@
 
 #include <Modules/Resources.h>
 #include <Windows/NotePadWindow.h>
+#include <Utils/FontLoader.h>
 
 constexpr auto TEXT_SIZE = 2024 * 16;
+const int MIN_FONT_SIZE = 16;
+
+float font_size = static_cast<float>(FontLoader::FontSize::widget_label);
 
 void NotePadWindow::Draw(IDirect3DDevice9*)
 {
@@ -16,10 +20,13 @@ void NotePadWindow::Draw(IDirect3DDevice9*)
     if (ImGui::Begin(Name(), GetVisiblePtr(), GetWinFlags())) {
         const ImVec2 cmax = ImGui::GetWindowContentRegionMax();
         const ImVec2 cmin = ImGui::GetWindowContentRegionMin();
+        const auto font = FontLoader::GetFontByPx(font_size);
+        ImGui::PushFont(font);
         if (ImGui::InputTextMultiline("##source", text, TEXT_SIZE,
                                       ImVec2(cmax.x - cmin.x, cmax.y - cmin.y), ImGuiInputTextFlags_AllowTabInput)) {
             filedirty = true;
         }
+        ImGui::PopFont();
     }
     ImGui::End();
     ImGui::PopStyleVar();
@@ -48,4 +55,10 @@ void NotePadWindow::SaveSettings(ToolboxIni* ini)
             filedirty = false;
         }
     }
+}
+
+void NotePadWindow::DrawSettingsInternal()
+{
+    ToolboxWindow::DrawSettingsInternal();
+    ImGui::DragFloat("Text size", &font_size, 1.0, MIN_FONT_SIZE, FontLoader::text_size_max, "%.0f");
 }

--- a/GWToolboxdll/Windows/NotePadWindow.h
+++ b/GWToolboxdll/Windows/NotePadWindow.h
@@ -21,6 +21,7 @@ public:
 
     void LoadSettings(ToolboxIni* ini) override;
     void SaveSettings(ToolboxIni* ini) override;
+    void DrawSettingsInternal() override;
 
 private:
     char text[2024 * 16]{}; // 2024 characters max


### PR DESCRIPTION
Adds a slider for the font size of text in a notepad.

I set the minimum to 16 as numbers under this didn't seem to make the font smaller (Unsure if this is an IMGUI thing) - but it's also likely as small as you can make it while still being readable anyway.

An example of size 48 font
![0f970a63d13b05717a11b8a1eb126f0f](https://github.com/user-attachments/assets/0834fc93-c6bf-4835-aa47-b38b09c2dce8)