### PR TITLE
Replace std::regex with CTRE where feasible

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -5,6 +5,7 @@ on: [push]
 jobs:
   build:
     runs-on: windows-latest
+    timeout-minutes: 15
 
     steps:
     - name: Setup Windows 10 SDK Action

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ find_path(SIMPLEINI_INCLUDE_DIRS "ConvertUTF.c")
 find_package(wolfssl CONFIG REQUIRED)
 find_package(minhook CONFIG REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
+find_package(ctre CONFIG REQUIRED)
 
 add_subdirectory(GWToolboxdll)
 add_subdirectory(Core)

--- a/GWToolboxdll/CMakeLists.txt
+++ b/GWToolboxdll/CMakeLists.txt
@@ -76,6 +76,7 @@ target_link_libraries(GWToolboxdll PRIVATE
     wintoast
     wolfssl::wolfssl
 	minhook::minhook
+	ctre::ctre
 
     # libs:
     Dbghelp.lib # for MiniDump

--- a/GWToolboxdll/GWToolbox.cpp
+++ b/GWToolboxdll/GWToolbox.cpp
@@ -856,7 +856,7 @@ std::filesystem::path GWToolbox::SaveSettings()
     ASSERT(Resources::SaveIniToFile(ini->location_on_disk, ini) == 0);
     const auto dir = ini->location_on_disk.parent_path();
     const auto dirstr = dir.wstring();
-    const auto printable = TextUtils::ctre_regex_replace<LR"(\\)">(dirstr, L"/");
+    const auto printable = TextUtils::str_replace_all(dirstr, LR"(\\)", L"/");
     Log::LogW(L"Toolbox settings saved to %s", printable.c_str());
     settings_folder_changed = false;
     return ini->location_on_disk;

--- a/GWToolboxdll/GWToolbox.cpp
+++ b/GWToolboxdll/GWToolbox.cpp
@@ -41,6 +41,7 @@
 
 #include "Utils/FontLoader.h"
 #include <Utils/ToolboxUtils.h>
+#include <Utils/TextUtils.h>
 
 #include <EmbeddedResource.h>
 #include "resource.h"
@@ -854,9 +855,9 @@ std::filesystem::path GWToolbox::SaveSettings()
     ToolboxSettings::LoadModules(ini);
     ASSERT(Resources::SaveIniToFile(ini->location_on_disk, ini) == 0);
     const auto dir = ini->location_on_disk.parent_path();
-    const auto dirstr = dir.wstring();
-    const std::wstring printable = std::regex_replace(dirstr, std::wregex(L"\\\\"), L"/");
-    Log::LogW(L"Toolbox settings saved to %s", printable.c_str());
+    const auto dirstr = dir.string();
+    const auto printable = TextUtils::ctre_regex_replace<R"(\\)">(dirstr, "/");
+    Log::Log("Toolbox settings saved to %s", printable.c_str());
     settings_folder_changed = false;
     return ini->location_on_disk;
 }

--- a/GWToolboxdll/GWToolbox.cpp
+++ b/GWToolboxdll/GWToolbox.cpp
@@ -855,9 +855,9 @@ std::filesystem::path GWToolbox::SaveSettings()
     ToolboxSettings::LoadModules(ini);
     ASSERT(Resources::SaveIniToFile(ini->location_on_disk, ini) == 0);
     const auto dir = ini->location_on_disk.parent_path();
-    const auto dirstr = dir.string();
-    const auto printable = TextUtils::ctre_regex_replace<R"(\\)">(dirstr, "/");
-    Log::Log("Toolbox settings saved to %s", printable.c_str());
+    const auto dirstr = dir.wstring();
+    const auto printable = TextUtils::ctre_regex_replace<LR"(\\)">(dirstr, L"/");
+    Log::LogW(L"Toolbox settings saved to %s", printable.c_str());
     settings_folder_changed = false;
     return ini->location_on_disk;
 }

--- a/GWToolboxdll/Modules/ChatCommands.cpp
+++ b/GWToolboxdll/Modules/ChatCommands.cpp
@@ -1836,7 +1836,7 @@ void CHAT_CMD_FUNC(ChatCommands::CmdTB)
             const auto file_location = GWToolbox::SaveSettings();
             const auto dir = file_location.parent_path();
             const auto dirstr = dir.wstring();
-            const auto printable = std::regex_replace(dirstr, std::wregex(L"\\\\"), L"/");
+            const auto printable = TextUtils::ctre_regex_replace<LR"(\\)">(dirstr, L"/");
             Log::InfoW(L"Settings saved to %s", printable.c_str());
         }
         else if (arg1 == L"load") {
@@ -1845,7 +1845,7 @@ void CHAT_CMD_FUNC(ChatCommands::CmdTB)
             const auto file_location = GWToolbox::LoadSettings();
             const auto dir = file_location.parent_path();
             const auto dirstr = dir.wstring();
-            const auto printable = std::regex_replace(dirstr, std::wregex(L"\\\\"), L"/");
+            const auto printable = TextUtils::ctre_regex_replace<L"\\\\">(dirstr, L"/");
             Log::InfoW(L"Settings loaded from %s", printable.c_str());
         }
         else if (arg1 == L"reset") {
@@ -1915,7 +1915,7 @@ void CHAT_CMD_FUNC(ChatCommands::CmdTB)
         const auto file_location = GWToolbox::SaveSettings();
         const auto dir = file_location.parent_path();
         const auto dirstr = dir.wstring();
-        const auto printable = std::regex_replace(dirstr, std::wregex(L"\\\\"), L"/");
+        const auto printable = TextUtils::ctre_regex_replace<LR"(\\)">(dirstr, L"/");
         Log::InfoW(L"Settings saved to %s", printable.c_str());
     }
     else if (arg1 == L"load") {
@@ -1931,7 +1931,7 @@ void CHAT_CMD_FUNC(ChatCommands::CmdTB)
         const auto file_location = GWToolbox::LoadSettings();
         const auto dir = file_location.parent_path();
         const auto dirstr = dir.wstring();
-        const auto printable = std::regex_replace(dirstr, std::wregex(L"\\\\"), L"/");
+        const auto printable = TextUtils::ctre_regex_replace<LR"(\\)">(dirstr, L"/");
         Log::InfoW(L"Settings loaded from %s", printable.c_str());
     }
     else {

--- a/GWToolboxdll/Modules/ChatCommands.cpp
+++ b/GWToolboxdll/Modules/ChatCommands.cpp
@@ -1508,12 +1508,11 @@ void ChatCommands::QuestPing::Update()
         GW::Chat::SendChat('#', print_buf);
     }
     if (!objectives.wstring().empty()) {
-        // Find current objective using regex
-        const std::wregex current_obj_regex(L"\\{s\\}([^\\{]+)");
-        std::wsmatch m;
-        if (std::regex_search(objectives.wstring(), m, current_obj_regex)) {
+        static constexpr ctll::fixed_string current_obj_pattern = LR"(\{s\}([^\{]+))";
+
+        if (auto m = ctre::match<current_obj_pattern>(objectives.wstring())) {
             wchar_t print_buf[128];
-            swprintf(print_buf, _countof(print_buf), L" - %s", m[1].str().c_str());
+            swprintf(print_buf, _countof(print_buf), L" - %s", m.get<1>().to_string().c_str());
             GW::Chat::SendChat('#', print_buf);
         }
         objectives.reset(nullptr);

--- a/GWToolboxdll/Modules/ChatCommands.cpp
+++ b/GWToolboxdll/Modules/ChatCommands.cpp
@@ -1173,14 +1173,14 @@ void ChatCommands::LoadSettings(ToolboxIni* ini)
             continue;
         }
         std::ranges::replace(cmd, '\x2', '\n');
-        static const std::regex index_regex("(\\d+):(.+)");
-        std::smatch match;
-        if (std::regex_match(alias, match, index_regex)) {
-            alias = match[2];
+        static constexpr ctll::fixed_string index_regex = "(\\d+):(.+)";
+        if (auto match = ctre::match<index_regex>(alias)) {
+            alias = match.get<2>().to_string();
         }
         const auto alias_wstr = TextUtils::StringToWString(alias);
         const auto command_wstr = TextUtils::StringToWString(cmd);
         CreateAlias(alias_wstr.c_str(), command_wstr.c_str());
+
     }
     if (cmd_aliases.empty()) {
         CreateAlias(L"ff", L"/resign");

--- a/GWToolboxdll/Modules/ChatCommands.cpp
+++ b/GWToolboxdll/Modules/ChatCommands.cpp
@@ -1835,7 +1835,7 @@ void CHAT_CMD_FUNC(ChatCommands::CmdTB)
             const auto file_location = GWToolbox::SaveSettings();
             const auto dir = file_location.parent_path();
             const auto dirstr = dir.wstring();
-            const auto printable = TextUtils::ctre_regex_replace<LR"(\\)">(dirstr, L"/");
+            const auto printable = TextUtils::str_replace_all(dirstr, LR"(\\)", L"/");
             Log::InfoW(L"Settings saved to %s", printable.c_str());
         }
         else if (arg1 == L"load") {
@@ -1844,7 +1844,7 @@ void CHAT_CMD_FUNC(ChatCommands::CmdTB)
             const auto file_location = GWToolbox::LoadSettings();
             const auto dir = file_location.parent_path();
             const auto dirstr = dir.wstring();
-            const auto printable = TextUtils::ctre_regex_replace<L"\\\\">(dirstr, L"/");
+            const auto printable = TextUtils::str_replace_all(dirstr, LR"(\\)", L"/");
             Log::InfoW(L"Settings loaded from %s", printable.c_str());
         }
         else if (arg1 == L"reset") {
@@ -1914,7 +1914,7 @@ void CHAT_CMD_FUNC(ChatCommands::CmdTB)
         const auto file_location = GWToolbox::SaveSettings();
         const auto dir = file_location.parent_path();
         const auto dirstr = dir.wstring();
-        const auto printable = TextUtils::ctre_regex_replace<LR"(\\)">(dirstr, L"/");
+        const auto printable = TextUtils::str_replace_all(dirstr, LR"(\\)", L"/");
         Log::InfoW(L"Settings saved to %s", printable.c_str());
     }
     else if (arg1 == L"load") {
@@ -1930,7 +1930,7 @@ void CHAT_CMD_FUNC(ChatCommands::CmdTB)
         const auto file_location = GWToolbox::LoadSettings();
         const auto dir = file_location.parent_path();
         const auto dirstr = dir.wstring();
-        const auto printable = TextUtils::ctre_regex_replace<LR"(\\)">(dirstr, L"/");
+        const auto printable = TextUtils::str_replace_all(dirstr, LR"(\\)", L"/");
         Log::InfoW(L"Settings loaded from %s", printable.c_str());
     }
     else {

--- a/GWToolboxdll/Modules/ChatSettings.h
+++ b/GWToolboxdll/Modules/ChatSettings.h
@@ -48,7 +48,7 @@ public:
     bool invalid = true; // Set when we can't find the agent name for some reason, or arguments passed are empty.
 
 protected:
-    std::vector<std::wstring> SanitiseForSend();
+    std::vector<std::wstring> SanitiseForSend() const;
     bool PrintMessage();
     bool Send();
     void Init();

--- a/GWToolboxdll/Modules/GameSettings.cpp
+++ b/GWToolboxdll/Modules/GameSettings.cpp
@@ -1360,19 +1360,19 @@ void GameSettings::PingItem(GW::Item* item, const uint32_t parts)
     }
     std::wstring out;
     if (parts & NAME && item->complete_name_enc) {
-        if (out.length()) {
+        if (!out.empty()) {
             out += L"\x2\x102\x2";
         }
         out += item->complete_name_enc;
     }
     else if (parts & NAME && item->name_enc) {
-        if (out.length()) {
+        if (!out.empty()) {
             out += L"\x2\x102\x2";
         }
         out += item->name_enc;
     }
     if (parts & DESC && item->info_string) {
-        if (out.length()) {
+        if (!out.empty()) {
             out += L"\x2\x102\x2";
         }
         out += ShorthandItemDescription(item);

--- a/GWToolboxdll/Modules/GameSettings.cpp
+++ b/GWToolboxdll/Modules/GameSettings.cpp
@@ -1485,8 +1485,8 @@ void PendingChatMessage::Init()
 
 std::vector<std::wstring> PendingChatMessage::SanitiseForSend() const
 {
-    const std::wstring sanitised = TextUtils::ctre_regex_replace<L"<[^>]+>">(output_message, L"");
-    const std::wstring sanitised2 = TextUtils::ctre_regex_replace<L"\n">(sanitised, L"|");
+    const std::wstring sanitised = TextUtils::ctre_regex_replace<L"<[^>]+>", L"">(output_message);
+    const std::wstring sanitised2 = TextUtils::ctre_regex_replace<L"\n", L"|">(sanitised);
 
     // Split the string by '|' character
     std::vector<std::wstring> parts;

--- a/GWToolboxdll/Modules/GameSettings.cpp
+++ b/GWToolboxdll/Modules/GameSettings.cpp
@@ -1483,15 +1483,15 @@ void PendingChatMessage::Init()
     }
 }
 
-std::vector<std::wstring> PendingChatMessage::SanitiseForSend()
+std::vector<std::wstring> PendingChatMessage::SanitiseForSend() const
 {
-    const std::wregex no_tags(L"<[^>]+>");
-    const std::wregex no_new_lines(L"\n");
-    std::wstring sanitised, sanitised2, temp;
-    std::regex_replace(std::back_inserter(sanitised), output_message.begin(), output_message.end(), no_tags, L"");
-    std::regex_replace(std::back_inserter(sanitised2), sanitised.begin(), sanitised.end(), no_new_lines, L"|");
+    const std::wstring sanitised = TextUtils::ctre_regex_replace<L"<[^>]+>">(output_message, L"");
+    const std::wstring sanitised2 = TextUtils::ctre_regex_replace<L"\n">(sanitised, L"|");
+
+    // Split the string by '|' character
     std::vector<std::wstring> parts;
     std::wstringstream wss(sanitised2);
+    std::wstring temp;
     while (std::getline(wss, temp, L'|')) {
         parts.push_back(temp);
     }

--- a/GWToolboxdll/Modules/InventoryManager.cpp
+++ b/GWToolboxdll/Modules/InventoryManager.cpp
@@ -1958,9 +1958,6 @@ void InventoryManager::Draw(IDirect3DDevice9*)
             // Are you sure prompt; at this point we've already got the list of items via FetchPotentialItems()
             ImGui::Text("You're about to salvage %d item%s:", potential_salvage_all_items.size(), potential_salvage_all_items.size() == 1 ? "" : "s");
             ImGui::TextDisabled("Untick an item to skip salvaging");
-            static const std::regex sanitiser("<[^>]+>");
-            static const std::wregex wsanitiser(L"<[^>]+>");
-            static const std::wstring wiki_url(L"https://wiki.guildwars.com/wiki/");
             const float& font_scale = ImGui::GetIO().FontGlobalScale;
             const float wiki_btn_width = 50.0f * font_scale;
             static float longest_item_name_length = 280.0f * font_scale;

--- a/GWToolboxdll/Modules/Resources.cpp
+++ b/GWToolboxdll/Modules/Resources.cpp
@@ -1307,8 +1307,8 @@ IDirect3DTexture9** Resources::GetItemImage(const std::wstring& item_name)
         }
         const std::string item_name_str = TextUtils::WStringToString(item_name);
         // matches any characters that need to be escaped in RegEx
-        static const std::regex specialChars{R"([-[\]{}()*+?.,\^$|#\s])"};
-        const std::string sanitized = std::regex_replace(item_name_str, specialChars, R"(\$&)");
+        static const std::regex SPECIAL_CHARS{R"([-[\]{}()*+?.,\^$|#\s])"};
+        const std::string sanitized = std::regex_replace(item_name_str, SPECIAL_CHARS, R"(\$&)");
         std::smatch m;
         // Find first png image that has an alt tag matching the html encoded title of the page
         char regex_str[255];

--- a/GWToolboxdll/Modules/Resources.cpp
+++ b/GWToolboxdll/Modules/Resources.cpp
@@ -1319,8 +1319,8 @@ IDirect3DTexture9** Resources::GetItemImage(const std::wstring& item_name)
         }
         const std::string item_name_str = TextUtils::WStringToString(item_name);
         // matches any characters that need to be escaped in RegEx
-        static const std::regex SPECIAL_CHARS{R"([-[\]{}()*+?.,\^$|#\s])"};
-        const std::string sanitized = std::regex_replace(item_name_str, SPECIAL_CHARS, R"(\$&)");
+        static constexpr ctll::fixed_string SPECIAL_CHARS{R"([\-\[\]{}()*+?.,\^$|#\s])"};
+        const std::string sanitized = TextUtils::ctre_regex_replace<SPECIAL_CHARS, R"(\$&)">(item_name_str);
         std::smatch m;
         // Find first png image that has an alt tag matching the html encoded title of the page
         char regex_str[255];

--- a/GWToolboxdll/Utils/GuiUtils.cpp
+++ b/GWToolboxdll/Utils/GuiUtils.cpp
@@ -501,9 +501,7 @@ namespace GuiUtils {
     {
         if (!sanitised && !decoded_ws.empty()) {
             sanitised = true;
-            static const std::wregex sanitiser(L"<[^>]+>");
-            auto sanitised_ws = std::regex_replace(decoded_ws, sanitiser, L"");
-            decoded_ws = std::move(sanitised_ws);
+            decoded_ws = TextUtils::ctre_regex_replace<L"<[^>]+>">(decoded_ws, L"");
         }
     }
 

--- a/GWToolboxdll/Utils/GuiUtils.cpp
+++ b/GWToolboxdll/Utils/GuiUtils.cpp
@@ -230,7 +230,7 @@ namespace GuiUtils {
 
     std::string SanitizeWikiUrl(std::string s)
     {
-        return TextUtils::ctre_regex_replace<R"([\s_]*\[.*?\][\s_]*)">(s, "");
+        return TextUtils::ctre_regex_replace<R"([\s_]*\[.*?\][\s_]*)", "">(s);
     }
 
     void OpenWiki(const std::wstring& url_path)
@@ -501,7 +501,7 @@ namespace GuiUtils {
     {
         if (!sanitised && !decoded_ws.empty()) {
             sanitised = true;
-            decoded_ws = TextUtils::ctre_regex_replace<L"<[^>]+>">(decoded_ws, L"");
+            decoded_ws = TextUtils::ctre_regex_replace<L"<[^>]+>", L"">(decoded_ws);
         }
     }
 

--- a/GWToolboxdll/Utils/GuiUtils.cpp
+++ b/GWToolboxdll/Utils/GuiUtils.cpp
@@ -230,8 +230,7 @@ namespace GuiUtils {
 
     std::string SanitizeWikiUrl(std::string s)
     {
-        const std::regex strip_bracket_whitespace(R"([\s_]*\[.*?\][\s_]*)");
-        return std::regex_replace(s, strip_bracket_whitespace, "");
+        return TextUtils::ctre_regex_replace<R"([\s_]*\[.*?\][\s_]*)">(s, "");
     }
 
     void OpenWiki(const std::wstring& url_path)

--- a/GWToolboxdll/Utils/TextUtils.cpp
+++ b/GWToolboxdll/Utils/TextUtils.cpp
@@ -197,7 +197,8 @@ namespace TextUtils {
         return out;
     }
 
-    std::string GuidToString(const GUID* guid) {
+    std::string GuidToString(const GUID* guid)
+    {
         ASSERT(guid);
         char guid_string[37]; // 32 hex chars + 4 hyphens + null terminator
         snprintf(
@@ -325,36 +326,38 @@ namespace TextUtils {
         return out;
     }
 
-    std::string SanitizePlayerName(const std::string_view str) {
+    std::string SanitizePlayerName(const std::string_view str)
+    {
         return WStringToString(SanitizePlayerName(StringToWString(str)));
     }
 
-    std::wstring SanitizePlayerName(const std::wstring_view str) {
+    std::wstring SanitizePlayerName(const std::wstring_view str)
+    {
         std::wstring result;
         wchar_t remove_char_token = 0;
 
         for (const auto& wchar : str) {
             if (remove_char_token) {
                 if (wchar == remove_char_token) {
-                    remove_char_token = 0;  // End removal mode if closing character is found
+                    remove_char_token = 0; // End removal mode if closing character is found
                 }
-                continue;  // Skip characters inside the brackets/parentheses
+                continue; // Skip characters inside the brackets/parentheses
             }
             if (wchar == L'[') {
-                remove_char_token = L']';  // Set to skip until the closing bracket
+                remove_char_token = L']'; // Set to skip until the closing bracket
                 if (!result.empty()) {
-                    result.pop_back();  // Remove the space before the opening bracket if needed
+                    result.pop_back(); // Remove the space before the opening bracket if needed
                 }
                 continue;
             }
             if (wchar == L'(') {
-                remove_char_token = L')';  // Set to skip until the closing parenthesis
+                remove_char_token = L')'; // Set to skip until the closing parenthesis
                 if (!result.empty()) {
                     result.pop_back();
                 }
                 continue;
             }
-            result.push_back(wchar);  // Add valid character to result
+            result.push_back(wchar); // Add valid character to result
         }
 
         return result;
@@ -444,7 +447,8 @@ namespace TextUtils {
         return str != end && errno != ERANGE;
     }
 
-    std::string TimeToString(time_t utc_timestamp, bool include_seconds) {
+    std::string TimeToString(time_t utc_timestamp, bool include_seconds)
+    {
         const time_t now = time(nullptr);
         if (!utc_timestamp) {
             utc_timestamp = now;
@@ -456,7 +460,7 @@ namespace TextUtils {
 
         std::string out;
         if (timeinfo->tm_yday != nowinfo->tm_yday || timeinfo->tm_year != nowinfo->tm_year) {
-            static constexpr const char* months[] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
+            static constexpr const char* months[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
             out += std::format("{} {:02d} ", months[timeinfo->tm_mon], timeinfo->tm_mday);
         }
         if (timeinfo->tm_year != nowinfo->tm_year) {
@@ -479,14 +483,16 @@ namespace TextUtils {
         return TimeToString(filetime_to_timet(utc_timestamp), include_seconds);
     }
 
-    std::vector<std::string> Split(const std::string& in, const std::string& token) {
+    std::vector<std::string> Split(const std::string& in, const std::string& token)
+    {
         std::vector<std::string> result;
         size_t start = 0;
         size_t pos = 0;
 
         while ((pos = in.find(token, start)) != std::string::npos) {
             std::string part = in.substr(start, pos - start);
-            if (!part.empty()) {  // Skip empty substrings
+            if (!part.empty()) {
+                // Skip empty substrings
                 result.push_back(part);
             }
             start = pos + token.length();
@@ -500,32 +506,35 @@ namespace TextUtils {
 
         return result;
     }
-    std::string Join(const std::vector<std::string>& parts, const std::string& token) {
+
+    std::string Join(const std::vector<std::string>& parts, const std::string& token)
+    {
         std::string result;
-        bool first = true;  // Track if it's the first valid part
+        bool first = true; // Track if it's the first valid part
 
         for (const auto& part : parts) {
             if (!part.empty()) {
                 if (!first) {
-                    result += token;  // Add the delimiter before non-first parts
+                    result += token; // Add the delimiter before non-first parts
                 }
                 result += part;
-                first = false;  // Switch after adding the first valid part
+                first = false; // Switch after adding the first valid part
             }
         }
 
         return result;
     }
 
-    std::string UcWords(const std::string_view input) {
+    std::string UcWords(const std::string_view input)
+    {
 #pragma warning(push)
 #pragma warning(disable : 4244)
-        std::string result(input);  // Create a copy of the input
+        std::string result(input); // Create a copy of the input
         bool capitalizeNext = true;
 
         for (size_t i = 0; i < result.length(); ++i) {
             if (std::isspace(static_cast<unsigned char>(result[i]))) {
-                capitalizeNext = true;  // Set flag to capitalize next letter after space
+                capitalizeNext = true; // Set flag to capitalize next letter after space
             }
             else if (capitalizeNext && std::isalpha(static_cast<unsigned char>(result[i]))) {
                 result[i] = std::toupper(static_cast<unsigned char>(result[i]));
@@ -536,6 +545,6 @@ namespace TextUtils {
             }
         }
 #pragma warning(pop)
-        return result;  // Return the modified string
+        return result; // Return the modified string
     }
 }

--- a/GWToolboxdll/Utils/TextUtils.h
+++ b/GWToolboxdll/Utils/TextUtils.h
@@ -74,10 +74,33 @@ namespace TextUtils {
     }
 
     template <ctll::fixed_string Pattern>
-    std::wstring ctre_regex_replace_w(const std::wstring_view input, const std::wstring_view replacement) {
-        const auto in = WStringToString(input);
-        const auto res = TextUtils::ctre_regex_replace<Pattern>(in, WStringToString(replacement));
-        return StringToWString(res);
+    std::wstring ctre_regex_replace(const std::wstring_view input, const std::wstring_view replacement) {
+        std::wstring result;
+        // Pre-allocate memory to avoid frequent reallocations
+        result.reserve(input.size());
+
+        size_t last_pos = 0;
+
+        // Iterate through all matches
+        for (const auto match : ctre::search_all<Pattern>(input)) {
+            // Get the matched substring and its position
+            const auto matched_view = match.get<0>().to_view();
+            const auto pos = std::distance(input.begin(), match.get<0>().begin());
+
+            // Append text before the match
+            result.append(input.substr(last_pos, pos - last_pos));
+            // Append the replacement
+            result.append(replacement);
+            // Update position
+            last_pos = pos + matched_view.size();
+        }
+
+        // Append the remaining text
+        if (last_pos < input.size()) {
+            result.append(input.substr(last_pos));
+        }
+
+        return result;
     }
 
     template <ctll::fixed_string Pattern, typename Formatter>

--- a/GWToolboxdll/Utils/TextUtils.h
+++ b/GWToolboxdll/Utils/TextUtils.h
@@ -42,75 +42,29 @@ namespace TextUtils {
     // Capitalise the first letter of each word. Replaces original.
     std::string UcWords(std::string_view input);
 
-
-    template <ctll::fixed_string Pattern>
-    std::string ctre_regex_replace(std::string_view input, const std::string_view replacement) {
-        std::string result;
-        // Pre-allocate memory to avoid frequent reallocations
-        result.reserve(input.size());
-
-        size_t last_pos = 0;
-
-        // Iterate through all matches
-        for (const auto match : ctre::search_all<Pattern>(input)) {
-            // Get the matched substring and its position
-            const auto matched_view = match.get<0>().to_view();
-            const auto pos = std::distance(input.begin(), match.get<0>().begin());
-
-            // Append text before the match
-            result.append(input.substr(last_pos, pos - last_pos));
-            // Append the replacement
-            result.append(replacement);
-            // Update position
-            last_pos = pos + matched_view.size();
-        }
-
-        // Append the remaining text
-        if (last_pos < input.size()) {
-            result.append(input.substr(last_pos));
-        }
-
-        return result;
+    template <ctll::fixed_string Pattern, typename ...Modifiers>
+    std::string ctre_regex_replace(std::string_view input, const std::string_view replacement)
+    {
+        auto r = ctre::split<Pattern, Modifiers...>(input);
+        return r | std::views::join_with(replacement) | std::ranges::to<std::string>();
     }
 
-    template <ctll::fixed_string Pattern>
-    std::wstring ctre_regex_replace(const std::wstring_view input, const std::wstring_view replacement) {
-        std::wstring result;
-        // Pre-allocate memory to avoid frequent reallocations
-        result.reserve(input.size());
-
-        size_t last_pos = 0;
-
-        // Iterate through all matches
-        for (const auto match : ctre::search_all<Pattern>(input)) {
-            // Get the matched substring and its position
-            const auto matched_view = match.get<0>().to_view();
-            const auto pos = std::distance(input.begin(), match.get<0>().begin());
-
-            // Append text before the match
-            result.append(input.substr(last_pos, pos - last_pos));
-            // Append the replacement
-            result.append(replacement);
-            // Update position
-            last_pos = pos + matched_view.size();
-        }
-
-        // Append the remaining text
-        if (last_pos < input.size()) {
-            result.append(input.substr(last_pos));
-        }
-
-        return result;
+    template <ctll::fixed_string Pattern, typename ...Modifiers>
+    std::wstring ctre_regex_replace(std::wstring_view input, const std::wstring_view replacement)
+    {
+        auto r = ctre::split<Pattern, Modifiers...>(input);
+        return r | std::views::join_with(replacement) | std::ranges::to<std::wstring>();
     }
 
-    template <ctll::fixed_string Pattern, typename Formatter>
-    std::wstring ctre_regex_replace_with_formatter(std::wstring_view input, Formatter formatter) {
+    template <ctll::fixed_string Pattern, typename Formatter, typename ...Modifiers>
+    std::wstring ctre_regex_replace_with_formatter(std::wstring_view input, Formatter formatter)
+    {
         std::wstring result;
         result.reserve(input.size());
         size_t last_pos = 0;
 
         // Iterate through all matches
-        for (auto match : ctre::search_all<Pattern>(input)) {
+        for (auto match : ctre::search_all<Pattern, Modifiers...>(input)) {
             // Get the matched substring and its position
             auto matched = match.get<0>().to_view();
             auto pos = std::distance(input.begin(), match.get<0>().begin());

--- a/GWToolboxdll/Utils/TextUtils.h
+++ b/GWToolboxdll/Utils/TextUtils.h
@@ -60,7 +60,8 @@ namespace TextUtils {
             return ctre_simple_regex_replace<char, Pattern, Modifiers...>(subject, Replacement);
         }
 
-        std::stringstream result;
+        std::string result;
+        result.reserve(subject.size() * 2);
         auto search_start = subject.begin();
 #pragma warning(push)
 #pragma warning(disable: 4244)
@@ -68,7 +69,7 @@ namespace TextUtils {
 #pragma warning(pop)
 
         for (auto match : ctre::search_all<Pattern, Modifiers...>(subject)) {
-            result.write(&*search_start, match.begin() - search_start);
+            result.append(&*search_start, match.begin() - search_start);
             std::string replaced_match(replacement);
             std::unordered_map<std::string, std::string> replacements;
 
@@ -111,14 +112,14 @@ namespace TextUtils {
                 }
             }
 
-            result << replaced_match;
+            result.append(replaced_match);
             search_start = match.end();
         }
 
         if (search_start != subject.end()) {
-            result.write(&*search_start, std::distance(search_start, subject.end()));
+            result.append(&*search_start, std::distance(search_start, subject.end()));
         }
-        return result.str();
+        return result;
     }
 
     template <ctll::fixed_string Pattern, ctll::fixed_string Replacement, typename... Modifiers>
@@ -130,7 +131,8 @@ namespace TextUtils {
             return ctre_simple_regex_replace<char, Pattern, Modifiers...>(subject, Replacement);
         }
 
-        std::wstringstream result;
+        std::wstring result;
+        result.reserve(subject.size() * 2);
         auto search_start = subject.begin();
 #pragma warning(push)
 #pragma warning(disable: 4244)
@@ -138,7 +140,7 @@ namespace TextUtils {
 #pragma warning(pop)
 
         for (auto match : ctre::search_all<Pattern, Modifiers...>(subject)) {
-            result.write(&*search_start, match.begin() - search_start);
+            result.append(&*search_start, match.begin() - search_start);
             std::wstring replaced_match(replacement);
             std::unordered_map<std::wstring, std::wstring> replacements;
 
@@ -181,14 +183,14 @@ namespace TextUtils {
                 }
             }
 
-            result << replaced_match;
+            result.append(replaced_match);
             search_start = match.end();
         }
 
         if (search_start != subject.end()) {
-            result.write(&*search_start, std::distance(search_start, subject.end()));
+            result.append(&*search_start, std::distance(search_start, subject.end()));
         }
-        return result.str();
+        return result;
     }
 
     template <ctll::fixed_string Pattern, typename Formatter, typename... Modifiers>

--- a/GWToolboxdll/Utils/TextUtils.h
+++ b/GWToolboxdll/Utils/TextUtils.h
@@ -48,7 +48,7 @@ namespace TextUtils {
     constexpr std::basic_string<CharT> ctre_simple_regex_replace(const std::basic_string_view<CharT> input, const std::basic_string_view<CharT> replacement)
     {
         auto r = ctre::split<Pattern, Modifiers...>(input);
-        return r | std::views::join_with(replacement) | std::ranges::to<std::basic_string<CharT>>();
+        return r | std::views::as_rvalue | std::views::join_with(replacement) | std::ranges::to<std::basic_string<CharT>>();
     }
 
     template <ctll::fixed_string Pattern, ctll::fixed_string Replacement, typename... Modifiers>

--- a/GWToolboxdll/Utils/TextUtils.h
+++ b/GWToolboxdll/Utils/TextUtils.h
@@ -68,8 +68,8 @@ namespace TextUtils {
         // Iterate through all matches
         for (auto match : ctre::search_all<Pattern, Modifiers...>(input)) {
             // Get the matched substring and its position
-            auto matched = match.get<0>().to_view();
-            auto pos = std::distance(input.begin(), match.get<0>().begin());
+            auto matched = match.template get<0>().to_view();
+            auto pos = std::distance(input.begin(), match.template get<0>().begin());
 
             // Append text before the match
             result.append(input.substr(last_pos, pos - last_pos));

--- a/GWToolboxdll/Utils/TextUtils.h
+++ b/GWToolboxdll/Utils/TextUtils.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "ctre.hpp"
+
 namespace TextUtils {
     std::string WStringToString(std::wstring_view str);
     std::wstring StringToWString(std::string_view str);
@@ -20,8 +22,8 @@ namespace TextUtils {
     std::wstring ToLower(std::wstring s);
     std::wstring RemoveDiacritics(std::wstring_view s);
 
-    std::wstring SanitizePlayerName(const std::wstring_view str);
-    std::string SanitizePlayerName(const std::string_view str);
+    std::wstring SanitizePlayerName(std::wstring_view str);
+    std::string SanitizePlayerName(std::string_view str);
     std::wstring GetPlayerNameFromEncodedString(const wchar_t* message, const wchar_t** start_pos_out = nullptr, const wchar_t** end_pos_out = nullptr);
 
     bool ParseInt(const char* str, int* val, int base = 10);
@@ -38,6 +40,71 @@ namespace TextUtils {
     // Turn and array of strings into a single string
     std::string Join(const std::vector<std::string>& parts, const std::string& token);
     // Capitalise the first letter of each word. Replaces original.
-    std::string UcWords(const std::string_view input);
+    std::string UcWords(std::string_view input);
 
+
+    template <ctll::fixed_string Pattern>
+    std::string ctre_regex_replace(std::string_view input, const std::string_view replacement) {
+        std::string result;
+        // Pre-allocate memory to avoid frequent reallocations
+        result.reserve(input.size());
+
+        size_t last_pos = 0;
+
+        // Iterate through all matches
+        for (const auto match : ctre::search_all<Pattern>(input)) {
+            // Get the matched substring and its position
+            const auto matched_view = match.get<0>().to_view();
+            const auto pos = std::distance(input.begin(), match.get<0>().begin());
+
+            // Append text before the match
+            result.append(input.substr(last_pos, pos - last_pos));
+            // Append the replacement
+            result.append(replacement);
+            // Update position
+            last_pos = pos + matched_view.size();
+        }
+
+        // Append the remaining text
+        if (last_pos < input.size()) {
+            result.append(input.substr(last_pos));
+        }
+
+        return result;
+    }
+
+    template <ctll::fixed_string Pattern>
+    std::wstring ctre_regex_replace_w(const std::wstring_view input, const std::wstring_view replacement) {
+        const auto in = WStringToString(input);
+        const auto res = TextUtils::ctre_regex_replace<Pattern>(in, WStringToString(replacement));
+        return StringToWString(res);
+    }
+
+    template <ctll::fixed_string Pattern, typename Formatter>
+    std::wstring ctre_regex_replace_with_formatter(std::wstring_view input, Formatter formatter) {
+        std::wstring result;
+        result.reserve(input.size());
+        size_t last_pos = 0;
+
+        // Iterate through all matches
+        for (auto match : ctre::search_all<Pattern>(input)) {
+            // Get the matched substring and its position
+            auto matched = match.get<0>().to_view();
+            auto pos = std::distance(input.begin(), match.get<0>().begin());
+
+            // Append text before the match
+            result.append(input.substr(last_pos, pos - last_pos));
+            // Apply custom formatter and append
+            result.append(formatter(match));
+            // Update position
+            last_pos = pos + matched.length();
+        }
+
+        // Append the remaining text
+        if (last_pos < input.size()) {
+            result.append(input.substr(last_pos));
+        }
+
+        return result;
+    }
 }

--- a/GWToolboxdll/Utils/TextUtils.h
+++ b/GWToolboxdll/Utils/TextUtils.h
@@ -71,38 +71,46 @@ namespace TextUtils {
         for (auto match : ctre::search_all<Pattern, Modifiers...>(subject)) {
             result.append(&*search_start, match.begin() - search_start);
             std::string replaced_match(replacement);
-            std::unordered_map<std::string, std::string> replacements;
+        struct Pair {
+            std::string key;
+            std::string value;
+        };
+        std::vector<Pair> replacements;
 
-            constexpr auto cnt = decltype(match)::count();
-            static_assert(cnt < 10, "Only up to 9 capture groups are supported");
-            if constexpr (ctre::search<R"(\$&)">(Replacement))
-                replacements["$&"] = match.to_string();
-            if constexpr (ctre::search<R"(\$')">(Replacement))
-                replacements["$'"] = std::string(match.end(), subject.end());
-            if constexpr (ctre::search<R"(\$`)">(Replacement))
-                replacements["$`"] = std::string(subject.begin(), match.begin());
-            if constexpr (ctre::search<R"(\$\$)">(Replacement))
-                replacements["$$"] = "$";
-            if constexpr (ctre::search<R"(\$0)">(Replacement) && cnt >= 0)
-                replacements["$0"] = match.template get<0>().to_string();
-            if constexpr (ctre::search<R"(\$1)">(Replacement) && cnt >= 1)
-                replacements["$1"] = match.template get<1>().to_string();
-            if constexpr (ctre::search<R"(\$2)">(Replacement) && cnt >= 2)
-                replacements["$2"] = match.template get<2>().to_string();
-            if constexpr (ctre::search<R"(\$3)">(Replacement) && cnt >= 3)
-                replacements["$3"] = match.template get<3>().to_string();
-            if constexpr (ctre::search<R"(\$4)">(Replacement) && cnt >= 4)
-                replacements["$4"] = match.template get<4>().to_string();
-            if constexpr (ctre::search<R"(\$5)">(Replacement) && cnt >= 5)
-                replacements["$5"] = match.template get<5>().to_string();
-            if constexpr (ctre::search<R"(\$6)">(Replacement) && cnt > 6)
-                replacements["$6"] = match.template get<6>().to_string();
-            if constexpr (ctre::search<R"(\$7)">(Replacement) && cnt > 7)
-                replacements["$7"] = match.template get<7>().to_string();
-            if constexpr (ctre::search<R"(\$8)">(Replacement) && cnt > 8)
-                replacements["$8"] = match.template get<8>().to_string();
-            if constexpr (ctre::search<R"(\$9)">(Replacement) && cnt > 9)
-                replacements["$9"] = match.template get<9>().to_string();
+        constexpr auto cnt = decltype(match)::count();
+        static_assert(cnt < 10, "Only up to 9 capture groups are supported");
+        // Add replacements to vector with emplace_back
+        constexpr auto has_escaped_dollar = ctre::search<R"(\$\$)">(Replacement);
+        if constexpr (has_escaped_dollar)
+            replacements.emplace_back("$$", "~$~");
+        if constexpr (ctre::search<R"(\$&)">(Replacement))
+            replacements.emplace_back("$&", match.to_string());
+        if constexpr (ctre::search<R"(\$')">(Replacement))
+            replacements.emplace_back("$'", std::string(match.end(), subject.end()));
+        if constexpr (ctre::search<R"(\$`)">(Replacement))
+            replacements.emplace_back("$`", std::string(subject.begin(), match.begin()));
+        // if constexpr (ctre::search<R"(\$0)">(Replacement))
+        //     replacements.emplace_back("$0", match.to_string());
+        if constexpr (ctre::search<R"(\$1)">(Replacement) && cnt > 1)
+            replacements.emplace_back("$1", match.template get<1>().to_string());
+        if constexpr (ctre::search<R"(\$2)">(Replacement) && cnt > 2)
+            replacements.emplace_back("$2", match.template get<2>().to_string());
+        if constexpr (ctre::search<R"(\$3)">(Replacement) && cnt > 3)
+            replacements.emplace_back("$3", match.template get<3>().to_string());
+        if constexpr (ctre::search<R"(\$4)">(Replacement) && cnt > 4)
+            replacements.emplace_back("$4", match.template get<4>().to_string());
+        if constexpr (ctre::search<R"(\$5)">(Replacement) && cnt > 5)
+            replacements.emplace_back("$5", match.template get<5>().to_string());
+        if constexpr (ctre::search<R"(\$6)">(Replacement) && cnt > 6)
+            replacements.emplace_back("$6", match.template get<6>().to_string());
+        if constexpr (ctre::search<R"(\$7)">(Replacement) && cnt > 7)
+            replacements.emplace_back("$7", match.template get<7>().to_string());
+        if constexpr (ctre::search<R"(\$8)">(Replacement) && cnt > 8)
+            replacements.emplace_back("$8", match.template get<8>().to_string());
+        if constexpr (ctre::search<R"(\$9)">(Replacement) && cnt > 9)
+            replacements.emplace_back("$9", match.template get<9>().to_string());
+        if constexpr (has_escaped_dollar)
+            replacements.emplace_back("~$~", "$");
 
             for (const auto& [key, value] : replacements) {
                 size_t pos = 0;
@@ -142,38 +150,46 @@ namespace TextUtils {
         for (auto match : ctre::search_all<Pattern, Modifiers...>(subject)) {
             result.append(&*search_start, match.begin() - search_start);
             std::wstring replaced_match(replacement);
-            std::unordered_map<std::wstring, std::wstring> replacements;
+        struct Pair {
+            std::wstring key;
+            std::wstring value;
+        };
+        std::vector<Pair> replacements;
 
-            constexpr auto cnt = decltype(match)::count();
-            static_assert(cnt < 10, "Only up to 9 capture groups are supported");
-            if constexpr (ctre::search<LR"(\$&)">(Replacement))
-                replacements[L"$&"] = match.to_string();
-            if constexpr (ctre::search<LR"(\$')">(Replacement))
-                replacements[L"$'"] = std::string(match.end(), subject.end());
-            if constexpr (ctre::search<LR"(\$`)">(Replacement))
-                replacements[L"$`"] = std::string(subject.begin(), match.begin());
-            if constexpr (ctre::search<LR"(\$\$)">(Replacement))
-                replacements[L"$$"] = L"$";
-            if constexpr (ctre::search<LR"(\$0)">(Replacement) && cnt >= 0)
-                replacements[L"$0"] = match.template get<0>().to_string();
-            if constexpr (ctre::search<LR"(\$1)">(Replacement) && cnt >= 1)
-                replacements[L"$1"] = match.template get<1>().to_string();
-            if constexpr (ctre::search<LR"(\$2)">(Replacement) && cnt >= 2)
-                replacements[L"$2"] = match.template get<2>().to_string();
-            if constexpr (ctre::search<LR"(\$3)">(Replacement) && cnt >= 3)
-                replacements[L"$3"] = match.template get<3>().to_string();
-            if constexpr (ctre::search<LR"(\$4)">(Replacement) && cnt >= 4)
-                replacements[L"$4"] = match.template get<4>().to_string();
-            if constexpr (ctre::search<LR"(\$5)">(Replacement) && cnt >= 5)
-                replacements[L"$5"] = match.template get<5>().to_string();
-            if constexpr (ctre::search<LR"(\$6)">(Replacement) && cnt > 6)
-                replacements[L"$6"] = match.template get<6>().to_string();
-            if constexpr (ctre::search<LR"(\$7)">(Replacement) && cnt > 7)
-                replacements[L"$7"] = match.template get<7>().to_string();
-            if constexpr (ctre::search<LR"(\$8)">(Replacement) && cnt > 8)
-                replacements[L"$8"] = match.template get<8>().to_string();
-            if constexpr (ctre::search<LR"(\$9)">(Replacement) && cnt > 9)
-                replacements[L"$9"] = match.template get<9>().to_string();
+        constexpr auto cnt = decltype(match)::count();
+        static_assert(cnt < 10, "Only up to 9 capture groups are supported");
+        // Add replacements to vector with emplace_back
+        constexpr auto has_escaped_dollar = ctre::search<LR"(\$\$)">(Replacement);
+        if constexpr (has_escaped_dollar)
+            replacements.emplace_back(L"$$", L"~$~");
+        if constexpr (ctre::search<LR"(\$&)">(Replacement))
+            replacements.emplace_back(L"$&", match.to_string());
+        if constexpr (ctre::search<LR"(\$')">(Replacement))
+            replacements.emplace_back(L"$'", std::string(match.end(), subject.end()));
+        if constexpr (ctre::search<LR"(\$`)">(Replacement))
+            replacements.emplace_back(L"$`", std::string(subject.begin(), match.begin()));
+        // if constexpr (ctre::search<LR"(\$0)">(Replacement))
+        //     replacements.emplace_back(L"$0", match.to_string());
+        if constexpr (ctre::search<LR"(\$1)">(Replacement) && cnt > 1)
+            replacements.emplace_back(L"$1", match.template get<1>().to_string());
+        if constexpr (ctre::search<LR"(\$2)">(Replacement) && cnt > 2)
+            replacements.emplace_back(L"$2", match.template get<2>().to_string());
+        if constexpr (ctre::search<LR"(\$3)">(Replacement) && cnt > 3)
+            replacements.emplace_back(L"$3", match.template get<3>().to_string());
+        if constexpr (ctre::search<LR"(\$4)">(Replacement) && cnt > 4)
+            replacements.emplace_back(L"$4", match.template get<4>().to_string());
+        if constexpr (ctre::search<LR"(\$5)">(Replacement) && cnt > 5)
+            replacements.emplace_back(L"$5", match.template get<5>().to_string());
+        if constexpr (ctre::search<LR"(\$6)">(Replacement) && cnt > 6)
+            replacements.emplace_back(L"$6", match.template get<6>().to_string());
+        if constexpr (ctre::search<LR"(\$7)">(Replacement) && cnt > 7)
+            replacements.emplace_back(L"$7", match.template get<7>().to_string());
+        if constexpr (ctre::search<LR"(\$8)">(Replacement) && cnt > 8)
+            replacements.emplace_back(L"$8", match.template get<8>().to_string());
+        if constexpr (ctre::search<LR"(\$9)">(Replacement) && cnt > 9)
+            replacements.emplace_back(L"$9", match.template get<9>().to_string());
+        if constexpr (has_escaped_dollar)
+            replacements.emplace_back(L"~$~", L"$");
 
             for (const auto& [key, value] : replacements) {
                 size_t pos = 0;

--- a/GWToolboxdll/Utils/TextUtils.h
+++ b/GWToolboxdll/Utils/TextUtils.h
@@ -1,6 +1,8 @@
 #pragma once
 
-#include "ctre.hpp"
+#define __forceinline
+#include <ctre.hpp>
+#undef __forceinline
 
 namespace TextUtils {
     std::string WStringToString(std::wstring_view str);

--- a/GWToolboxdll/Utils/TextUtils.h
+++ b/GWToolboxdll/Utils/TextUtils.h
@@ -54,7 +54,7 @@ namespace TextUtils {
     template <ctll::fixed_string Pattern, ctll::fixed_string Replacement, typename... Modifiers>
     constexpr std::string ctre_regex_replace(const std::string_view subject)
     {
-        // this is actually SLOWER than the stringstream version, so don't use it.
+        // this is actually SLOWER than the string appending version, so don't use it.
         static constexpr ctll::fixed_string special_tokens = R"(\$(\d+|'|&|`|\$))";
         if constexpr (!ctre::search<special_tokens>(Replacement) && false) {
             return ctre_simple_regex_replace<char, Pattern, Modifiers...>(subject, Replacement);
@@ -79,10 +79,9 @@ namespace TextUtils {
 
         constexpr auto cnt = decltype(match)::count();
         static_assert(cnt < 10, "Only up to 9 capture groups are supported");
-        // Add replacements to vector with emplace_back
         constexpr auto has_escaped_dollar = ctre::search<R"(\$\$)">(Replacement);
         if constexpr (has_escaped_dollar)
-            replacements.emplace_back("$$", "~$~");
+            replacements.emplace_back("$$", "###ESCAPED_DOLLAR###");
         if constexpr (ctre::search<R"(\$&)">(Replacement))
             replacements.emplace_back("$&", match.to_string());
         if constexpr (ctre::search<R"(\$')">(Replacement))
@@ -110,7 +109,7 @@ namespace TextUtils {
         if constexpr (ctre::search<R"(\$9)">(Replacement) && cnt > 9)
             replacements.emplace_back("$9", match.template get<9>().to_string());
         if constexpr (has_escaped_dollar)
-            replacements.emplace_back("~$~", "$");
+            replacements.emplace_back("###ESCAPED_DOLLAR###", "$");
 
             for (const auto& [key, value] : replacements) {
                 size_t pos = 0;
@@ -133,7 +132,7 @@ namespace TextUtils {
     template <ctll::fixed_string Pattern, ctll::fixed_string Replacement, typename... Modifiers>
     constexpr std::wstring ctre_regex_replace(const std::wstring_view subject)
     {
-        // this is actually SLOWER than the stringstream version, so don't use it.
+        // this is actually SLOWER than the string appending version, so don't use it.
         static constexpr ctll::fixed_string special_tokens = LR"(\$(\d+|'|&|`|\$))";
         if constexpr (!ctre::search<special_tokens>(Replacement) && false) {
             return ctre_simple_regex_replace<char, Pattern, Modifiers...>(subject, Replacement);
@@ -158,10 +157,9 @@ namespace TextUtils {
 
         constexpr auto cnt = decltype(match)::count();
         static_assert(cnt < 10, "Only up to 9 capture groups are supported");
-        // Add replacements to vector with emplace_back
         constexpr auto has_escaped_dollar = ctre::search<LR"(\$\$)">(Replacement);
         if constexpr (has_escaped_dollar)
-            replacements.emplace_back(L"$$", L"~$~");
+            replacements.emplace_back(L"$$", L"###ESCAPED_DOLLAR###");
         if constexpr (ctre::search<LR"(\$&)">(Replacement))
             replacements.emplace_back(L"$&", match.to_string());
         if constexpr (ctre::search<LR"(\$')">(Replacement))
@@ -189,7 +187,7 @@ namespace TextUtils {
         if constexpr (ctre::search<LR"(\$9)">(Replacement) && cnt > 9)
             replacements.emplace_back(L"$9", match.template get<9>().to_string());
         if constexpr (has_escaped_dollar)
-            replacements.emplace_back(L"~$~", L"$");
+            replacements.emplace_back(L"###ESCAPED_DOLLAR###", L"$");
 
             for (const auto& [key, value] : replacements) {
                 size_t pos = 0;

--- a/GWToolboxdll/Utils/TextUtils.h
+++ b/GWToolboxdll/Utils/TextUtils.h
@@ -115,7 +115,9 @@ namespace TextUtils {
             search_start = match.end();
         }
 
-        result.write(&*search_start, subject.end() - search_start);
+        if (search_start != subject.end()) {
+            result.write(&*search_start, std::distance(search_start, subject.end()));
+        }
         return result.str();
     }
 
@@ -183,7 +185,9 @@ namespace TextUtils {
             search_start = match.end();
         }
 
-        result.write(&*search_start, subject.end() - search_start);
+        if (search_start != subject.end()) {
+            result.write(&*search_start, std::distance(search_start, subject.end()));
+        }
         return result.str();
     }
 
@@ -216,7 +220,8 @@ namespace TextUtils {
         return result;
     }
 
-    inline std::string str_replace_all(std::string subject, const std::string_view needle, const std::string_view str) {
+    inline std::string str_replace_all(std::string subject, const std::string_view needle, const std::string_view str)
+    {
         size_t pos = 0;
         while ((pos = subject.find(needle, pos)) != std::string::npos) {
             subject.replace(pos, needle.length(), str);
@@ -225,7 +230,8 @@ namespace TextUtils {
         return subject;
     }
 
-    inline std::wstring str_replace_all(std::wstring haystack, const std::wstring_view needle, const std::wstring_view str) {
+    inline std::wstring str_replace_all(std::wstring haystack, const std::wstring_view needle, const std::wstring_view str)
+    {
         size_t pos = 0;
         while ((pos = haystack.find(needle, pos)) != std::wstring::npos) {
             haystack.replace(pos, needle.length(), str);
@@ -233,5 +239,4 @@ namespace TextUtils {
         }
         return haystack;
     }
-
 }

--- a/GWToolboxdll/Utils/ToolboxUtils.cpp
+++ b/GWToolboxdll/Utils/ToolboxUtils.cpp
@@ -747,31 +747,31 @@ namespace ToolboxUtils {
         // Change "Life draining -3, Health regeneration -1" > "Vampiric" (add at end of description)
         static constexpr ctll::fixed_string vampiric_pattern = L"\x2\x102\x2.\x10A\xA86\x10A\xA54\x1\x101.\x1\x2\x102\x2.\x10A\xA7E\x10A\xA53\x1\x101.\x1";
         if (ctre::match<vampiric_pattern>(original)) {
-            original = TextUtils::ctre_regex_replace<vampiric_pattern>(original, L"");
+            original = TextUtils::ctre_regex_replace<vampiric_pattern, L"">(original);
             original += L"\x2\x102\x2\x108\x107" L"Vampiric\x1";
         }
 
         // Change "Energy gain on hit 1, Energy regeneration -1" > "Zealous" (add at end of description)
         static constexpr ctll::fixed_string zealous_pattern = L"\x2\x102\x2.\x10A\xA86\x10A\xA50\x1\x101.\x1\x2\x102\x2.\x10A\xA7E\x10A\xA51\x1\x101.\x1";
         if (ctre::match<zealous_pattern>(original)) {
-            original = TextUtils::ctre_regex_replace<zealous_pattern>(original, L"");
+            original = TextUtils::ctre_regex_replace<zealous_pattern, L"">(original);
             original += L"\x2\x102\x2\x108\x107" L"Zealous\x1";
         }
 
         // Change "Damage" > "Dmg"
-        original = TextUtils::ctre_regex_replace<L"\xA4C">(original, L"\xA4E");
+        original = TextUtils::str_replace_all(original, L"\xA4C", L"\xA4E");
 
         // Change Bow "Two-Handed" > ""
-        original = TextUtils::ctre_regex_replace<L"\x8102\x1227">(original, L"\xA3E");
+        original = TextUtils::str_replace_all(original, L"\x8102\x1227", L"\xA3E");
 
         // Change "Halves casting time of spells" > "HCT"
-        original = TextUtils::ctre_regex_replace<L"\xA80\x10A\xA47\x1">(original, L"\x108\x107" L"HCT\x1");
+        original = TextUtils::str_replace_all(original, L"\xA80\x10A\xA47\x1", L"\x108\x107" L"HCT\x1");
 
         // Change "Halves skill recharge of spells" > "HSR"
-        original = TextUtils::ctre_regex_replace<L"\xA80\x10A\xA58\x1">(original, L"\x108\x107" "HSR\x1");
+        original = TextUtils::str_replace_all(original, L"\xA80\x10A\xA58\x1", L"\x108\x107" "HSR\x1");
 
         // Remove (Stacking) and (Non-stacking) rubbish
-        original = TextUtils::ctre_regex_replace<L"\x2.\x10A\xAA8\x10A[\xAB1\xAB2]\x1\x1">(original, L"");
+        original = TextUtils::ctre_regex_replace<L"\x2.\x10A\xAA8\x10A[\xAB1\xAB2]\x1\x1", L"">(original);
 
         // Replace (while affected by a(n) to just (n)
         original = TextUtils::ctre_regex_replace_with_formatter<L"\x8101\x4D9C\x10A.\x1">(
@@ -782,12 +782,12 @@ namespace ToolboxUtils {
             });
 
         // Replace (while xxx) to just (xxx)
-        original = TextUtils::ctre_regex_replace<L"\xAB4">(original, L"\x108\x107" L"Attacking\x1");
-        original = TextUtils::ctre_regex_replace<L"\xAB5">(original, L"\x108\x107" L"Casting\x1");
-        original = TextUtils::ctre_regex_replace<L"\xAB6">(original, L"\x108\x107" L"Condition\x1");
-        original = TextUtils::ctre_regex_replace<L"[\xAB7\x4B6]">(original, L"\x108\x107" L"Enchanted\x1");
-        original = TextUtils::ctre_regex_replace<L"[\xAB8\x4B4]">(original, L"\x108\x107" L"Hexed\x1");
-        original = TextUtils::ctre_regex_replace<L"[\xAB9\xABA]">(original, L"\x108\x107" L"Stance\x1");
+        original = TextUtils::str_replace_all(original, L"\xAB4", L"\x108\x107" L"Attacking\x1");
+        original = TextUtils::str_replace_all(original, L"\xAB5", L"\x108\x107" L"Casting\x1");
+        original = TextUtils::str_replace_all(original, L"\xAB6", L"\x108\x107" L"Condition\x1");
+        original = TextUtils::ctre_regex_replace<L"[\xAB7\x4B6]", L"\x108\x107" L"Enchanted\x1">(original);
+        original = TextUtils::ctre_regex_replace<L"[\xAB8\x4B4]", L"\x108\x107" L"Hexed\x1">(original);
+        original = TextUtils::ctre_regex_replace<L"[\xAB9\xABA]", L"\x108\x107" L"Stance\x1">(original);
 
         // Combine Attribute + 3, Attribute + 1 to Attribute +3 +1 (e.g. headpiece)
         original = TextUtils::ctre_regex_replace_with_formatter<L".\x10A\xA84\x10A.\x1\x101.\x1\x2\x102\x2.\x10A\xA84\x10A.\x1\x101.\x1">(
@@ -803,29 +803,31 @@ namespace ToolboxUtils {
             });
 
         // Remove "Value: 122 gold"
-        original = TextUtils::ctre_regex_replace<L"\x2\x102\x2\xA3E\x10A\xA8A\x10A\xA59\x1\x10B.\x101.(\x102.)?\x1\x1">(original, L"");
+        original = TextUtils::ctre_regex_replace<L"\x2\x102\x2\xA3E\x10A\xA8A\x10A\xA59\x1\x10B.\x101.(\x102.)?\x1\x1", L"">(original);
 
         // Remove other "greyed" generic terms e.g. "Two-Handed", "Unidentified"
-        original = TextUtils::ctre_regex_replace<L"\x2\x102\x2\xA3E\x10A.\x1">(original, L"");
+        original = TextUtils::ctre_regex_replace<L"\x2\x102\x2\xA3E\x10A.\x1", L"">(original);
 
         // Remove "Necromancer Munne sometimes gives these to me in trade" etc
-        original = TextUtils::ctre_regex_replace<L"\x2\x102\x2.\x10A\x8102.\x1">(original, L"");
+        original = TextUtils::ctre_regex_replace<L"\x2\x102\x2.\x10A\x8102.\x1", L"">(original);
 
         // Remove "Inscription: None"
-        original = TextUtils::ctre_regex_replace<L"\x2\x102\x2.\x10A\x8101\x5A1F\x1">(original, L"");
+        original = TextUtils::ctre_regex_replace<L"\x2\x102\x2.\x10A\x8101\x5A1F\x1", L"">(original);
 
         // Remove "Crafted in tribute to an enduring legend." etc
-        original = TextUtils::ctre_regex_replace<L"\x2\x102\x2.\x10A\x8103.\x1">(original, L"");
+        original = TextUtils::ctre_regex_replace<L"\x2\x102\x2.\x10A\x8103.\x1", L"">(original);
 
         // Remove "20% Additional damage during festival events" > "Dmg +20% (Festival)"
-        original = TextUtils::ctre_regex_replace<L".\x10A\x108\x10A\x8103\xB71\x101\x100\x1\x1">(
-            original, L"\xA85\x10A\xA4E\x1\x101\x114\x2\xAA8\x10A\x108\x107" L"Festival\x1\x1");
+        original = TextUtils::ctre_regex_replace<
+            L".\x10A\x108\x10A\x8103\xB71\x101\x100\x1\x1",
+            L"\xA85\x10A\xA4E\x1\x101\x114\x2\xAA8\x10A\x108\x107" L"Festival\x1\x1"
+        >(original);
 
         // Check for customized item with +20% damage
         static constexpr ctll::fixed_string dmg_plus_20_pattern = L"\x2\x102\x2.\x10A\xA85\x10A[\xA4C\xA4E]\x1\x101\x114\x1";
         if (item->customized && ctre::search<dmg_plus_20_pattern>(original)) {
             // Remove "\nDamage +20%" > "\n"
-            original = TextUtils::ctre_regex_replace<dmg_plus_20_pattern>(original, L"");
+            original = TextUtils::ctre_regex_replace<dmg_plus_20_pattern, L"">(original);
             // Append "Customized"
             original += L"\x2\x102\x2\x108\x107" L"Customized\x1";
         }

--- a/GWToolboxdll/Utils/ToolboxUtils.cpp
+++ b/GWToolboxdll/Utils/ToolboxUtils.cpp
@@ -34,12 +34,11 @@
 #include <Timer.h>
 
 namespace {
-    
-    typedef UUID* (__cdecl* PortalGetUserId_pt)();
+    typedef UUID* (__cdecl*PortalGetUserId_pt)();
     PortalGetUserId_pt PortalGetUserId_Func = 0;
 
     GW::Array<GW::AvailableCharacterInfo>* available_chars_ptr = nullptr;
-    
+
     bool IsInfused(const GW::Item* item)
     {
         return item && item->info_string && wcschr(item->info_string, 0xAC9);
@@ -47,7 +46,8 @@ namespace {
 }
 
 namespace GW {
-    void WaitForFrame(const wchar_t* frame_label, OnGotFrame_Callback callback) {
+    void WaitForFrame(const wchar_t* frame_label, OnGotFrame_Callback callback)
+    {
         if (const auto frame = GW::UI::GetFrameByLabel(frame_label)) {
             callback(frame);
         }
@@ -59,14 +59,15 @@ namespace GW {
                     callback(frame);
                     GW::GameThread::Enqueue([callback]() {
                         GW::UI::RemoveCreateUIComponentCallback((GW::HookEntry*)callback);
-                        });
+                    });
                 }
-                },0x4000);
+            }, 0x4000);
         }
     }
 
     namespace Map {
-        bool GetMapWorldMapBounds(GW::AreaInfo* map, ImRect* out) {
+        bool GetMapWorldMapBounds(GW::AreaInfo* map, ImRect* out)
+        {
             if (!map) return false;
             auto bounds = &map->icon_start_x;
             if (*bounds == 0)
@@ -74,16 +75,17 @@ namespace GW {
 
             // NB: Even though area info holds map bounds as uints, the world map uses signed floats anyway - a cast should be fine here.
             *out = {
-                { static_cast<float> (bounds[0]), static_cast<float>(bounds[1]) },
-                { static_cast<float> (bounds[2]), static_cast<float>(bounds[3]) }
+                {static_cast<float>(bounds[0]), static_cast<float>(bounds[1])},
+                {static_cast<float>(bounds[2]), static_cast<float>(bounds[3])}
             };
             return true;
         }
+
         void PingCompass(const GW::GamePos& position)
         {
             constexpr float compass_scale = 96.f;
             GW::GameThread::Enqueue([cpy = position]() {
-                GW::UI::CompassPoint point({ std::lroundf(cpy.x / compass_scale), std::lroundf(cpy.y / compass_scale) });
+                GW::UI::CompassPoint point({std::lroundf(cpy.x / compass_scale), std::lroundf(cpy.y / compass_scale)});
                 GW::UI::UIPacket::kCompassDraw packet = {
                     .player_number = GW::PlayerMgr::GetPlayerNumber(),
                     .session_id = (uint32_t)TIMER_INIT(),
@@ -91,20 +93,26 @@ namespace GW {
                     .points = &point
                 };
                 GW::UI::SendUIMessage(GW::UI::UIMessage::kCompassDraw, &packet);
-                });
+            });
         }
-        GW::Array<GW::MapProp*>* GetMapProps() {
+
+        GW::Array<GW::MapProp*>* GetMapProps()
+        {
             const auto m = GetMapContext();
             const auto p = m ? m->props : nullptr;
             return p ? &p->propArray : nullptr;
         }
     }
+
     namespace PartyMgr {
-        GW::PlayerPartyMemberArray* GetPartyPlayers(uint32_t party_id) {
+        GW::PlayerPartyMemberArray* GetPartyPlayers(uint32_t party_id)
+        {
             const auto party = GW::PartyMgr::GetPartyInfo(party_id);
             return party ? &party->players : nullptr;
         }
-        size_t GetPlayerPartyIndex(uint32_t player_number, uint32_t party_id) {
+
+        size_t GetPlayerPartyIndex(uint32_t player_number, uint32_t party_id)
+        {
             const auto players = GetPartyPlayers(party_id);
             if (!players) return 0;
             for (size_t i = 0, size = players->size(); i < size; i++) {
@@ -113,8 +121,9 @@ namespace GW {
             }
             return 0;
         }
-        
-        uint32_t GetPartyMemberAgentId(uint32_t party_member_index, uint32_t party_id) {
+
+        uint32_t GetPartyMemberAgentId(uint32_t party_member_index, uint32_t party_id)
+        {
             uint32_t current_idx = (uint32_t)-1;
             const auto party = GW::PartyMgr::GetPartyInfo(party_id);
             if (!party) return 0;
@@ -142,8 +151,10 @@ namespace GW {
             return 0;
         }
     }
+
     namespace AccountMgr {
-        GW::Array<AvailableCharacterInfo>* GetAvailableChars() {
+        GW::Array<AvailableCharacterInfo>* GetAvailableChars()
+        {
             if (available_chars_ptr)
                 return available_chars_ptr;
             const uintptr_t address = GW::Scanner::Find("\x8b\x35\x00\x00\x00\x00\x57\x69\xF8\x84\x00\x00\x00", "xx????xxxxxxx", 0x2);
@@ -151,16 +162,19 @@ namespace GW {
             available_chars_ptr = *(GW::Array<AvailableCharacterInfo>**)address;
             return available_chars_ptr;
         }
+
         const wchar_t* GetCurrentPlayerName()
         {
             const auto c = GetCharContext();
             return c ? c->player_name : nullptr;
         }
+
         const wchar_t* GetAccountEmail()
         {
             const auto c = GetCharContext();
             return c ? c->player_email : nullptr;
         }
+
         const UUID* GetPortalAccountUuid()
         {
             if (!PortalGetUserId_Func) {
@@ -169,7 +183,9 @@ namespace GW {
             }
             return PortalGetUserId_Func ? PortalGetUserId_Func() : nullptr;
         }
-        AvailableCharacterInfo* GetAvailableCharacter(const wchar_t* name) {
+
+        AvailableCharacterInfo* GetAvailableCharacter(const wchar_t* name)
+        {
             const auto characters = name ? GetAvailableChars() : nullptr;
             if (!characters)
                 return nullptr;
@@ -182,7 +198,8 @@ namespace GW {
     }
 
     namespace MemoryMgr {
-        bool GetPersonalDir(std::wstring& out) {
+        bool GetPersonalDir(std::wstring& out)
+        {
             out.resize(512, 0);
             if (!GetPersonalDir(out.capacity(), out.data()))
                 return false;
@@ -190,16 +207,20 @@ namespace GW {
             return !out.empty();
         }
     }
+
     namespace UI {
-        void AsyncDecodeStr(const wchar_t* enc_str, std::wstring* out, GW::Constants::Language language_id) {
+        void AsyncDecodeStr(const wchar_t* enc_str, std::wstring* out, GW::Constants::Language language_id)
+        {
             out->clear();
             AsyncDecodeStr(enc_str, [](void* param, const wchar_t* s) {
                 *(std::wstring*)param = s;
-                }, out, language_id);
+            }, out, language_id);
         }
     }
+
     namespace Agents {
-        void AsyncGetAgentName(const Agent* agent, std::wstring& out) {
+        void AsyncGetAgentName(const Agent* agent, std::wstring& out)
+        {
             UI::AsyncDecodeStr(GetAgentEncName(agent), &out);
         }
     }
@@ -217,17 +238,19 @@ namespace ToolboxUtils {
         const auto res = (array[real_index] & flag);
         return res != 0;
     }
-    uint8_t GetMissionState(GW::Constants::MapID map_id, const GW::Array<uint32_t>& missions_completed, const GW::Array<uint32_t>& missions_bonus) {
+
+    uint8_t GetMissionState(GW::Constants::MapID map_id, const GW::Array<uint32_t>& missions_completed, const GW::Array<uint32_t>& missions_bonus)
+    {
         const auto area_info = GW::Map::GetMapInfo(map_id);
         if (!area_info)
             return 0;
         switch (area_info->type) {
-        case GW::RegionType::CooperativeMission:
-        case GW::RegionType::MissionOutpost:
-        case GW::RegionType::Dungeon:
-            break;
-        default:
-            return 0;
+            case GW::RegionType::CooperativeMission:
+            case GW::RegionType::MissionOutpost:
+            case GW::RegionType::Dungeon:
+                break;
+            default:
+                return 0;
         }
         uint8_t state_out = 0;
         auto complete = ArrayBoolAt(missions_completed, (uint32_t)map_id);
@@ -238,24 +261,26 @@ namespace ToolboxUtils {
         auto master = false;
 
         switch (area_info->campaign) {
-        case GW::Constants::Campaign::Factions:
-        case GW::Constants::Campaign::Nightfall:
-            // Master = bonus, Expert = complete, Primary = any
-            master = bonus;
-            expert = complete;
-            primary = master || expert;
-            break;
+            case GW::Constants::Campaign::Factions:
+            case GW::Constants::Campaign::Nightfall:
+                // Master = bonus, Expert = complete, Primary = any
+                master = bonus;
+                expert = complete;
+                primary = master || expert;
+                break;
         }
 
-        if(primary)
+        if (primary)
             state_out |= MissionState::Primary;
-        if(expert)
+        if (expert)
             state_out |= MissionState::Expert;
-        if(master)
+        if (master)
             state_out |= MissionState::Master;
         return state_out;
     }
-    uint8_t GetMissionState(GW::Constants::MapID map_id, bool is_hard_mode) {
+
+    uint8_t GetMissionState(GW::Constants::MapID map_id, bool is_hard_mode)
+    {
         const auto w = GW::GetWorldContext();
         const GW::Array<uint32_t>* missions_completed = &w->missions_completed;
         const GW::Array<uint32_t>* missions_bonus = &w->missions_bonus;
@@ -265,7 +290,9 @@ namespace ToolboxUtils {
         }
         return GetMissionState(map_id, *missions_completed, *missions_bonus);
     }
-    uint8_t GetMissionState() {
+
+    uint8_t GetMissionState()
+    {
         return GetMissionState(GW::Map::GetMapID(), GW::PartyMgr::GetIsPartyInHardMode());
     }
 
@@ -574,7 +601,6 @@ namespace ToolboxUtils {
     std::wstring ShorthandItemDescription(GW::Item* item)
     {
         std::wstring original(item->info_string);
-        std::wsmatch m;
         wchar_t buffer[128];
 
         // For armor items, include full item name and a few description bits.
@@ -585,17 +611,21 @@ namespace ToolboxUtils {
             case GW::Constants::ItemType::Gloves:
             case GW::Constants::ItemType::Leggings: {
                 original = item->complete_name_enc;
-                const std::wstring item_str(item->info_string);
-                const std::wregex stacking_att(L"\x2.\x10A\xA84\x10A(.{1,2})\x1\x101\x101\x1\x2\xA3E\x10A\xAA8\x10A\xAB1\x1\x1");
-                if (std::regex_search(item_str, m, stacking_att)) {
-                    swprintf(buffer, _countof(buffer), L"\x2\xAA8\x10A\xA84\x10A%s\x1\x101\x101\x1", m[1].str().c_str());
+                const std::wstring_view item_str(item->info_string);
+
+                auto stacking_match = ctre::match<L"\x2.\x10A\xA84\x10A(.{1,2})\x1\x101\x101\x1\x2\xA3E\x10A\xAA8\x10A\xAB1\x1\x1">(item_str);
+                if (stacking_match) {
+                    auto capture = stacking_match.get<1>().to_view();
+                    swprintf(buffer, _countof(buffer), L"\x2\xAA8\x10A\xA84\x10A%ls\x1\x101\x101\x1", capture.data());
                     original += buffer;
                 }
-                const std::wregex armor_rating(L"\xA3B\x10A\xA86\x10A\xA44\x1\x101(.)\x1\x2");
-                if (std::regex_search(item_str, m, armor_rating)) {
-                    swprintf(buffer, _countof(buffer), L"\x2\x102\x2\xA86\x10A\xA44\x1\x101%s", m[1].str().c_str());
+
+                if (auto armor_match = ctre::match<L"\xA3B\x10A\xA86\x10A\xA44\x1\x101(.)\x1\x2">(item_str)) {
+                    auto capture = armor_match.get<1>().to_view();
+                    swprintf(buffer, _countof(buffer), L"\x2\x102\x2\xA86\x10A\xA44\x1\x101%ls", capture.data());
                     original += buffer;
                 }
+
                 if (IsInfused(item)) {
                     original += L"\x2\x102\x2\xAC9";
                 }
@@ -606,210 +636,194 @@ namespace ToolboxUtils {
         }
 
         // Replace "Requires 9 Divine Favor" > "q9 Divine Favor"
-        static const std::wregex regexp_req(L".\x10A\x0AA8\x10A\xAA9\x10A.\x1\x101.\x1\x1");
-        while (std::regex_search(original, m, regexp_req)) {
-            for (auto& match : m) {
-                const std::wstring found = match.str();
+        original = TextUtils::ctre_regex_replace_with_formatter<L".\x10A\x0AA8\x10A\xAA9\x10A.\x1\x101.\x1\x1">(
+            original,
+            [&buffer](auto& match) -> std::wstring {
+                auto found = match.get<0>().to_view();
                 swprintf(buffer, _countof(buffer), L"\x108\x107, q%d \x1\x2%c", found.at(9) - 0x100, found.at(6));
-                original = std::regex_replace(original, std::wregex(found), buffer);
-            }
-        }
+                return buffer;
+            });
+
         // Replace "Requires 9 Scythe Mastery" > "q9 Scythe Mastery"
-        static const std::wregex regexp_req2(L".\x10A\xAA8\x10A\xAA9\x10A\x8101.\x1\x101.\x1\x1");
-        while (std::regex_search(original, m, regexp_req2)) {
-            for (auto& match : m) {
-                const std::wstring found = match.str();
+        original = TextUtils::ctre_regex_replace_with_formatter<L".\x10A\xAA8\x10A\xAA9\x10A\x8101.\x1\x101.\x1\x1">(
+            original,
+            [&buffer](auto& match) -> std::wstring {
+                auto found = match.get<0>().to_view();
                 swprintf(buffer, _countof(buffer), L"\x108\x107, q%d \x1\x2\x8101%c", found.at(10) - 0x100, found.at(7));
-                original = std::regex_replace(original, std::wregex(found), buffer);
-            }
-        }
+                return buffer;
+            });
 
         // "vs. Earth damage" > "Earth"
-        // "vs. Demons" > "Demons"
-        static const std::wregex vs_damage(L"[\xAAC\xAAF]\x10A.\x1");
-        while (std::regex_search(original, m, vs_damage)) {
-            for (auto& match : m) {
-                const std::wstring found = match.str();
+        original = TextUtils::ctre_regex_replace_with_formatter<L"[\xAAC\xAAF]\x10A.\x1">(
+            original,
+            [&buffer](auto& match) -> std::wstring {
+                auto found = match.get<0>().to_view();
                 swprintf(buffer, _countof(buffer), L"%c", found.at(2));
-                original = std::regex_replace(original, std::wregex(found), buffer);
-            }
-        }
+                return buffer;
+            });
 
         // Replace "Lengthens ??? duration on foes by 33%" > "??? duration +33%"
-        static const std::wregex regexp_lengthens_duration(L"\xAA4\x10A.\x1");
-        while (std::regex_search(original, m, regexp_lengthens_duration)) {
-            for (auto& match : m) {
-                const std::wstring found = match.str();
+        original = TextUtils::ctre_regex_replace_with_formatter<L"\xAA4\x10A.\x1">(
+            original,
+            [&buffer](auto& match) -> std::wstring {
+                auto found = match.get<0>().to_view();
                 swprintf(buffer, _countof(buffer), L"%c\x2\x108\x107 +33%%\x1", found.at(2));
-                original = std::regex_replace(original, std::wregex(found), buffer);
-            }
-        }
+                return buffer;
+            });
 
         // Replace "Reduces ??? duration on you by 20%" > "??? duration -20%"
-        static const std::wregex regexp_reduces_duration(L"\xAA7\x10A.\x1");
-        while (std::regex_search(original, m, regexp_reduces_duration)) {
-            for (auto& match : m) {
-                const std::wstring found = match.str();
+        original = TextUtils::ctre_regex_replace_with_formatter<L"\xAA7\x10A.\x1">(
+            original,
+            [&buffer](auto& match) -> std::wstring {
+                auto found = match.get<0>().to_view();
                 swprintf(buffer, _countof(buffer), L"%c\x2\x108\x107 -20%%\x1", found.at(2));
-                original = std::regex_replace(original, std::wregex(found), buffer);
-            }
-        }
+                return buffer;
+            });
 
-        // Change "Damage 15% (while Health is above 50%)" to "Damage +15^50"
-        //std::wregex damage_15_over_50(L".\x010A\xA85\x010A\xA4C\x1\x101.\x1\x2" L".\x010A\xAA8\x010A\xABC\x10A\xA52\x1\x101.\x1\x1");
         // Change " (while Health is above n)" to "^n";
-        static const std::wregex n_over_n(L"\xAA8\x10A\xABC\x10A\xA52\x1\x101.\x1");
-        while (std::regex_search(original, m, n_over_n)) {
-            for (auto& match : m) {
-                std::wstring found = match.str();
+        original = TextUtils::ctre_regex_replace_with_formatter<L"\xAA8\x10A\xABC\x10A\xA52\x1\x101.\x1">(
+            original,
+            [&buffer](auto& match) -> std::wstring {
+                auto found = match.get<0>().to_view();
                 swprintf(buffer, _countof(buffer), L"\x108\x107^%d\x1", found.at(7) - 0x100);
-                original = std::regex_replace(original, std::wregex(found), buffer);
-            }
-        }
+                return buffer;
+            });
 
         // Change "Enchantments last 20% longer" to "Ench +20%"
-        static const std::wregex enchantments(L"\xAA2\x101.");
-        while (std::regex_search(original, m, enchantments)) {
-            for (auto& match : m) {
-                std::wstring found = match.str();
+        original = TextUtils::ctre_regex_replace_with_formatter<L"\xAA2\x101.">(
+            original,
+            [&buffer](auto& match) -> std::wstring {
+                auto found = match.get<0>().to_view();
                 swprintf(buffer, _countof(buffer), L"\x108\x107" L"Enchantments +%d%%\x1", found.at(2) - 0x100);
-                original = std::regex_replace(original, std::wregex(found), buffer);
-            }
-        }
+                return buffer;
+            });
 
         // "(Chance: 18%)" > "(18%)"
-        static const std::wregex chance_regex(L"\xA87\x10A\xA48\x1\x101.");
-        while (std::regex_search(original, m, chance_regex)) {
-            for (auto& match : m) {
-                std::wstring found = match.str();
+        original = TextUtils::ctre_regex_replace_with_formatter<L"\xA87\x10A\xA48\x1\x101.">(
+            original,
+            [&buffer](auto& match) -> std::wstring {
+                auto found = match.get<0>().to_view();
                 swprintf(buffer, _countof(buffer), L"\x108\x107%d%%\x1", found.at(5) - 0x100);
-                original = std::regex_replace(original, std::wregex(found), buffer);
-            }
-        }
+                return buffer;
+            });
+
         // Change "Halves skill recharge of <attribute> spells" > "HSR <attribute>"
-        static const std::wregex hsr_attribute(L"\xA81\x10A\xA58\x1\x10B.\x1");
-        while (std::regex_search(original, m, hsr_attribute)) {
-            for (auto& match : m) {
-                std::wstring found = match.str();
+        original = TextUtils::ctre_regex_replace_with_formatter<L"\xA81\x10A\xA58\x1\x10B.\x1">(
+            original,
+            [&buffer](auto& match) -> std::wstring {
+                auto found = match.get<0>().to_view();
                 swprintf(buffer, _countof(buffer), L"\x108\x107" L"HSR \x1\x2%c", found.at(5));
-                original = std::regex_replace(original, std::wregex(found), buffer);
-            }
-        }
+                return buffer;
+            });
+
         // Change "Inscription: "Blah Blah"" to just "Blah Blah"
-        static const std::wregex inscription(L"\x8101\x5DC5\x10A..\x1");
-        while (std::regex_search(original, m, inscription)) {
-            for (auto& match : m) {
-                std::wstring found = match.str();
+        original = TextUtils::ctre_regex_replace_with_formatter<L"\x8101\x5DC5\x10A..\x1">(
+            original,
+            [&buffer](auto& match) -> std::wstring {
+                auto found = match.get<0>().to_view();
                 swprintf(buffer, _countof(buffer), L"%c%c", found.at(3), found.at(4));
-                original = std::regex_replace(original, std::wregex(found), buffer);
-            }
-        }
+                return buffer;
+            });
 
         // Change "Halves casting time of <attribute> spells" > "HCT <attribute>"
-        static const std::wregex hct_attribute(L"\xA81\x10A\xA47\x1\x10B.\x1");
-        while (std::regex_search(original, m, hct_attribute)) {
-            for (auto& match : m) {
-                std::wstring found = match.str();
+        original = TextUtils::ctre_regex_replace_with_formatter<L"\xA81\x10A\xA47\x1\x10B.\x1">(
+            original,
+            [&buffer](auto& match) -> std::wstring {
+                auto found = match.get<0>().to_view();
                 swprintf(buffer, _countof(buffer), L"\x108\x107" L"HCT \x1\x2%c", found.at(5));
-                original = std::regex_replace(original, std::wregex(found), buffer);
-            }
-        }
+                return buffer;
+            });
 
         // Change "Piercing Dmg: 11-22" > "Piercing: 11-22"
-        static const std::wregex weapon_dmg(L"\xA89\x10A\xA4E\x1\x10B.\x1\x101.\x102.");
-        while (std::regex_search(original, m, weapon_dmg)) {
-            for (auto& match : m) {
-                std::wstring found = match.str();
+        original = TextUtils::ctre_regex_replace_with_formatter<L"\xA89\x10A\xA4E\x1\x10B.\x1\x101.\x102.">(
+            original,
+            [&buffer](auto& match) -> std::wstring {
+                auto found = match.get<0>().to_view();
                 swprintf(buffer, _countof(buffer), L"%c\x2\x108\x107: %d-%d\x1", found.at(5), found.at(8) - 0x100, found.at(10) - 0x100);
-                original = std::regex_replace(original, std::wregex(found), buffer);
-            }
-        }
+                return buffer;
+            });
 
         // Change "Life draining -3, Health regeneration -1" > "Vampiric" (add at end of description)
-        static const std::wregex vampiric(L"\x2\x102\x2.\x10A\xA86\x10A\xA54\x1\x101.\x1" L"\x2\x102\x2.\x10A\xA7E\x10A\xA53\x1\x101.\x1");
-        if (std::regex_search(original, vampiric)) {
-            original = std::regex_replace(original, vampiric, L"");
-            original += L"\x2\x102\x2\x108\x107" L"Vampiric\x1";
+        if (ctre::match<L"\x2\x102\x2.\x10A\xA86\x10A\xA54\x1\x101.\x1\x2\x102\x2.\x10A\xA7E\x10A\xA53\x1\x101.\x1">(original)) {
+            original = TextUtils::ctre_regex_replace_w<L"\x2\x102\x2.\x10A\xA86\x10A\xA54\x1\x101.\x1\x2\x102\x2.\x10A\xA7E\x10A\xA53\x1\x101.\x1">(original, L"");
+            original += L"\x2\x102\x2\x108\x107Vampiric\x1";
         }
+
         // Change "Energy gain on hit 1, Energy regeneration -1" > "Zealous" (add at end of description)
-        static const std::wregex zealous(L"\x2\x102\x2.\x10A\xA86\x10A\xA50\x1\x101.\x1" L"\x2\x102\x2.\x10A\xA7E\x10A\xA51\x1\x101.\x1");
-        if (std::regex_search(original, zealous)) {
-            original = std::regex_replace(original, zealous, L"");
-            original += L"\x2\x102\x2\x108\x107" L"Zealous\x1";
+        if (ctre::match<L"\x2\x102\x2.\x10A\xA86\x10A\xA50\x1\x101.\x1\x2\x102\x2.\x10A\xA7E\x10A\xA51\x1\x101.\x1">(original)) {
+            original = TextUtils::ctre_regex_replace_w<L"\x2\x102\x2.\x10A\xA86\x10A\xA50\x1\x101.\x1\x2\x102\x2.\x10A\xA7E\x10A\xA51\x1\x101.\x1">(original, L"");
+            original += L"\x2\x102\x2\x108\x107Zealous\x1";
         }
 
         // Change "Damage" > "Dmg"
-        original = std::regex_replace(original, std::wregex(L"\xA4C"), L"\xA4E");
+        original = TextUtils::ctre_regex_replace_w<L"\xA4C">(original, L"\xA4E");
 
         // Change Bow "Two-Handed" > ""
-        original = std::regex_replace(original, std::wregex(L"\x8102\x1227"), L"\xA3E");
+        original = TextUtils::ctre_regex_replace_w<L"\x8102\x1227">(original, L"\xA3E");
 
         // Change "Halves casting time of spells" > "HCT"
-        original = std::regex_replace(original, std::wregex(L"\xA80\x10A\xA47\x1"), L"\x108\x107" L"HCT\x1");
+        original = TextUtils::ctre_regex_replace_w<L"\xA80\x10A\xA47\x1">(original, L"\x108\x107HCT\x1");
 
         // Change "Halves skill recharge of spells" > "HSR"
-        static const std::wregex half_skill_recharge(L"\xA80\x10A\xA58\x1");
-        original = std::regex_replace(original, half_skill_recharge, L"\x108\x107" L"HSR\x1");
+        original = TextUtils::ctre_regex_replace_w<L"\xA80\x10A\xA58\x1">(original, L"\x108\x107HSR\x1");
 
         // Remove (Stacking) and (Non-stacking) rubbish
-        static const std::wregex stacking_non_stacking(L"\x2.\x10A\xAA8\x10A[\xAB1\xAB2]\x1\x1");
-        original = std::regex_replace(original, stacking_non_stacking, L"");
+        original = TextUtils::ctre_regex_replace_w<L"\x2.\x10A\xAA8\x10A[\xAB1\xAB2]\x1\x1">(original, L"");
 
         // Replace (while affected by a(n) to just (n)
-        const std::wregex while_affected_by(L"\x8101\x4D9C\x10A.\x1");
-        while (std::regex_search(original, m, while_affected_by)) {
-            for (auto& match : m) {
-                const std::wstring found = match.str();
-                wmemset(buffer, 0, 2);
-                buffer[0] = found.at(3);
-                original = std::regex_replace(original, std::wregex(found), buffer);
-            }
-        }
+        original = TextUtils::ctre_regex_replace_with_formatter<L"\x8101\x4D9C\x10A.\x1">(
+            original,
+            [](auto& match) -> std::wstring {
+                auto found = match.get<0>().to_view();
+                return std::wstring(1, found.at(3));
+            });
+
         // Replace (while xxx) to just (xxx)
-        original = std::regex_replace(original, std::wregex(L"\xAB4"), L"\x108\x107" L"Attacking\x1");
-        original = std::regex_replace(original, std::wregex(L"\xAB5"), L"\x108\x107" L"Casting\x1");
-        original = std::regex_replace(original, std::wregex(L"\xAB6"), L"\x108\x107" L"Condition\x1");
-        original = std::regex_replace(original, std::wregex(L"[\xAB7\x4B6]"), L"\x108\x107" L"Enchanted\x1");
-        original = std::regex_replace(original, std::wregex(L"[\xAB8\x4B4]"), L"\x108\x107" L"Hexed\x1");
-        original = std::regex_replace(original, std::wregex(L"[\xAB9\xABA]"), L"\x108\x107" L"Stance\x1");
+        original = TextUtils::ctre_regex_replace_w<L"\xAB4">(original, L"\x108\x107" L"Attacking\x1");
+        original = TextUtils::ctre_regex_replace_w<L"\xAB5">(original, L"\x108\x107" L"Casting\x1");
+        original = TextUtils::ctre_regex_replace_w<L"\xAB6">(original, L"\x108\x107" L"Condition\x1");
+        original = TextUtils::ctre_regex_replace_w<L"[\xAB7\x4B6]">(original, L"\x108\x107" L"Enchanted\x1");
+        original = TextUtils::ctre_regex_replace_w<L"[\xAB8\x4B4]">(original, L"\x108\x107" L"Hexed\x1");
+        original = TextUtils::ctre_regex_replace_w<L"[\xAB9\xABA]">(original, L"\x108\x107" L"Stance\x1");
 
         // Combine Attribute + 3, Attribute + 1 to Attribute +3 +1 (e.g. headpiece)
-        static const std::wregex attribute_stacks(L".\x10A\xA84\x10A.\x1\x101.\x1\x2\x102\x2.\x10A\xA84\x10A.\x1\x101.\x1");
-        if (std::regex_search(original, m, attribute_stacks)) {
-            for (auto& match : m) {
-                const std::wstring found = match.str();
+        original = TextUtils::ctre_regex_replace_with_formatter<L".\x10A\xA84\x10A.\x1\x101.\x1\x2\x102\x2.\x10A\xA84\x10A.\x1\x101.\x1">(
+            original,
+            [&buffer](auto& match) -> std::wstring {
+                auto found = match.get<0>().to_view();
                 if (found[4] != found[16]) {
-                    continue; // Different attributes.
+                    return std::wstring(found); // Different attributes, return unchanged
                 }
                 swprintf(buffer, _countof(buffer), L"%c\x10A\xA84\x10A%c\x1\x101%c\x2\xA84\x101%c\x1",
                          found[0], found[4], found[7], found[19]);
-                original = std::regex_replace(original, std::wregex(found), buffer);
-            }
-        }
+                return buffer;
+            });
+
         // Remove "Value: 122 gold"
-        original = std::regex_replace(original, std::wregex(L"\x2\x102\x2\xA3E\x10A\xA8A\x10A\xA59\x1\x10B.\x101.(\x102.)?\x1\x1"), L"");
+        original = TextUtils::ctre_regex_replace_w<L"\x2\x102\x2\xA3E\x10A\xA8A\x10A\xA59\x1\x10B.\x101.(\x102.)?\x1\x1">(original, L"");
 
         // Remove other "greyed" generic terms e.g. "Two-Handed", "Unidentified"
-        original = std::regex_replace(original, std::wregex(L"\x2\x102\x2\xA3E\x10A.\x1"), L"");
+        original = TextUtils::ctre_regex_replace_w<L"\x2\x102\x2\xA3E\x10A.\x1">(original, L"");
 
         // Remove "Necromancer Munne sometimes gives these to me in trade" etc
-        original = std::regex_replace(original, std::wregex(L"\x2\x102\x2.\x10A\x8102.\x1"), L"");
+        original = TextUtils::ctre_regex_replace_w<L"\x2\x102\x2.\x10A\x8102.\x1">(original, L"");
 
         // Remove "Inscription: None"
-        original = std::regex_replace(original, std::wregex(L"\x2\x102\x2.\x10A\x8101\x5A1F\x1"), L"");
+        original = TextUtils::ctre_regex_replace_w<L"\x2\x102\x2.\x10A\x8101\x5A1F\x1">(original, L"");
 
         // Remove "Crafted in tribute to an enduring legend." etc
-        original = std::regex_replace(original, std::wregex(L"\x2\x102\x2.\x10A\x8103.\x1"), L"");
+        original = TextUtils::ctre_regex_replace_w<L"\x2\x102\x2.\x10A\x8103.\x1">(original, L"");
 
         // Remove "20% Additional damage during festival events" > "Dmg +20% (Festival)"
-        original = std::regex_replace(original, std::wregex(L".\x10A\x108\x10A\x8103\xB71\x101\x100\x1\x1"), L"\xA85\x10A\xA4E\x1\x101\x114\x2\xAA8\x10A\x108\x107" L"Festival\x1\x1");
+        original = TextUtils::ctre_regex_replace_w<L".\x10A\x108\x10A\x8103\xB71\x101\x100\x1\x1">(
+            original, L"\xA85\x10A\xA4E\x1\x101\x114\x2\xAA8\x10A\x108\x107" L"Festival\x1\x1");
 
-        static const std::wregex dmg_plus_20(L"\x2\x102\x2.\x10A\xA85\x10A[\xA4C\xA4E]\x1\x101\x114\x1");
-        if (item->customized && std::regex_search(original, dmg_plus_20)) {
+        // Check for customized item with +20% damage
+        if (item->customized && ctre::match<L"\x2\x102\x2.\x10A\xA85\x10A[\xA4C\xA4E]\x1\x101\x114\x1">(original)) {
             // Remove "\nDamage +20%" > "\n"
-            original = std::regex_replace(original, dmg_plus_20, L"");
+            original = TextUtils::ctre_regex_replace_w<L"\x2\x102\x2.\x10A\xA85\x10A[\xA4C\xA4E]\x1\x101\x114\x1">(original, L"");
             // Append "Customized"
-            original += L"\x2\x102\x2\x108\x107" L"Customized\x1";
+            original += L"\x2\x102\x2\x108\x107Customized\x1";
         }
 
         return original;

--- a/GWToolboxdll/Utils/ToolboxUtils.cpp
+++ b/GWToolboxdll/Utils/ToolboxUtils.cpp
@@ -745,30 +745,30 @@ namespace ToolboxUtils {
 
         // Change "Life draining -3, Health regeneration -1" > "Vampiric" (add at end of description)
         if (ctre::match<L"\x2\x102\x2.\x10A\xA86\x10A\xA54\x1\x101.\x1\x2\x102\x2.\x10A\xA7E\x10A\xA53\x1\x101.\x1">(original)) {
-            original = TextUtils::ctre_regex_replace_w<L"\x2\x102\x2.\x10A\xA86\x10A\xA54\x1\x101.\x1\x2\x102\x2.\x10A\xA7E\x10A\xA53\x1\x101.\x1">(original, L"");
+            original = TextUtils::ctre_regex_replace<L"\x2\x102\x2.\x10A\xA86\x10A\xA54\x1\x101.\x1\x2\x102\x2.\x10A\xA7E\x10A\xA53\x1\x101.\x1">(original, L"");
             original += L"\x2\x102\x2\x108\x107Vampiric\x1";
         }
 
         // Change "Energy gain on hit 1, Energy regeneration -1" > "Zealous" (add at end of description)
         if (ctre::match<L"\x2\x102\x2.\x10A\xA86\x10A\xA50\x1\x101.\x1\x2\x102\x2.\x10A\xA7E\x10A\xA51\x1\x101.\x1">(original)) {
-            original = TextUtils::ctre_regex_replace_w<L"\x2\x102\x2.\x10A\xA86\x10A\xA50\x1\x101.\x1\x2\x102\x2.\x10A\xA7E\x10A\xA51\x1\x101.\x1">(original, L"");
+            original = TextUtils::ctre_regex_replace<L"\x2\x102\x2.\x10A\xA86\x10A\xA50\x1\x101.\x1\x2\x102\x2.\x10A\xA7E\x10A\xA51\x1\x101.\x1">(original, L"");
             original += L"\x2\x102\x2\x108\x107Zealous\x1";
         }
 
         // Change "Damage" > "Dmg"
-        original = TextUtils::ctre_regex_replace_w<L"\xA4C">(original, L"\xA4E");
+        original = TextUtils::ctre_regex_replace<L"\xA4C">(original, L"\xA4E");
 
         // Change Bow "Two-Handed" > ""
-        original = TextUtils::ctre_regex_replace_w<L"\x8102\x1227">(original, L"\xA3E");
+        original = TextUtils::ctre_regex_replace<L"\x8102\x1227">(original, L"\xA3E");
 
         // Change "Halves casting time of spells" > "HCT"
-        original = TextUtils::ctre_regex_replace_w<L"\xA80\x10A\xA47\x1">(original, L"\x108\x107HCT\x1");
+        original = TextUtils::ctre_regex_replace<L"\xA80\x10A\xA47\x1">(original, L"\x108\x107HCT\x1");
 
         // Change "Halves skill recharge of spells" > "HSR"
-        original = TextUtils::ctre_regex_replace_w<L"\xA80\x10A\xA58\x1">(original, L"\x108\x107HSR\x1");
+        original = TextUtils::ctre_regex_replace<L"\xA80\x10A\xA58\x1">(original, L"\x108\x107HSR\x1");
 
         // Remove (Stacking) and (Non-stacking) rubbish
-        original = TextUtils::ctre_regex_replace_w<L"\x2.\x10A\xAA8\x10A[\xAB1\xAB2]\x1\x1">(original, L"");
+        original = TextUtils::ctre_regex_replace<L"\x2.\x10A\xAA8\x10A[\xAB1\xAB2]\x1\x1">(original, L"");
 
         // Replace (while affected by a(n) to just (n)
         original = TextUtils::ctre_regex_replace_with_formatter<L"\x8101\x4D9C\x10A.\x1">(
@@ -779,12 +779,12 @@ namespace ToolboxUtils {
             });
 
         // Replace (while xxx) to just (xxx)
-        original = TextUtils::ctre_regex_replace_w<L"\xAB4">(original, L"\x108\x107" L"Attacking\x1");
-        original = TextUtils::ctre_regex_replace_w<L"\xAB5">(original, L"\x108\x107" L"Casting\x1");
-        original = TextUtils::ctre_regex_replace_w<L"\xAB6">(original, L"\x108\x107" L"Condition\x1");
-        original = TextUtils::ctre_regex_replace_w<L"[\xAB7\x4B6]">(original, L"\x108\x107" L"Enchanted\x1");
-        original = TextUtils::ctre_regex_replace_w<L"[\xAB8\x4B4]">(original, L"\x108\x107" L"Hexed\x1");
-        original = TextUtils::ctre_regex_replace_w<L"[\xAB9\xABA]">(original, L"\x108\x107" L"Stance\x1");
+        original = TextUtils::ctre_regex_replace<L"\xAB4">(original, L"\x108\x107" L"Attacking\x1");
+        original = TextUtils::ctre_regex_replace<L"\xAB5">(original, L"\x108\x107" L"Casting\x1");
+        original = TextUtils::ctre_regex_replace<L"\xAB6">(original, L"\x108\x107" L"Condition\x1");
+        original = TextUtils::ctre_regex_replace<L"[\xAB7\x4B6]">(original, L"\x108\x107" L"Enchanted\x1");
+        original = TextUtils::ctre_regex_replace<L"[\xAB8\x4B4]">(original, L"\x108\x107" L"Hexed\x1");
+        original = TextUtils::ctre_regex_replace<L"[\xAB9\xABA]">(original, L"\x108\x107" L"Stance\x1");
 
         // Combine Attribute + 3, Attribute + 1 to Attribute +3 +1 (e.g. headpiece)
         original = TextUtils::ctre_regex_replace_with_formatter<L".\x10A\xA84\x10A.\x1\x101.\x1\x2\x102\x2.\x10A\xA84\x10A.\x1\x101.\x1">(
@@ -800,28 +800,28 @@ namespace ToolboxUtils {
             });
 
         // Remove "Value: 122 gold"
-        original = TextUtils::ctre_regex_replace_w<L"\x2\x102\x2\xA3E\x10A\xA8A\x10A\xA59\x1\x10B.\x101.(\x102.)?\x1\x1">(original, L"");
+        original = TextUtils::ctre_regex_replace<L"\x2\x102\x2\xA3E\x10A\xA8A\x10A\xA59\x1\x10B.\x101.(\x102.)?\x1\x1">(original, L"");
 
         // Remove other "greyed" generic terms e.g. "Two-Handed", "Unidentified"
-        original = TextUtils::ctre_regex_replace_w<L"\x2\x102\x2\xA3E\x10A.\x1">(original, L"");
+        original = TextUtils::ctre_regex_replace<L"\x2\x102\x2\xA3E\x10A.\x1">(original, L"");
 
         // Remove "Necromancer Munne sometimes gives these to me in trade" etc
-        original = TextUtils::ctre_regex_replace_w<L"\x2\x102\x2.\x10A\x8102.\x1">(original, L"");
+        original = TextUtils::ctre_regex_replace<L"\x2\x102\x2.\x10A\x8102.\x1">(original, L"");
 
         // Remove "Inscription: None"
-        original = TextUtils::ctre_regex_replace_w<L"\x2\x102\x2.\x10A\x8101\x5A1F\x1">(original, L"");
+        original = TextUtils::ctre_regex_replace<L"\x2\x102\x2.\x10A\x8101\x5A1F\x1">(original, L"");
 
         // Remove "Crafted in tribute to an enduring legend." etc
-        original = TextUtils::ctre_regex_replace_w<L"\x2\x102\x2.\x10A\x8103.\x1">(original, L"");
+        original = TextUtils::ctre_regex_replace<L"\x2\x102\x2.\x10A\x8103.\x1">(original, L"");
 
         // Remove "20% Additional damage during festival events" > "Dmg +20% (Festival)"
-        original = TextUtils::ctre_regex_replace_w<L".\x10A\x108\x10A\x8103\xB71\x101\x100\x1\x1">(
+        original = TextUtils::ctre_regex_replace<L".\x10A\x108\x10A\x8103\xB71\x101\x100\x1\x1">(
             original, L"\xA85\x10A\xA4E\x1\x101\x114\x2\xAA8\x10A\x108\x107" L"Festival\x1\x1");
 
         // Check for customized item with +20% damage
         if (item->customized && ctre::match<L"\x2\x102\x2.\x10A\xA85\x10A[\xA4C\xA4E]\x1\x101\x114\x1">(original)) {
             // Remove "\nDamage +20%" > "\n"
-            original = TextUtils::ctre_regex_replace_w<L"\x2\x102\x2.\x10A\xA85\x10A[\xA4C\xA4E]\x1\x101\x114\x1">(original, L"");
+            original = TextUtils::ctre_regex_replace<L"\x2\x102\x2.\x10A\xA85\x10A[\xA4C\xA4E]\x1\x101\x114\x1">(original, L"");
             // Append "Customized"
             original += L"\x2\x102\x2\x108\x107Customized\x1";
         }

--- a/GWToolboxdll/Windows/ObserverExportWindow.cpp
+++ b/GWToolboxdll/Windows/ObserverExportWindow.cpp
@@ -450,7 +450,7 @@ void ObserverExportWindow::ExportToJSON(Version version)
                 return static_cast<unsigned char>(c == ' ' ? '_' : c);
             });
             // replace non-alphanumeric with "x" to make simply FS safe, but also show something is missing
-            name = std::regex_replace(name, std::regex("[^A-Za-z0-9.-_]/g"), "x");
+            name = TextUtils::ctre_regex_replace<"[^A-Za-z0-9.-_]/g">(name, "x");
             filename = export_time + "_" + name + ".json";
             json["filename"] = filename;
             break;

--- a/GWToolboxdll/Windows/ObserverExportWindow.cpp
+++ b/GWToolboxdll/Windows/ObserverExportWindow.cpp
@@ -450,7 +450,7 @@ void ObserverExportWindow::ExportToJSON(Version version)
                 return static_cast<unsigned char>(c == ' ' ? '_' : c);
             });
             // replace non-alphanumeric with "x" to make simply FS safe, but also show something is missing
-            name = TextUtils::ctre_regex_replace<"[^A-Za-z0-9.-_]/g">(name, "x");
+            name = TextUtils::ctre_regex_replace<"[^A-Za-z0-9.-_]/g", "x">(name);
             filename = export_time + "_" + name + ".json";
             json["filename"] = filename;
             break;

--- a/GWToolboxdll/Windows/TargetInfoWindow.cpp
+++ b/GWToolboxdll/Windows/TargetInfoWindow.cpp
@@ -275,12 +275,11 @@ namespace {
                             std::string title_attr = item_match.get<1>().to_string();
                             if (!std::ranges::contains(agent_info->items_dropped, title_attr))
                                 agent_info->items_dropped.push_back(title_attr);
-
                         }
                     }
 
                     static constexpr ctll::fixed_string notes_regex = "<h2><span class=\"mw-headline\" id=\"Notes\">(?:[\\s\\S]*?)<ul([\\s\\S]*?)</ul>";
-                                                if (auto m = ctre::search<notes_regex>(agent_info->wiki_content)) {
+                    if (auto m = ctre::search<notes_regex>(agent_info->wiki_content)) {
                         std::string list_found = m.get<1>().to_string();
 
                         static constexpr ctll::fixed_string list_item_regex = "<li>([\\s\\S]*?)</li>";

--- a/GWToolboxdll/stdafx.h
+++ b/GWToolboxdll/stdafx.h
@@ -72,11 +72,14 @@
 #include <ToolboxIni.h>
 
 #include <nlohmann/json.hpp>
-#include <ctre.hpp>
 #include <easywsclient.hpp>
 #include <mp3.h>
 #include <IconsFontAwesome5.h>
 #include <mapbox/earcut.hpp>
+
+#define __forceinline
+#include <ctre.hpp>
+#undef __forceinline
 
 #include <imgui.h>
 #include <imgui_internal.h>

--- a/GWToolboxdll/stdafx.h
+++ b/GWToolboxdll/stdafx.h
@@ -34,6 +34,7 @@
 #include <memory>
 #include <mutex>
 #include <numbers>
+#include <print>
 #include <queue>
 #include <ranges>
 #include <regex>
@@ -71,6 +72,7 @@
 #include <ToolboxIni.h>
 
 #include <nlohmann/json.hpp>
+#include <ctre.hpp>
 #include <easywsclient.hpp>
 #include <mp3.h>
 #include <IconsFontAwesome5.h>

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -11,7 +11,8 @@
     "minhook",
     "nlohmann-json",
     "simpleini",
-    "wolfssl"
+    "wolfssl",
+    "ctre"
   ],
   "overrides": [
     {


### PR DESCRIPTION
can't replace all usage of std::regex because ctre only works for regexes known at compile time

I also wasn't able to come up with a solution that allows special replacements like `$1 $& or $'`

We might need to use PCRE2 for that, but it's not as much of a drop-in replacement