### PR TITLE
Pet Module - Adds feature to keep open the pet command window

### DIFF
--- a/GWToolboxdll/GWToolbox.cpp
+++ b/GWToolboxdll/GWToolbox.cpp
@@ -47,6 +47,8 @@
 
 #include <DelayImp.h>
 
+#include "Modules/PetModule.h"
+
 // declare method here as recommended by imgui
 extern IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
 
@@ -1093,6 +1095,7 @@ void GWToolbox::UpdateInitialising(float)
     ToggleModule(LoginModule::Instance());
     ToggleModule(AprilFools::Instance());
     ToggleModule(SettingsWindow::Instance());
+    ToggleModule(PetModule::Instance());
 
     ToolboxSettings::LoadModules(ini); // initialize all other modules as specified by the user
 

--- a/GWToolboxdll/GWToolbox.cpp
+++ b/GWToolboxdll/GWToolbox.cpp
@@ -33,6 +33,7 @@
 #include <Modules/ItemDescriptionHandler.h>
 #include <Modules/LoginModule.h>
 #include <Modules/Updater.h>
+#include <Modules/PetModule.h>
 #include <Windows/SettingsWindow.h>
 
 #include <Windows/MainWindow.h>
@@ -47,7 +48,6 @@
 
 #include <DelayImp.h>
 
-#include "Modules/PetModule.h"
 
 // declare method here as recommended by imgui
 extern IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);

--- a/GWToolboxdll/Modules/PetModule.cpp
+++ b/GWToolboxdll/Modules/PetModule.cpp
@@ -1,13 +1,17 @@
 #include "PetModule.h"
 
+
 #include "../stdafx.h"
+
 #include <GWCA/Constants/Constants.h>
 #include <GWCA/Managers/MapMgr.h>
 #include <GWCA/Managers/UIMgr.h>
 #include <ToolboxModule.h>
 #include "Defines.h"
+#include "Utils/GuiUtils.h"
 
 namespace {
+    int interval = 0;
     bool display_window = false;
     GW::Constants::MapID map_id = GW::Constants::MapID::None;
     GW::Constants::MapID previous_map_id = GW::Constants::MapID::None;
@@ -39,19 +43,28 @@ void PetModule::Update(const float)
         return;
     }
 
-    if (GW::Map::GetInstanceType() != instance_type || GW::Map::GetMapID() != map_id) {
-        previous_instance_type = instance_type;
-        previous_map_id = map_id;
+    if (interval % 60 == 0) {
 
-        instance_type = GW::Map::GetInstanceType();
-        map_id = GW::Map::GetMapID();
+        if (GW::Map::GetInstanceType() != instance_type || GW::Map::GetMapID() != map_id) {
+            previous_instance_type = instance_type;
+            previous_map_id = map_id;
 
-        display_window = instance_type == GW::Constants::InstanceType::Explorable;
+            instance_type = GW::Map::GetInstanceType();
+            map_id = GW::Map::GetMapID();
+
+            display_window = instance_type == GW::Constants::InstanceType::Explorable;
+        }
+
+        if (display_window) {
+            Keypress(GW::UI::ControlAction_OpenPetCommander);
+            display_window = !display_window;
+        }
+
+        interval = 0;
     }
 
-    if (display_window) {
-        Keypress(GW::UI::ControlAction_OpenPetCommander);
-        display_window = !display_window;
-    }
+
+
+    interval += 1;
 }
 

--- a/GWToolboxdll/Modules/PetModule.cpp
+++ b/GWToolboxdll/Modules/PetModule.cpp
@@ -1,0 +1,57 @@
+#include "PetModule.h"
+
+#include "../stdafx.h"
+#include <GWCA/Constants/Constants.h>
+#include <GWCA/Managers/MapMgr.h>
+#include <GWCA/Managers/UIMgr.h>
+#include <ToolboxModule.h>
+#include "Defines.h"
+
+namespace {
+    bool display_window = false;
+    GW::Constants::MapID map_id = GW::Constants::MapID::None;
+    GW::Constants::MapID previous_map_id = GW::Constants::MapID::None;
+    GW::Constants::InstanceType instance_type = GW::Constants::InstanceType::Loading;
+    GW::Constants::InstanceType previous_instance_type = GW::Constants::InstanceType::Loading;
+}
+
+void PetModule::LoadSettings(ToolboxIni* ini)
+{
+    ToolboxModule::LoadSettings(ini);
+    LOAD_BOOL(keep_pet_window_open);
+}
+
+void PetModule::SaveSettings(ToolboxIni* ini)
+{
+    ToolboxModule::SaveSettings(ini);
+    SAVE_BOOL(keep_pet_window_open);
+}
+
+void PetModule::DrawSettingsInternal()
+{
+    ToolboxModule::DrawSettingsInternal();
+    ImGui::Checkbox("Keep Pet Command Window Open", &keep_pet_window_open);
+}
+
+void PetModule::Update(const float)
+{
+    if (!keep_pet_window_open || GW::Map::GetInstanceType() == GW::Constants::InstanceType::Loading) {
+        return;
+    }
+
+    if (GW::Map::GetInstanceType() != instance_type || GW::Map::GetMapID() != map_id) {
+        previous_instance_type = instance_type;
+        previous_map_id = map_id;
+
+        instance_type = GW::Map::GetInstanceType();
+        map_id = GW::Map::GetMapID();
+
+        display_window = instance_type == GW::Constants::InstanceType::Explorable;
+    }
+
+    if (display_window) {
+        Keypress(GW::UI::ControlAction_OpenPetCommander);
+        display_window = !display_window;
+    }
+}
+

--- a/GWToolboxdll/Modules/PetModule.h
+++ b/GWToolboxdll/Modules/PetModule.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <ToolboxModule.h>
+
+class PetModule : public ToolboxModule {
+    PetModule() = default;
+    ~PetModule() override = default;
+
+public:
+    static PetModule& Instance()
+    {
+        static PetModule instance;
+        return instance;
+    }
+
+    [[nodiscard]] const char* Name() const override { return "Pet"; }
+    [[nodiscard]] const char* Icon() const override { return ICON_FA_PAW; }
+
+    void LoadSettings(ToolboxIni* ini) override;
+    void SaveSettings(ToolboxIni* ini) override;
+    void DrawSettingsInternal() override;
+    void Update(float) override;
+
+private:
+    bool keep_pet_window_open = false;
+};


### PR DESCRIPTION
Tested going in a mission
Tested going in and out of an outpost
Tested going in and out of two explorable areas

I didn't see a documented window ID for the pet command window so did it through a keypress, if there is a better way feel free to change it or lmk and I'm happy to.