### PR TITLE
Export Resources::GetSkillImage for External Plugin Use

### DIFF
--- a/GWToolboxdll/Modules/Resources.cpp
+++ b/GWToolboxdll/Modules/Resources.cpp
@@ -1052,6 +1052,8 @@ IDirect3DTexture9** Resources::GetGuildWarsWikiImage(const char* filename, size_
     return texture;
 }
 
+#pragma comment(linker, "/EXPORT:?GetSkillImage@Resources@@SAPAPAUIDirect3DTexture9@@W4SkillID@Constants@GW@@@Z")
+
 IDirect3DTexture9** Resources::GetSkillImage(GW::Constants::SkillID skill_id)
 {
     const auto skill = GW::SkillbarMgr::GetSkillConstantData(skill_id);


### PR DESCRIPTION
This PR addresses an accessibility issue encountered while developing an external observer plugin that requires skill icon textures.

The `Resources::GetSkillImage` function, which provides access to skill textures, was previously internal to GWToolboxdll.dll. External plugins loaded as separate DLLs could not directly call this function, preventing them from displaying skill icons using the core Toolbox resources. 

I'm currently looking to implements Widgets and use these features to my Observe Plugin.

To resolve this, this PR introduces the following line to Resources.cpp:
```c++
#pragma comment(linker, "/EXPORT:?GetSkillImage@Resources@@SAPAPAUIDirect3DTexture9@@W4SkillID@Constants@GW@@@Z")
```

Its make possible to use this previous intern function on my DLL.

I tested and seems to not affected others parts of TB, and works on my side !

I hope this can be merged or a similar solution, so we can use textures on external plugins.

Thanks

![image](https://github.com/user-attachments/assets/a5a76755-0409-4958-8624-c0cdb041063b)
