### PR TITLE
Update vcpkg config to enable minhook compatibility

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "a54c4ba3aef5fe56cf11192f4476aaf057876551",
+    "baseline": "17efc2fb931c821e34672335a7e27d9d5f63116a",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [


### PR DESCRIPTION
The currently used baseline for the vcpkg git registry is from Nov 10, 2024 and contains a version of minhook with `cmake_minimum_required(VERSION 3.0)` defined within its CMakeLists.txt. [As of CMake 4.0, this is no longer compatible. ](https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features) As a result, attempting to build with `cmake --preset=vcpkg` utilizing CMake 4.x will fail.

Minhook has been updated to `v1.3.4` and now contains `cmake_minimum_required(VERSION 3.0...3.5)`, making it compatible with CMake 4.x. The vcpkg repo has been updated to reflect this change as well.

This change updates the vcpkg git baseline registry to use a current (May 15, 2025) version of the vcpkg repo, which includes the new Minhook version.