### PR TITLE
Add generic chat command to change settings from GWToolbox.ini

### DIFF
--- a/GWToolboxdll/GWToolbox.cpp
+++ b/GWToolboxdll/GWToolbox.cpp
@@ -322,20 +322,6 @@ namespace {
         return true;
     }
 
-    ToolboxIni* OpenSettingsFile()
-    {
-        static ToolboxIni* inifile = nullptr;
-        const auto full_path = Resources::GetSettingFile(GWTOOLBOX_INI_FILENAME);
-        if (!GWToolbox::SettingsFolderChanged() && inifile) {
-            return inifile;
-        }
-        auto tmp = new ToolboxIni(false, false, false);
-        ASSERT(tmp->LoadIfExists(full_path) == SI_OK);
-        tmp->location_on_disk = full_path;
-        inifile = tmp;
-        return inifile;
-    }
-
     bool CanRenderToolbox()
     {
         return !gwtoolbox_disabled
@@ -354,7 +340,7 @@ namespace {
             if (enable) {
                 return true;
             }
-            m.SaveSettings(OpenSettingsFile());
+            m.SaveSettings(GWToolbox::OpenSettingsFile());
             modules_terminating.push_back(&m);
             m.SignalTerminate();
             vec.erase(found);
@@ -370,7 +356,7 @@ namespace {
         }
         vec.push_back(&m);
         m.Initialize();
-        m.LoadSettings(OpenSettingsFile());
+        m.LoadSettings(GWToolbox::OpenSettingsFile());
         ReorderModules(vec);
         return true; // Added successfully
     }
@@ -835,6 +821,20 @@ bool GWToolbox::IsModuleEnabled(const char* name)
 bool GWToolbox::SettingsFolderChanged()
 {
     return settings_folder_changed;
+}
+
+ToolboxIni* GWToolbox::OpenSettingsFile()
+{
+    static ToolboxIni* inifile = nullptr;
+    const auto full_path = Resources::GetSettingFile(GWTOOLBOX_INI_FILENAME);
+    if (!GWToolbox::SettingsFolderChanged() && inifile) {
+        return inifile;
+    }
+    auto tmp = new ToolboxIni(false, false, false);
+    ASSERT(tmp->LoadIfExists(full_path) == SI_OK);
+    tmp->location_on_disk = full_path;
+    inifile = tmp;
+    return inifile;
 }
 
 std::filesystem::path GWToolbox::SaveSettings()

--- a/GWToolboxdll/GWToolbox.h
+++ b/GWToolboxdll/GWToolbox.h
@@ -38,6 +38,7 @@ public:
     static void Disable();
     static bool CanTerminate();
 
+    static ToolboxIni* OpenSettingsFile();
     static std::filesystem::path SaveSettings();
     static std::filesystem::path LoadSettings();
     static bool SetSettingsFolder(const std::filesystem::path& path);


### PR DESCRIPTION
Motivation: I wanted a hotkey to toggle the minimap scale, basically a zoom button. But I figured I might as well go for a generic solution.

`/config set|get|toggle|load [section key [value]]...`
uses the names from GWToolbox.ini and applies a set of settings to the running configuration similar to the Save/LoadSettings mechanism.

This is somewhat in competition with /tb_setting which currently handles 2 example boolean settings, while /config generically handles all ini settings (aside from separate files like AgentColors.ini).
`/tb_setting skillbar_skills_overlay on`
achieves the same as
`/config set skillbar display_skill_overlay true`

Since /config does not care what type of value it is working with, toggle behaves different than it does for /tb_setting with booleans. /config toggle just switches between the value on disk in GWToolbox.ini and the one on the /config cmdline. This comes with one drawback, if the settings are saved to disk after running e.g.
`/config toggle minimap scale 2`
further execution of the same toggle command will result in no change, leaving scale at 2.
I see 2 ways to work around that:
1: ignore the issue, but provide a setting to disable auto-saving (on exit/on enabling modules) to lower the chances of accidentally running it this
2: add a macro to all settings, which generates a pair of persistent and ephemeral value for all settings, such that changes made by toggle are never saved to disk
or 3: drop the toggle feature and just got with set|get|load

Is this kind of generic setting command something we want?