### PR TITLE
Fix QuestLogRow_UICallback_Func

### DIFF
--- a/GWToolboxdll/Modules/QuestModule.cpp
+++ b/GWToolboxdll/Modules/QuestModule.cpp
@@ -649,7 +649,7 @@ void QuestModule::Initialize()
     }
     RefreshQuestPath(GW::QuestMgr::GetActiveQuestId());
 
-    address = GW::Scanner::Find("\x83\xc0\xfc\x83\xf8\x54", "xxxxxx", -0xe);
+    address = GW::Scanner::Find("\x83\xc0\xfc\x83\xf8\x55", "xxxxxx", -0xe);
     if (GW::Scanner::IsValidPtr(address, GW::ScannerSection::Section_TEXT)) {
         QuestLogRow_UICallback_Func = (GW::UI::UIInteractionCallback)address;
         GW::Hook::CreateHook((void**)&QuestLogRow_UICallback_Func, OnQuestLogRow_UICallback, (void**)&QuestLogRow_UICallback_Ret);


### PR DESCRIPTION
Last byte has shifted by 0x1 due to UI message change. It's causing the double click on quest to not work, but also some random bugs such as crashing when accepting a skill from NPC