### PR TITLE
fix(injector): normalize LF to CRLF in changelog before display

### DIFF
--- a/GWToolbox/Download.cpp
+++ b/GWToolbox/Download.cpp
@@ -480,7 +480,14 @@ bool DownloadWindow::Create()
 
 void DownloadWindow::SetChangelog(const char* str, const size_t length) const
 {
-    const std::wstring content(str, str + length);
+    // Win32 Edit control requires CRLF; GitHub release bodies use bare LF
+    std::wstring content;
+    content.reserve(length);
+    for (const char* p = str; p != str + length; ++p) {
+        if (*p == '\n' && (p == str || p[-1] != '\r'))
+            content += L'\r';
+        content += static_cast<wchar_t>(*p);
+    }
     SendMessageW(m_hChangelog, WM_SETTEXT, 0, reinterpret_cast<LPARAM>(content.c_str()));
 }
 


### PR DESCRIPTION
GitHub release bodies use bare LF but the Win32 Edit control only treats CRLF as a line break, rendering lone \n as box glyphs in the update window.

The fix normalizes line endings in `SetChangelog` before the text is passed to `WM_SETTEXT`.

Fixes #2399

Generated with [Claude Code](https://claude.ai/code)