### PR TITLE
fix(TitleTracker): hide deprecated title tracks from the widget

### DIFF
--- a/GWToolboxdll/Modules/ChatCommands.cpp
+++ b/GWToolboxdll/Modules/ChatCommands.cpp
@@ -2084,11 +2084,8 @@ void ChatCommands::Update(const float delta)
     if (title_names.empty()) {
         const auto* titles = GetTitles();
         for (size_t i = 0; titles && i < titles->size(); i++) {
-            switch (static_cast<GW::Constants::TitleID>(i)) {
-                case GW::Constants::TitleID::Deprecated_SkillHunter:
-                case GW::Constants::TitleID::Deprecated_TreasureHunter:
-                case GW::Constants::TitleID::Deprecated_Wisdom:
-                    continue;
+            if (GW::PlayerMgr::IsDeprecatedTitle(static_cast<GW::Constants::TitleID>(i))) {
+                continue;
             }
             auto dtn = new DecodedTitleName(static_cast<GW::Constants::TitleID>(i));
             title_names.push_back(dtn);

--- a/GWToolboxdll/Utils/ToolboxUtils.cpp
+++ b/GWToolboxdll/Utils/ToolboxUtils.cpp
@@ -550,6 +550,18 @@ namespace GW {
             const auto player = GW::Agents::GetControlledCharacter();
             return player ? &player->pos : nullptr;
         }
+        bool IsDeprecatedTitle(GW::Constants::TitleID title_id)
+        {
+            using namespace GW::Constants;
+            switch (title_id) {
+                case TitleID::Deprecated_SkillHunter:
+                case TitleID::Deprecated_TreasureHunter:
+                case TitleID::Deprecated_Wisdom:
+                    return true;
+                default:
+                    return false;
+            }
+        }
     } // namespace PlayerMgr
     namespace Agents {
         bool IsAgentCarryingBundle(uint32_t agent_id)

--- a/GWToolboxdll/Utils/ToolboxUtils.h
+++ b/GWToolboxdll/Utils/ToolboxUtils.h
@@ -209,6 +209,8 @@ namespace GW {
     namespace PlayerMgr {
         bool IsMelandrusAccord();
         GW::GamePos* GetPlayerPosition();
+        // Old title variants the game still exposes but that no longer accrue
+        bool IsDeprecatedTitle(GW::Constants::TitleID title_id);
     }
     namespace Agents {
         bool IsAgentCarryingBundle(uint32_t agent_id);

--- a/GWToolboxdll/Widgets/TitleTrackerWidget.cpp
+++ b/GWToolboxdll/Widgets/TitleTrackerWidget.cpp
@@ -51,20 +51,6 @@ namespace {
     std::vector<TitleProgress*> title_progress_by_id;
     std::vector<TitleProgress*> title_progress_by_title;
 
-    // Old title variants the game still exposes but no longer accrue; hide them from the widget
-    bool IsDeprecatedTitle(GW::Constants::TitleID title_id)
-    {
-        using namespace GW::Constants;
-        switch (title_id) {
-            case TitleID::Deprecated_SkillHunter:
-            case TitleID::Deprecated_TreasureHunter:
-            case TitleID::Deprecated_Wisdom:
-                return true;
-            default:
-                return false;
-        }
-    }
-
     const uint32_t GetTitleMax(GW::Constants::TitleID title_id)
     {
         using namespace GW::Constants;
@@ -348,7 +334,7 @@ void TitleTrackerWidget::Initialize()
     }
     for (size_t i = 0; i != (size_t)GW::Constants::TitleID::Codex; i++) {
         const auto title_id = static_cast<GW::Constants::TitleID>(i);
-        if (IsDeprecatedTitle(title_id)) continue;
+        if (GW::PlayerMgr::IsDeprecatedTitle(title_id)) continue;
         title_progress_by_id.push_back(new TitleProgress(title_id));
         title_progress_by_title.push_back(title_progress_by_id.back());
     }

--- a/GWToolboxdll/Widgets/TitleTrackerWidget.cpp
+++ b/GWToolboxdll/Widgets/TitleTrackerWidget.cpp
@@ -51,6 +51,20 @@ namespace {
     std::vector<TitleProgress*> title_progress_by_id;
     std::vector<TitleProgress*> title_progress_by_title;
 
+    // Old title variants the game still exposes but no longer accrue; hide them from the widget
+    bool IsDeprecatedTitle(GW::Constants::TitleID title_id)
+    {
+        using namespace GW::Constants;
+        switch (title_id) {
+            case TitleID::Deprecated_SkillHunter:
+            case TitleID::Deprecated_TreasureHunter:
+            case TitleID::Deprecated_Wisdom:
+                return true;
+            default:
+                return false;
+        }
+    }
+
     const uint32_t GetTitleMax(GW::Constants::TitleID title_id)
     {
         using namespace GW::Constants;
@@ -333,7 +347,9 @@ void TitleTrackerWidget::Initialize()
         RegisterUIMessageCallback(&OnPostUIMessage_HookEntry, msg, OnPostUIMessage, 0x8000);
     }
     for (size_t i = 0; i != (size_t)GW::Constants::TitleID::Codex; i++) {
-        title_progress_by_id.push_back(new TitleProgress(static_cast<GW::Constants::TitleID>(i)));
+        const auto title_id = static_cast<GW::Constants::TitleID>(i);
+        if (IsDeprecatedTitle(title_id)) continue;
+        title_progress_by_id.push_back(new TitleProgress(title_id));
         title_progress_by_title.push_back(title_progress_by_id.back());
     }
     GW::GameThread::Enqueue(RefreshTitleProgress, true);


### PR DESCRIPTION
The title widget created a `TitleProgress` for every `TitleID` up to `Codex`, which includes the deprecated tracks the game still exposes but that no longer accrue:

- `Deprecated_TreasureHunter` (old, non-account-bound)
- `Deprecated_Wisdom` (old, non-account-bound)
- `Deprecated_SkillHunter` (pre-hard-mode)

As reported on Discord, this surfaced the old Treasure Hunter track in the checkbox list alongside the current one. This skips deprecated IDs when building the title list so only the current tracks appear.

Second commit centralises the check: `ChatCommands.cpp` already had the exact same deprecated-title switch inline, so both now share `GW::PlayerMgr::IsDeprecatedTitle` in `ToolboxUtils`. (The Completion window uses hardcoded HOM achievement lists rather than iterating the `TitleID` enum, so it needs no change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)