### PR TITLE
docs(history): open 8.33 release notes

### DIFF
--- a/site/src/content/docs/history.md
+++ b/site/src/content/docs/history.md
@@ -7,6 +7,11 @@ section: meta
 Previous releases are available on Github as dll files. There is no support for older releases. If you are looking for
 the latest version, go to the [Home Page](./) instead.
 
+## Version 8.33
+* [Fix] Loot Beacons: each beacon now always matches the colour of the item's name tag, and the per-rarity colour pickers have been removed — the rarity colours were also realigned to the game's own item palette so beacons read the same as the drop text.
+* [Fix] Title Tracker: the old, no-longer-obtainable versions of the Treasure Hunter and Wisdom title tracks (and the pre-hard-mode Skill Hunter) no longer appear in the widget's title list or the `/title` command.
+* [Fix] Trader window: the per-order "Whisper" buttons no longer share a click target when order descriptions are blank, so whispering a specific seller works reliably.
+
 ## Version 8.32
 * [Perf] In-world overlays that drape on the ground — quest paths, Skill Range Rings, Loot Beacons, Danger Rings and Weather — now read the terrain height straight from the game's heightfield instead of asking the game to recalculate it once per vertex every frame. Large overlays that used to drag the framerate down are now a fraction of the cost.
 * [Fix] Skill Range Rings: fixed severe FPS drops while hovering a skill. The rings were re-projected onto the terrain every frame; the draped geometry is now cached and only recomputed when you or your target moves, so inspecting a skill's range no longer tanks the framerate.


### PR DESCRIPTION
Opens the **8.33** section in the version history with the user-facing changes landed since the 8.32 version bump (`47b4a605`):

- **Loot Beacons** — beacons always match the item name-tag colour; the per-rarity colour pickers were removed and the rarity palette realigned to the game's own (#2428, #2429).
- **Title Tracker** — hides the deprecated Treasure Hunter / Wisdom / pre-hard-mode Skill Hunter tracks from the widget list and `/title` command (#2430).
- **Trader window** — per-order Whisper buttons no longer collide when order descriptions are blank.

`npm --prefix site run build` runs clean and `dist/llms-full.txt` picks up the new section.

**Not included (flagging for a call):** the *Cartographer Helper* module received substantial work since 8.32 and is now marked "usable", but it self-describes as a debug/experimental tool and was already registered before 8.32 — let me know if you want it written up as a feature for 8.33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)