### PR TITLE
Fetch pre-searing trader quotes directly from presearing.com's price sheet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,5 +4,6 @@ Instructions for any AI agent in this repo. (`CLAUDE.md` just imports this.)
 
 - **Comments:** explain *why*, not *what*; one concise line, no prose blocks. Exempt: `// ===` banners, license/file headers.
 - **Variables:** prefer `auto` when the initializer makes the type clear (`const auto x = TIMER_INIT();`).
+- **Functions:** don't extract a function for a few lines of logic used at only one call site; inline it. Extract only when it's called from more than one place, or the logic is substantial enough to warrant a name of its own.
 - **Docs (`site/`):** pages go in `src/content/docs/`; `llms.txt`/`llms-full.txt` auto-generate from them. A new page needs `description:` frontmatter plus a `src/lib/nav.ts` entry to appear in `llms.txt`. After changes run `npm --prefix site run build` and check `site/dist/llms.txt`.
 - **Explaining a feature:** first check if it's documented (`src/content/docs/` or <https://www.gwtoolbox.com/docs/>); if missing/wrong, flag it, offer a fix, and link the page.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,5 +5,6 @@ Instructions for any AI agent in this repo. (`CLAUDE.md` just imports this.)
 - **Comments:** explain *why*, not *what*; one concise line, no prose blocks. Exempt: `// ===` banners, license/file headers.
 - **Variables:** prefer `auto` when the initializer makes the type clear (`const auto x = TIMER_INIT();`).
 - **Functions:** don't extract a function for a few lines of logic used at only one call site; inline it. Extract only when it's called from more than one place, or the logic is substantial enough to warrant a name of its own.
+- **Reuse:** before adding a string/formatting or ImGui/dialog helper, check `Utils/TextUtils.h` and `Utils/GuiUtils.h` - there's often one already.
 - **Docs (`site/`):** pages go in `src/content/docs/`; `llms.txt`/`llms-full.txt` auto-generate from them. A new page needs `description:` frontmatter plus a `src/lib/nav.ts` entry to appear in `llms.txt`. After changes run `npm --prefix site run build` and check `site/dist/llms.txt`.
 - **Explaining a feature:** first check if it's documented (`src/content/docs/` or <https://www.gwtoolbox.com/docs/>); if missing/wrong, flag it, offer a fix, and link the page.

--- a/GWToolboxdll/Modules/ItemTooltipModule.cpp
+++ b/GWToolboxdll/Modules/ItemTooltipModule.cpp
@@ -516,7 +516,7 @@ void ItemTooltipModule::DrawSettingsInternal()
     }
 
     // --- Trader prices -------------------------------------------------------
-    ImGui::CheckboxWithHelp("Show trader prices in item tooltip", &settings.show_trader_prices, "Current rune, dye and mod prices are fetched from https://kamadan.gwtoolbox.com");
+    ImGui::CheckboxWithHelp("Show trader prices in item tooltip", &settings.show_trader_prices, "Current rune, dye and mod prices are fetched from https://kamadan.gwtoolbox.com (or, while pre-searing, presearing.com's community price sheet)");
     if (settings.show_trader_prices) {
         ImGui::Indent();
 

--- a/GWToolboxdll/Modules/LootBeaconsModule.cpp
+++ b/GWToolboxdll/Modules/LootBeaconsModule.cpp
@@ -472,7 +472,7 @@ void LootBeaconsModule::DrawSettingsInternal()
         ImGui::TextColored(red, GameWorldCompositor::HasFailed() ? "In-world compositor FAILED to install." : "In-world compositor: not installed yet.");
 
     ImGui::TextUnformatted("Beacon by gold value");
-    ImGui::ShowHelp("Any drop whose Kamadan trader price meets a threshold gets a beacon,\nregardless of rarity - catches ectos, gemstones, dyes and other white-rarity valuables.\nAn item that clears both thresholds uses the higher tier's colour.");
+    ImGui::ShowHelp("Any drop whose trader price (Kamadan, or presearing.com's price sheet while pre-searing) meets a threshold gets a beacon,\nregardless of rarity - catches ectos, gemstones, dyes and other white-rarity valuables.\nAn item that clears both thresholds uses the higher tier's colour.");
     for (auto* value : {&value_low, &value_high}) {
         ImGui::PushID(value->label);
         if (ImGui::Checkbox("##enabled", &value->enabled)) beacons_dirty = true;

--- a/GWToolboxdll/Modules/PriceCheckerModule.cpp
+++ b/GWToolboxdll/Modules/PriceCheckerModule.cpp
@@ -399,12 +399,6 @@ namespace {
         return !prices_by_identifier.empty();
     }
 
-    std::string PresearingSheetCsvUrl(const char* tab_name)
-    {
-        // Same CSV export a published Google Sheet's "File > Share > Publish to web" produces - no key/auth needed.
-        return std::format("https://docs.google.com/spreadsheets/d/{}/gviz/tq?tqx=out:csv&sheet={}", presearing_sheet_id, tab_name);
-    }
-
     std::string Trim(const std::string& s)
     {
         const auto first = s.find_first_not_of(" \t\r\n");
@@ -572,7 +566,9 @@ const std::unordered_map<std::string, uint32_t>& PriceCheckerModule::FetchPrices
         last_request_was_presearing = is_presearing;
         if (is_presearing) {
             for (const char* tab_name : presearing_sheet_tabs) {
-                Resources::Download(PresearingSheetCsvUrl(tab_name), [tab_name](bool success, const std::string& response, void*) {
+                // Same CSV export a published Google Sheet's "File > Share > Publish to web" produces - no key/auth needed.
+                const auto csv_url = std::format("https://docs.google.com/spreadsheets/d/{}/gviz/tq?tqx=out:csv&sheet={}", presearing_sheet_id, tab_name);
+                Resources::Download(csv_url, [tab_name](bool success, const std::string& response, void*) {
                     if (!success) {
                         last_request_time -= request_interval;
                         return;

--- a/GWToolboxdll/Modules/PriceCheckerModule.cpp
+++ b/GWToolboxdll/Modules/PriceCheckerModule.cpp
@@ -35,9 +35,7 @@ namespace {
     bool fetching_prices;
     const char* trader_quotes_url = "https://kamadan.gwtoolbox.com/trader_quotes";
 
-    // Pre-searing has no live trader-quote service; presearing.com's own price-check page is fed
-    // straight from this public, manually-curated, community-maintained Google Sheet (no API key or
-    // auth needed - it's the same CSV export the sheet's own "File > Share > Publish" flow produces).
+    // No live pre-searing trader-quote service exists - this is presearing.com's own public, community-maintained price sheet.
     const char* presearing_sheet_id = "1u8-n_EJe9Nfl1twUHExLeuuYNT0Szo_7ss4HmmNytqk";
 
     constexpr clock_t request_interval = 1000 * 60 * 5;
@@ -300,10 +298,7 @@ namespace {
         const char* id;            // matches an id in price_info_by_unique_mod_struct above
     };
 
-    // Hand-mapped from the sheet's "Runes" and "Insignias" tabs onto the mod-struct ids above -
-    // the sheet only has free-text item names, no ids of its own. Rows the sheet itself flags as not
-    // usable in pre-searing (e.g. Heralds), or that carry no price of their own (extra description
-    // rows for a multi-tier bonus, e.g. Radiant's leg/other-armor tiers), are intentionally omitted.
+    // Hand-mapped onto the mod-struct ids above, since the sheet only has free-text item names; rows it flags as pre-searing-unusable or with no price of their own are omitted.
     const std::vector<PresearingSheetItem> presearing_sheet_items = {
         {"Runes", "Common", "Attunement", "08038225300423"},
         {"Runes", "Common", "Minor Vigor", "08038227e802c2"},
@@ -448,15 +443,13 @@ namespace {
         return fields;
     }
 
-    // Parses cells like "500g" / "1k" / "1.5k" into a gold amount. Cells using a unit we don't
-    // recognise (e.g. presearing.com's "BD" - meaning unconfirmed) or that are blank are left
-    // unparsed rather than guessed at, since a wrong price is worse than a missing one.
+    // Parses "500g"/"1k"/"1.5k"; other units (e.g. presearing.com's unconfirmed "BD") are left unparsed rather than guessed at.
     bool ParseGoldAmount(const std::string& cell, double& out_gold)
     {
         const auto trimmed = Trim(cell);
         if (trimmed.empty()) return false;
 
-        const char unit = static_cast<char>(std::tolower(static_cast<unsigned char>(trimmed.back())));
+        const auto unit = static_cast<char>(std::tolower(static_cast<unsigned char>(trimmed.back())));
         if (unit != 'g' && unit != 'k') return false;
 
         const auto number_part = trimmed.substr(0, trimmed.size() - 1);
@@ -470,8 +463,7 @@ namespace {
         return true;
     }
 
-    // Parses one presearing.com sheet tab's CSV export and merges any recognised items into
-    // prices_by_identifier - only touches ids owned by this tab, leaving other tabs' cached prices intact.
+    // Merges recognised rows into prices_by_identifier; only touches ids owned by this tab, leaving other tabs' cached prices intact.
     bool ParsePresearingSheetCsv(const char* tab_name, const std::string& csv)
     {
         std::vector<std::string> lines;

--- a/GWToolboxdll/Modules/PriceCheckerModule.cpp
+++ b/GWToolboxdll/Modules/PriceCheckerModule.cpp
@@ -16,6 +16,7 @@
 
 #include <GWCA/Managers/GameThreadMgr.h>
 #include <Timer.h>
+#include <Utils/TextUtils.h>
 #include <Utils/ToolboxUtils.h>
 
 namespace pricechecker_api {
@@ -399,14 +400,6 @@ namespace {
         return !prices_by_identifier.empty();
     }
 
-    std::string Trim(const std::string& s)
-    {
-        const auto first = s.find_first_not_of(" \t\r\n");
-        if (first == std::string::npos) return {};
-        const auto last = s.find_last_not_of(" \t\r\n");
-        return s.substr(first, last - first + 1);
-    }
-
     // Minimal RFC4180-ish CSV line splitter - handles quoted fields, commas inside quotes, and "" as an escaped quote.
     std::vector<std::string> ParseCsvLine(const std::string& line)
     {
@@ -440,7 +433,7 @@ namespace {
     // Parses "500g"/"1k"/"1.5k"; other units (e.g. presearing.com's unconfirmed "BD") are left unparsed rather than guessed at.
     bool ParseGoldAmount(const std::string& cell, double& out_gold)
     {
-        const auto trimmed = Trim(cell);
+        const auto trimmed = TextUtils::trim(cell);
         if (trimmed.empty()) return false;
 
         const auto unit = static_cast<char>(std::tolower(static_cast<unsigned char>(trimmed.back())));
@@ -460,21 +453,14 @@ namespace {
     // Merges recognised rows into prices_by_identifier; only touches ids owned by this tab, leaving other tabs' cached prices intact.
     bool ParsePresearingSheetCsv(const char* tab_name, const std::string& csv)
     {
-        std::vector<std::string> lines;
-        size_t start = 0;
-        while (start <= csv.size()) {
-            const auto pos = csv.find('\n', start);
-            lines.push_back(pos == std::string::npos ? csv.substr(start) : csv.substr(start, pos - start));
-            if (pos == std::string::npos) break;
-            start = pos + 1;
-        }
+        const auto lines = TextUtils::Split(csv, "\n");
         if (lines.empty()) return false;
 
         const auto header = ParseCsvLine(lines.front());
         int item_name_col = -1, low_col = -1, high_col = -1;
         constexpr int category_col = 0;
         for (size_t i = 0; i < header.size(); i++) {
-            const auto cell = Trim(header[i]);
+            const auto cell = TextUtils::trim(header[i]);
             if (cell == "Item Name") item_name_col = static_cast<int>(i);
             else if (cell.starts_with("Price Low")) low_col = static_cast<int>(i); // rightmost column wins - latest date
             else if (cell.starts_with("Price High")) high_col = static_cast<int>(i);
@@ -485,16 +471,15 @@ namespace {
         const std::string tab_name_str = tab_name;
         std::string current_category;
         for (size_t i = 1; i < lines.size(); i++) {
-            if (lines[i].empty()) continue;
             const auto fields = ParseCsvLine(lines[i]);
             const auto max_col = std::max({item_name_col, low_col, high_col});
             if (fields.size() <= static_cast<size_t>(max_col)) continue;
 
-            if (const auto category_cell = Trim(fields[category_col]); !category_cell.empty()) {
+            if (const auto category_cell = TextUtils::trim(fields[category_col]); !category_cell.empty()) {
                 current_category = category_cell;
             }
 
-            const auto item_name = Trim(fields[item_name_col]);
+            const auto item_name = TextUtils::trim(fields[item_name_col]);
             if (item_name.empty()) continue; // extra description row for the item above, not a distinct item
 
             const auto entry = std::ranges::find_if(presearing_sheet_items, [&](const PresearingSheetItem& item) {

--- a/GWToolboxdll/Modules/PriceCheckerModule.cpp
+++ b/GWToolboxdll/Modules/PriceCheckerModule.cpp
@@ -34,9 +34,11 @@ namespace {
 
     bool fetching_prices;
     const char* trader_quotes_url = "https://kamadan.gwtoolbox.com/trader_quotes";
+    const char* presearing_quotes_url = "https://presearing.gwtoolbox.com/trader_quotes";
 
     constexpr clock_t request_interval = 1000 * 60 * 5;
     clock_t last_request_time = -request_interval;
+    bool last_request_was_presearing = false;
     std::unordered_map<std::string, uint32_t> prices_by_identifier;
 
     PriceCheckerModule::Settings settings;
@@ -358,9 +360,15 @@ void PriceCheckerModule::DrawSettingsInternal()
 
 const std::unordered_map<std::string, uint32_t>& PriceCheckerModule::FetchPrices()
 {
+    const bool is_presearing = GW::Map::IsPreSearing();
+    if (is_presearing != last_request_was_presearing) {
+        // Crossing the pre/post-searing boundary invalidates the cached quotes - force a refetch from the right source.
+        last_request_time = -request_interval;
+    }
     if (TIMER_DIFF(last_request_time) > request_interval) {
         last_request_time = TIMER_INIT();
-        Resources::Download(trader_quotes_url, [](bool success, const std::string& response, void*) {
+        last_request_was_presearing = is_presearing;
+        Resources::Download(is_presearing ? presearing_quotes_url : trader_quotes_url, [](bool success, const std::string& response, void*) {
             if (!success) {
                 last_request_time -= request_interval;
                 return;

--- a/GWToolboxdll/Modules/PriceCheckerModule.cpp
+++ b/GWToolboxdll/Modules/PriceCheckerModule.cpp
@@ -34,7 +34,11 @@ namespace {
 
     bool fetching_prices;
     const char* trader_quotes_url = "https://kamadan.gwtoolbox.com/trader_quotes";
-    const char* presearing_quotes_url = "https://presearing.gwtoolbox.com/trader_quotes";
+
+    // Pre-searing has no live trader-quote service; presearing.com's own price-check page is fed
+    // straight from this public, manually-curated, community-maintained Google Sheet (no API key or
+    // auth needed - it's the same CSV export the sheet's own "File > Share > Publish" flow produces).
+    const char* presearing_sheet_id = "1u8-n_EJe9Nfl1twUHExLeuuYNT0Szo_7ss4HmmNytqk";
 
     constexpr clock_t request_interval = 1000 * 60 * 5;
     clock_t last_request_time = -request_interval;
@@ -285,6 +289,88 @@ namespace {
         {0x000b1985, {"Jadeite Shard", "0b1985"}},
     };
 
+    // -------------------------------------------------------------------------
+    // Pre-searing price sheet (presearing.com's community-maintained Google Sheet)
+    // -------------------------------------------------------------------------
+
+    struct PresearingSheetItem {
+        const char* tab_name;      // Google Sheets tab ("sheet=" query param)
+        const char* category;      // the sheet's grouping column, carried forward over blank cells
+        const char* item_name;     // the sheet's "Item Name" column, verbatim
+        const char* id;            // matches an id in price_info_by_unique_mod_struct above
+    };
+
+    // Hand-mapped from the sheet's "Runes" and "Insignias" tabs onto the mod-struct ids above -
+    // the sheet only has free-text item names, no ids of its own. Rows the sheet itself flags as not
+    // usable in pre-searing (e.g. Heralds), or that carry no price of their own (extra description
+    // rows for a multi-tier bonus, e.g. Radiant's leg/other-armor tiers), are intentionally omitted.
+    const std::vector<PresearingSheetItem> presearing_sheet_items = {
+        {"Runes", "Common", "Attunement", "08038225300423"},
+        {"Runes", "Common", "Minor Vigor", "08038227e802c2"},
+        {"Runes", "Common", "Vitae", "08038225300425"},
+        {"Runes", "Elementalist", "Air Magic", "08038521e80801"},
+        {"Runes", "Elementalist", "Earth Magic", "08038521e80901"},
+        {"Runes", "Elementalist", "Energy Storage", "08038521e80c01"},
+        {"Runes", "Elementalist", "Fire Magic", "08038521e80a01"},
+        {"Runes", "Elementalist", "Water Magic", "08038521e80b01"},
+        {"Runes", "Mesmer", "Domination", "08038321e80201"},
+        {"Runes", "Mesmer", "Fast Casting", "08038321e80001"},
+        {"Runes", "Mesmer", "Illusion", "08038321e80101"},
+        {"Runes", "Mesmer", "Inspiration", "08038321e80301"},
+        {"Runes", "Monk", "Divine Favor", "08038621e81001"},
+        {"Runes", "Monk", "Healing Prayers", "08038621e80d01"},
+        {"Runes", "Monk", "Protection Prayers", "08038621e80f01"},
+        {"Runes", "Monk", "Smiting", "08038621e80e01"},
+        {"Runes", "Necromancer", "Blood Magic", "08038421e80401"},
+        {"Runes", "Necromancer", "Curses", "08038421e80701"},
+        {"Runes", "Necromancer", "Death Magic", "08038421e80501"},
+        {"Runes", "Necromancer", "Soul Reaping", "08038421e80601"},
+        {"Runes", "Ranger", "Beast Mastery", "08038821e81601"},
+        {"Runes", "Ranger", "Expertise", "08038821e81701"},
+        {"Runes", "Ranger", "Marksmanship", "08038821e81901"},
+        {"Runes", "Ranger", "Wilderness Survival", "08038821e81801"},
+        {"Runes", "Warrior", "Absorption", "08038727e802ea"},
+        {"Runes", "Warrior", "Axe Mastery", "08038721e81201"},
+        {"Runes", "Warrior", "Hammer Mastery", "08038721e81301"},
+        {"Runes", "Warrior", "Strength", "08038721e81101"},
+        {"Runes", "Warrior", "Swordsmanship", "08038721e81401"},
+        {"Runes", "Warrior", "Tactics", "08038721e81501"},
+
+        {"Insignias", "Common", "Blessed", "084abfa53003d2"},
+        {"Insignias", "Common", "Brawler's", "084abea53003d0"},
+        {"Insignias", "Common", "Radiant", "084abb253003ca"},
+        {"Insignias", "Common", "Sentry's", "084ac1a53003d6"},
+        {"Insignias", "Common", "Stalwart", "084abda53003ce"},
+        {"Insignias", "Common", "Survivor", "084abc253003cc"},
+        {"Insignias", "Elementalist", "Aeromancer", "084acca53003ea"},
+        {"Insignias", "Elementalist", "Geomancer", "084acaa53003e6"},
+        {"Insignias", "Elementalist", "Hydromancer", "084ac9a53003e4"},
+        {"Insignias", "Elementalist", "Prismatic", "084ac8a53003e2"},
+        {"Insignias", "Elementalist", "Pyromancer", "084acba53003e8"},
+        {"Insignias", "Mesmer", "Artificer's", "084ab8a53003c4"},
+        {"Insignias", "Mesmer", "Prodigy's", "084ab9a53003c6"},
+        {"Insignias", "Mesmer", "Virtuoso's", "084abaa53003c8"},
+        {"Insignias", "Monk", "Anchorite's", "084acfa53003f0"},
+        {"Insignias", "Monk", "Disciple's", "084acea53003ee"},
+        {"Insignias", "Monk", "Wanderer's", "084acda53003ec"},
+        {"Insignias", "Necromancer", "Blighter's", "084ac7a53003e0"},
+        {"Insignias", "Necromancer", "Bonelace", "084ac5a53003dc"},
+        {"Insignias", "Necromancer", "Minion Master's", "084ac6a53003de"},
+        {"Insignias", "Necromancer", "Tormentor's", "084ac3253003d8"},
+        {"Insignias", "Necromancer", "Undertaker's", "084ac4a53003da"},
+        {"Insignias", "Ranger", "Beastmaster's", "084ad9a5300400"},
+        {"Insignias", "Ranger", "Earthbound", "084ad6a53003fa"},
+        {"Insignias", "Ranger", "Frostbound", "084ad5a53003f8"},
+        {"Insignias", "Ranger", "Pyrebound", "084ad7a53003fc"},
+        {"Insignias", "Ranger", "Scout's", "084adaa5300402"},
+        {"Insignias", "Ranger", "Stormbound", "084ad8a53003fe"},
+        {"Insignias", "Warrior", "Dreadnought", "084ad3a53003f4"},
+        {"Insignias", "Warrior", "Knight's", "084ad0a53003f2"},
+        {"Insignias", "Warrior", "Sentinel's", "084ad4a53003f6"},
+    };
+
+    const char* presearing_sheet_tabs[] = {"Runes", "Insignias"};
+
     int MaterialSlotToModelID(GW::Constants::MaterialSlot mat)
     {
         const auto info = GW::Items::GetMaterialInfo(mat);
@@ -316,6 +402,130 @@ namespace {
             prices_by_identifier[key] = static_cast<uint32_t>(entry.p);
         }
         return !prices_by_identifier.empty();
+    }
+
+    std::string PresearingSheetCsvUrl(const char* tab_name)
+    {
+        // Same CSV export a published Google Sheet's "File > Share > Publish to web" produces - no key/auth needed.
+        return std::format("https://docs.google.com/spreadsheets/d/{}/gviz/tq?tqx=out:csv&sheet={}", presearing_sheet_id, tab_name);
+    }
+
+    std::string Trim(const std::string& s)
+    {
+        const auto first = s.find_first_not_of(" \t\r\n");
+        if (first == std::string::npos) return {};
+        const auto last = s.find_last_not_of(" \t\r\n");
+        return s.substr(first, last - first + 1);
+    }
+
+    // Minimal RFC4180-ish CSV line splitter - handles quoted fields, commas inside quotes, and "" as an escaped quote.
+    std::vector<std::string> ParseCsvLine(const std::string& line)
+    {
+        std::vector<std::string> fields;
+        std::string field;
+        bool in_quotes = false;
+        for (size_t i = 0; i < line.size(); i++) {
+            const char c = line[i];
+            if (in_quotes) {
+                if (c == '"' && i + 1 < line.size() && line[i + 1] == '"') {
+                    field += '"';
+                    i++;
+                } else if (c == '"') {
+                    in_quotes = false;
+                } else {
+                    field += c;
+                }
+            } else if (c == '"') {
+                in_quotes = true;
+            } else if (c == ',') {
+                fields.push_back(std::move(field));
+                field.clear();
+            } else {
+                field += c;
+            }
+        }
+        fields.push_back(std::move(field));
+        return fields;
+    }
+
+    // Parses cells like "500g" / "1k" / "1.5k" into a gold amount. Cells using a unit we don't
+    // recognise (e.g. presearing.com's "BD" - meaning unconfirmed) or that are blank are left
+    // unparsed rather than guessed at, since a wrong price is worse than a missing one.
+    bool ParseGoldAmount(const std::string& cell, double& out_gold)
+    {
+        const auto trimmed = Trim(cell);
+        if (trimmed.empty()) return false;
+
+        const char unit = static_cast<char>(std::tolower(static_cast<unsigned char>(trimmed.back())));
+        if (unit != 'g' && unit != 'k') return false;
+
+        const auto number_part = trimmed.substr(0, trimmed.size() - 1);
+        if (number_part.empty()) return false;
+
+        char* end = nullptr;
+        const double value = std::strtod(number_part.c_str(), &end);
+        if (end != number_part.c_str() + number_part.size()) return false;
+
+        out_gold = unit == 'k' ? value * 1000.0 : value;
+        return true;
+    }
+
+    // Parses one presearing.com sheet tab's CSV export and merges any recognised items into
+    // prices_by_identifier - only touches ids owned by this tab, leaving other tabs' cached prices intact.
+    bool ParsePresearingSheetCsv(const char* tab_name, const std::string& csv)
+    {
+        std::vector<std::string> lines;
+        size_t start = 0;
+        while (start <= csv.size()) {
+            const auto pos = csv.find('\n', start);
+            lines.push_back(pos == std::string::npos ? csv.substr(start) : csv.substr(start, pos - start));
+            if (pos == std::string::npos) break;
+            start = pos + 1;
+        }
+        if (lines.empty()) return false;
+
+        const auto header = ParseCsvLine(lines.front());
+        int item_name_col = -1, low_col = -1, high_col = -1;
+        constexpr int category_col = 0;
+        for (size_t i = 0; i < header.size(); i++) {
+            const auto cell = Trim(header[i]);
+            if (cell == "Item Name") item_name_col = static_cast<int>(i);
+            else if (cell.starts_with("Price Low")) low_col = static_cast<int>(i); // rightmost column wins - latest date
+            else if (cell.starts_with("Price High")) high_col = static_cast<int>(i);
+        }
+        if (item_name_col < 0 || low_col < 0 || high_col < 0) return false;
+
+        size_t found_count = 0;
+        const std::string tab_name_str = tab_name;
+        std::string current_category;
+        for (size_t i = 1; i < lines.size(); i++) {
+            if (lines[i].empty()) continue;
+            const auto fields = ParseCsvLine(lines[i]);
+            const auto max_col = std::max({item_name_col, low_col, high_col});
+            if (fields.size() <= static_cast<size_t>(max_col)) continue;
+
+            if (const auto category_cell = Trim(fields[category_col]); !category_cell.empty()) {
+                current_category = category_cell;
+            }
+
+            const auto item_name = Trim(fields[item_name_col]);
+            if (item_name.empty()) continue; // extra description row for the item above, not a distinct item
+
+            const auto entry = std::ranges::find_if(presearing_sheet_items, [&](const PresearingSheetItem& item) {
+                return item.tab_name == tab_name_str && item.category == current_category && item.item_name == item_name;
+            });
+            if (entry == presearing_sheet_items.end()) continue;
+
+            double low = 0.0, high = 0.0;
+            const bool has_low = ParseGoldAmount(fields[low_col], low);
+            const bool has_high = ParseGoldAmount(fields[high_col], high);
+            if (!has_low && !has_high) continue;
+
+            const double price = has_low && has_high ? (low + high) / 2.0 : (has_low ? low : high);
+            prices_by_identifier[entry->id] = static_cast<uint32_t>(std::lround(price));
+            found_count++;
+        }
+        return found_count > 0;
     }
 
     void SignalItemDescriptionUpdated()
@@ -368,14 +578,27 @@ const std::unordered_map<std::string, uint32_t>& PriceCheckerModule::FetchPrices
     if (TIMER_DIFF(last_request_time) > request_interval) {
         last_request_time = TIMER_INIT();
         last_request_was_presearing = is_presearing;
-        Resources::Download(is_presearing ? presearing_quotes_url : trader_quotes_url, [](bool success, const std::string& response, void*) {
-            if (!success) {
-                last_request_time -= request_interval;
-                return;
+        if (is_presearing) {
+            for (const char* tab_name : presearing_sheet_tabs) {
+                Resources::Download(PresearingSheetCsvUrl(tab_name), [tab_name](bool success, const std::string& response, void*) {
+                    if (!success) {
+                        last_request_time -= request_interval;
+                        return;
+                    }
+                    ParsePresearingSheetCsv(tab_name, response);
+                    SignalItemDescriptionUpdated();
+                });
             }
-            ParsePriceJson(response);
-            SignalItemDescriptionUpdated();
-        });
+        } else {
+            Resources::Download(trader_quotes_url, [](bool success, const std::string& response, void*) {
+                if (!success) {
+                    last_request_time -= request_interval;
+                    return;
+                }
+                ParsePriceJson(response);
+                SignalItemDescriptionUpdated();
+            });
+        }
     }
     return prices_by_identifier;
 }

--- a/GWToolboxdll/Modules/PriceCheckerModule.h
+++ b/GWToolboxdll/Modules/PriceCheckerModule.h
@@ -33,7 +33,8 @@ public:
 
     void DrawSettingsInternal() override;
 
-    // Fetch (and cache) prices from kamadan.gwtoolbox.com.
+    // Fetch (and cache) prices from kamadan.gwtoolbox.com, or presearing.gwtoolbox.com
+    // while in pre-searing (see GW::Map::IsPreSearing()).
     // Returns the current price map; triggers a background refresh if stale.
     static const std::unordered_map<std::string, uint32_t>& FetchPrices();
 

--- a/GWToolboxdll/Modules/PriceCheckerModule.h
+++ b/GWToolboxdll/Modules/PriceCheckerModule.h
@@ -33,8 +33,8 @@ public:
 
     void DrawSettingsInternal() override;
 
-    // Fetch (and cache) prices from kamadan.gwtoolbox.com, or presearing.gwtoolbox.com
-    // while in pre-searing (see GW::Map::IsPreSearing()).
+    // Fetch (and cache) prices from kamadan.gwtoolbox.com, or directly from presearing.com's
+    // community price-check spreadsheet while in pre-searing (see GW::Map::IsPreSearing()).
     // Returns the current price map; triggers a background refresh if stale.
     static const std::unordered_map<std::string, uint32_t>& FetchPrices();
 

--- a/site/src/content/docs/history.md
+++ b/site/src/content/docs/history.md
@@ -11,6 +11,7 @@ the latest version, go to the [Home Page](./) instead.
 * [Fix] Loot Beacons: each beacon now always matches the colour of the item's name tag, and the per-rarity colour pickers have been removed — the rarity colours were also realigned to the game's own item palette so beacons read the same as the drop text.
 * [Fix] Title Tracker: the old, no-longer-obtainable versions of the Treasure Hunter and Wisdom title tracks (and the pre-hard-mode Skill Hunter) no longer appear in the widget's title list or the `/title` command.
 * [Fix] Trader window: the per-order "Whisper" buttons no longer share a click target when order descriptions are blank, so whispering a specific seller works reliably.
+* [Fix] Price Checker: rune and insignia tooltips while in pre-searing now show pre-searing prices, sourced from presearing.com's community price sheet, instead of the unrelated post-searing Kamadan Trading Post price for the same item.
 
 ## Version 8.32
 * [Perf] In-world overlays that drape on the ground — quest paths, Skill Range Rings, Loot Beacons, Danger Rings and Weather — now read the terrain height straight from the game's heightfield instead of asking the game to recalculate it once per vertex every frame. Large overlays that used to drag the framerate down are now a fraction of the cost.


### PR DESCRIPTION
## Summary
- `PriceCheckerModule::FetchPrices()` checks `GW::Map::IsPreSearing()` (same helper already used in `ItemTooltipModule.cpp`) and, while pre-searing, fetches trader quotes directly - no backend service in between.
- presearing.com's own price-check page turns out to be fed from a public, manually-curated Google Sheet, fetched client-side as a CSV export (`docs.google.com/spreadsheets/d/<id>/gviz/tq?tqx=out:csv&sheet=<tab>`) - no API key or auth needed. GWToolboxdll now hits that same URL directly for the `Runes` and `Insignias` tabs and parses the CSV in-process.
- The sheet has free-text item names, not the mod-struct ids `price_info_by_unique_mod_struct` already keys off of, so there's a hand-built `presearing_sheet_items` mapping table (verified row-for-row against a live pull of both tabs - 30/30 Runes and 31/31 Insignias matched; the one deliberate miss is "Heralds", which the sheet itself flags as not usable in pre-searing).
- Crossing the pre/post-searing boundary forces an immediate refetch so a cached quote from one side isn't shown on the other.
- Price cells using a unit we don't confidently understand (the sheet uses `g`/`k` for gold, but also an unexplained `BD` suffix) are left unparsed rather than guessed at - a wrong price is worse than a missing one.

## Not in scope / follow-up
- Only `Runes` and `Insignias` are wired up - the sheet also has `Consumables`, `Inscriptions`, `Minipets`, `Weapon Mods` tabs, but those don't map cleanly onto the existing id scheme (or don't apply to pre-searing) without more work.
- Someone from presearing.com could confirm what `BD` means so those cells can be parsed too.

## Test plan
- [ ] Build and confirm compiles clean (MSVC/Windows toolchain, not available in this environment)
- [ ] Verify prices update on entering/leaving pre-searing outposts, and that the Runes/Insignias tooltip prices roughly match what's shown on presearing.com/pricecheck