### PR TITLE
chore: remove slop comments across the codebase

### DIFF
--- a/Core/Event.h
+++ b/Core/Event.h
@@ -11,9 +11,8 @@ public:
 
     ~Event();
 
-    // If the event is auto resetting only 1 thread is released. Otherwise
-    // all waiting threads are released. In both cases the event is reset
-    // after this call.
+    // Releases 1 waiting thread if auto-resetting, otherwise all of them;
+    // either way the event is reset after this call.
     void Pulse() const;
 
     // If the event is created with the auto-reset flag enabled, only one
@@ -24,37 +23,23 @@ public:
     // is called. This function is only useful for events that are not auto-resetting.
     void Reset() const;
 
-    // Blocks until the event is set to done.
     void WaitUntilDone() const;
 
-    // Returns True if event is set done. False otherwise.
     bool WaitWithTimeout(uint32_t WaitMs) const;
 
-    // True if the event is set done. False otherwise.
     bool TryWait() const;
 
-    // Blocks until at least one event is set to done.
-    // You can wait on most "MAX_WAIT_OBJECTS".
+    // The static wait helpers below take at most "MAX_WAIT_OBJECTS" events.
     static void WaitAny(Event* Events, size_t Count, Event** EventSignaled);
 
-    // Blocks until all events are set to done.
-    // You can wait on most "MAX_WAIT_OBJECTS".
     static void WaitAll(Event* Events, size_t Count);
 
-    // Wait up to the requested msecs for at least one event to be set to done.
-    // You can wait on most "MAX_WAIT_OBJECTS".
     static bool WaitAnyWithTimeout(Event* Events, size_t Count, uint32_t WaitMs, Event** EventSignaled);
 
-    // Wait up to the requested msecs for all events to be set to done.
-    // You can wait on most "MAX_WAIT_OBJECTS".
     static bool WaitAllWithTimeout(const Event* Events, size_t Count, uint32_t WaitMs);
 
-    //  Check if at least one event is set to done.
-    // You can wait on most "MAX_WAIT_OBJECTS".
     static bool TryWaitAny(Event* Events, size_t Count, Event** EventSignaled);
 
-    // Check if all events are set to done.
-    // You can wait on most "MAX_WAIT_OBJECTS".
     static bool TryWaitAll(Event* Events, size_t Count);
 
 private:

--- a/Core/File.cpp
+++ b/Core/File.cpp
@@ -21,11 +21,8 @@ bool WriteEntireFile(const wchar_t* FilePath, const void* Content, size_t Length
     DWORD BytesWritten;
     auto Buffer = reinterpret_cast<const uint8_t*>(Content);
 
-    //
-    // We don't early quit, because there is a difference between writing a empty
-    // file and not writing the file at all. The file could already exist, in which
-    // case it would be "cleared" and if it doesn't exist, it would be created.
-    //
+    // No early quit on an empty Content: writing nothing still clears/creates the file,
+    // which isn't the same as not writing at all.
     while (Length != 0) {
         const size_t BytesToWrite = std::min<size_t>(Length, static_cast<DWORD>(-1));
         const DWORD dwBytesToWrite = BytesToWrite;

--- a/Core/Path.cpp
+++ b/Core/Path.cpp
@@ -67,7 +67,6 @@ bool PathCreateDirectorySafe(const fs::path& path)
         return false;
     }
     if (result) {
-        // Already a valid directory
         return true;
     }
     result = create_directories(path, errcode);
@@ -107,14 +106,12 @@ bool PathRecursiveRemove(const fs::path& from)
         return false;
     }
     if (!result) {
-        // Doesn't exist anyway
         return true;
     }
     if (!PathIsDirectorySafe(from, &result)) {
         return false;
     }
     if (result) {
-        // directory
         if (!PathDirectoryIteratorSafe(from, &it)) {
             return false;
         }
@@ -154,7 +151,6 @@ bool PathSafeCopy(const fs::path& from, const fs::path& to, const bool copy_if_t
         return false;
     }
     if (result) {
-        // directory
         if (!PathDirectoryIteratorSafe(from, &it)) {
             return false;
         }

--- a/Core/Path.h
+++ b/Core/Path.h
@@ -10,9 +10,7 @@ bool PathDirectoryIteratorSafe(const std::filesystem::path& path, std::filesyste
 // exists without catch; returns false on failure
 bool PathExistsSafe(const std::filesystem::path& path, bool* out);
 
-// Get absolute path of current running executable
 bool PathGetExeFullPath(std::filesystem::path& out);
-// Get basename of current running executable
 bool PathGetExeFileName(std::wstring& out);
 
 bool PathGetProgramDirectory(std::filesystem::path& out);

--- a/GWToolbox/Install.cpp
+++ b/GWToolbox/Install.cpp
@@ -191,7 +191,6 @@ bool Uninstall(const bool quiet, std::wstring& error)
     }
 
     if (DeleteAllFiles) {
-        // Delete all files
         DeleteInstallationDirectory(error);
     }
 

--- a/GWToolbox/Settings.cpp
+++ b/GWToolbox/Settings.cpp
@@ -128,7 +128,6 @@ void ParseCommandLine()
 
 bool IsRunningAsAdmin()
 {
-    // Allocate and initialize a SID of the administrators group.
     PSID AdministratorsGroup = nullptr;
     SID_IDENTIFIER_AUTHORITY NtAuthority = SECURITY_NT_AUTHORITY;
     if (!AllocateAndInitializeSid(
@@ -142,8 +141,6 @@ bool IsRunningAsAdmin()
         return false;
     }
 
-    // Determine whether the SID of administrators group is enabled in
-    // the primary access token of the process.
     BOOL IsRunAsAdmin = FALSE;
     if (!CheckTokenMembership(nullptr, AdministratorsGroup, &IsRunAsAdmin)) {
         FreeSid(AdministratorsGroup);

--- a/GWToolboxdll/CircurlarBuffer.h
+++ b/GWToolboxdll/CircurlarBuffer.h
@@ -45,7 +45,6 @@ struct CircularBuffer {
         return *this;
     }
 
-    // Iterator class for range-based for loops
     class Iterator {
     public:
         Iterator(CircularBuffer* buf, size_t index) : buffer(buf), current_index(index) {}
@@ -76,7 +75,6 @@ struct CircularBuffer {
         size_t current_index;
     };
 
-    // Const iterator class
     class ConstIterator {
     public:
         ConstIterator(const CircularBuffer* buf, size_t index) : buffer(buf), current_index(index) {}
@@ -107,7 +105,6 @@ struct CircularBuffer {
         size_t current_index;
     };
 
-    // Iterator access methods
     Iterator begin() { return Iterator(this, 0); }
 
     Iterator end() { return Iterator(this, count); }

--- a/GWToolboxdll/D3DContainers.cpp
+++ b/GWToolboxdll/D3DContainers.cpp
@@ -6,12 +6,10 @@
 #define M_PI 3.14159265358979323846f
 #endif
 
-// D3DVertex
 D3DVertex::D3DVertex(const float x, const float y, const float z, const DWORD color) : x(x), y(y), z(z), color(color) {}
 
 D3DVertex::D3DVertex(const float x, const float y, const DWORD color) : x(x), y(y), z(0.f), color(color) {}
 
-// D3DQuad
 D3DQuad::D3DQuad(const D3DVec2f& tl, const D3DVec2f& br, DWORD color)
 {
     const D3DVertex TL{tl.x, tl.y, color};
@@ -22,7 +20,6 @@ D3DQuad::D3DQuad(const D3DVec2f& tl, const D3DVec2f& br, DWORD color)
     t[1] = {TL, BR, BL};
 }
 
-// D3DLine
 D3DLine::D3DLine(const D3DVec2f& a, const D3DVec2f& b, float thickness, DWORD color)
 {
     const float dx = b.x - a.x;
@@ -38,7 +35,6 @@ D3DLine::D3DLine(const D3DVec2f& a, const D3DVec2f& b, float thickness, DWORD co
     t[1] = {TL, BR, BL};
 }
 
-// D3DDiamond
 D3DDiamond::D3DDiamond(const D3DVec2f& pos, float radius, DWORD color)
 {
     const D3DVertex top{pos.x, pos.y + radius, color};
@@ -49,7 +45,6 @@ D3DDiamond::D3DDiamond(const D3DVec2f& pos, float radius, DWORD color)
     t[1] = {top, bot, left};
 }
 
-// D3DVelocityArrow
 D3DVelocityArrow::D3DVelocityArrow(const D3DVec2f& pos, const D3DVec2f& velocity, float length, float half_width, DWORD color)
 {
     const float vlen_sq = velocity.x * velocity.x + velocity.y * velocity.y;
@@ -67,7 +62,6 @@ D3DVertexBuffer::~D3DVertexBuffer() {
     DEBUG_ASSERT(!buffer);
 }
 
-// D3DVertexBuffer
 void D3DVertexBuffer::Initialize(IDirect3DDevice9* device)
 {
     dirty = false;

--- a/GWToolboxdll/GWToolbox.cpp
+++ b/GWToolboxdll/GWToolbox.cpp
@@ -225,9 +225,7 @@ namespace {
 
     // All modules including widgets and windows
     std::vector<ToolboxModule*> modules_enabled{};
-    // Widgets
     std::vector<ToolboxWidget*> widgets_enabled{};
-    // Windows
     std::vector<ToolboxWindow*> windows_enabled{};
     // Modules that aren't widgets or windows
     std::vector<ToolboxModule*> other_modules_enabled{};
@@ -422,7 +420,6 @@ namespace {
     {
         const auto found = std::ranges::find(vec, &m);
         if (found != vec.end()) {
-            // Module found
             if (enable) {
                 return true;
             }
@@ -433,7 +430,6 @@ namespace {
             ReorderModules(vec);
             return false;
         }
-        // Module not found
         if (!enable) {
             return false;
         }
@@ -594,7 +590,6 @@ namespace {
             //}
             break;
 
-            // keyboard messages
             case WM_KEYUP:
             case WM_SYSKEYUP:
                 if (io.WantCaptureKeyboard || io.WantTextInput) {
@@ -620,7 +615,6 @@ namespace {
                     return true;
                 }
             case WM_ACTIVATE:
-                // send to toolbox modules and plugins
                 {
                     bool captured = false;
                     for (const auto m : tb.GetAllModules()) {
@@ -1085,7 +1079,6 @@ void GWToolbox::Update(GW::HookStatus*)
     // (minimized, device lost) and a map change during that window can't serve a stale index.
     PropSurface::BeginFrame();
 
-    // Update loop
     for (const auto m : modules_enabled) {
         if (profiling_enabled) {
             LARGE_INTEGER t0, t1;
@@ -1155,7 +1148,6 @@ void GWToolbox::Draw(IDirect3DDevice9* device)
         return;
     }
 
-    // Draw loop
     Resources::DxUpdate(device);
 
     if (!CanRenderToolbox()) return;
@@ -1248,7 +1240,6 @@ void GWToolbox::Draw(IDirect3DDevice9* device)
     // actually read the pixels out and save them to disk.
     ToolboxSettings::FlushPendingScreenshot(device);
 
-    // Update and Render additional Platform Windows
     if (io.ConfigFlags & ImGuiConfigFlags_ViewportsEnable) {
         ImGui::UpdatePlatformWindows();
         ImGui::RenderPlatformWindowsDefault();

--- a/GWToolboxdll/IRC.cpp
+++ b/GWToolboxdll/IRC.cpp
@@ -120,7 +120,6 @@ int IRC::start(const char* server, int port, const char* nick, const char* user,
     }
     ping_sent = 0;
 
-    //setup hints
     hints.ai_family = AF_UNSPEC;     //IPv4 or IPv6 doesnt matter
     hints.ai_socktype = SOCK_STREAM; //TCP stream socket
 
@@ -136,14 +135,12 @@ int IRC::start(const char* server, int port, const char* nick, const char* user,
         return 1;
     }
 
-    //setup socket
     if ((irc_socket = socket(servinfo->ai_family, servinfo->ai_socktype, servinfo->ai_protocol)) == INVALID_SOCKET) {
         printf("Failed to socket: %d\n", WSAGetLastError());
         return 1;
     }
     disconnect();
 
-    //Connect
     if (connect(irc_socket, servinfo->ai_addr, servinfo->ai_addrlen) == SOCKET_ERROR) {
         printf("Failed to connect: %d\n", WSAGetLastError());
         closesocket(irc_socket);
@@ -180,7 +177,6 @@ void IRC::disconnect()
     shutdown(irc_socket, 2);
 #endif
     closesocket(irc_socket);
-    // Destroy thread.
     pending_disconnect = true;
     if (t.joinable()) {
         t.join();

--- a/GWToolboxdll/ImGuiAddons.cpp
+++ b/GWToolboxdll/ImGuiAddons.cpp
@@ -49,7 +49,6 @@ namespace ImGui {
     {
         if ((col & IM_COL32_A_MASK) == 0) return;
 
-        // Calculate scale to fit within max dimensions while preserving aspect ratio
         float scale_x = max_width / size.x;
         float scale_y = max_height / size.y;
         float scale = (scale_x < scale_y) ? scale_x : scale_y;
@@ -173,7 +172,6 @@ namespace ImGui {
     {
         bool value_changed = false;
 
-        // Choose input function and flags based on whether we have a hint
         ImGuiInputTextFlags flags = (show_password  && *show_password) ? ImGuiInputTextFlags_None : ImGuiInputTextFlags_Password;
 
 
@@ -227,7 +225,6 @@ namespace ImGui {
         ImFont* font = ImGui::GetFont();
         const float size = ImGui::GetFontSize();
 
-        // Draw outline passes
         for (int dx = -1; dx <= 1; dx++) {
             for (int dy = -1; dy <= 1; dy++) {
                 if (dx == 0 && dy == 0) continue;
@@ -235,10 +232,8 @@ namespace ImGui {
             }
         }
 
-        // Draw foreground text
         dl->AddText(font, size, pos, ImGui::GetColorU32(ImGuiCol_Text), label);
 
-        // Advance cursor as normal
         ImGui::Dummy(ImGui::CalcTextSize(label));
     }
 
@@ -488,9 +483,7 @@ namespace ImGui {
                     || (c >= '0' && c <= '9')
                     || (c >= 'A' && c <= 'Z')
                     || (c >= 'a' && c <= 'z')) {
-                    // build temporary word
                     if (time_since_last_update < word_building_delay) {
-                        // append
                         const size_t i = strnlen(word, 64);
                         if (i + 1 < 64) {
                             word[i] = static_cast<char>(c);
@@ -498,7 +491,6 @@ namespace ImGui {
                         }
                     }
                     else {
-                        // reset
                         word[0] = static_cast<char>(c);
                         word[1] = '\0';
                     }
@@ -544,7 +536,6 @@ namespace ImGui {
             keyboard_selected_now = true;
         }
 
-        // Display items
         bool value_changed = false;
         for (auto i = 0; i < items_count; i++) {
             PushID(reinterpret_cast<void*>(i));
@@ -649,19 +640,14 @@ namespace ImGui {
         ImVec2 image_size;  // Final image size
         ImVec2 offset = { 0.0f, 0.0f };  // Offset for centering the image
 
-        // Check if texture is wider or taller in relation to the container
         if (texture_ratio > container_ratio) {
-            // The texture is wider, scale by container width
             image_size.x = size_of_container.x;
             image_size.y = size_of_container.x / texture_ratio;
-            // Center the image vertically
             offset.y = (size_of_container.y - image_size.y) * 0.5f;
         }
         else {
-            // The texture is taller, scale by container height
             image_size.y = size_of_container.y;
             image_size.x = size_of_container.y * texture_ratio;
-            // Center the image horizontally
             offset.x = (size_of_container.x - image_size.x) * 0.5f;
         }
 
@@ -728,7 +714,6 @@ namespace ImGui {
         return value_changed;
     }
 
-    // Store original positions of the windows
     std::unordered_map<std::string_view, ImVec2> original_positions;
 
     void ClampWindowToScreen(ImGuiWindow* window)
@@ -739,28 +724,23 @@ namespace ImGui {
         const ImVec2 display_size = viewport->Size; // Get the display size
         const std::string_view window_name = window->Name;      // Get the window name
 
-        // Check if the window position needs to be clamped based on the original position if available
         const ImVec2 original_pos = original_positions.contains(window_name) ? original_positions[window_name] : window_pos;
 
-        // Determine if clamping is needed
         const bool needs_clamping = original_pos.x + window_size.x > display_size.x ||
                                     original_pos.y + window_size.y > display_size.y ||
                                     original_pos.x < 0 ||
                                     original_pos.y < 0;
 
         if (needs_clamping) {
-            // Save the original position if not already saved
             if (!original_positions.contains(window_name)) {
                 original_positions[window_name] = window_pos;
             }
 
-            // Clamp window position to ensure the entire content is on screen
             if (window_pos.x + window_size.x > display_size.x) window_pos.x = display_size.x - window_size.x;
             if (window_pos.x < 0) window_pos.x = 0;
             if (window_pos.y + window_size.y > display_size.y) window_pos.y = display_size.y - window_size.y;
             if (window_pos.y < 0) window_pos.y = 0;
 
-            // Set the new window position
             ImGui::SetWindowPos(window, window_pos, ImGuiCond_Always);
             if (window->Collapsed) {
                 original_positions[window_name] = window_pos;

--- a/GWToolboxdll/Logger.h
+++ b/GWToolboxdll/Logger.h
@@ -31,7 +31,6 @@ namespace Log {
     // printf-style wide-string log
     GWTOOLBOXDLL_EXPORT void LogW(const wchar_t* msg, ...);
 
-    // flushes log file.
     GWTOOLBOXDLL_EXPORT void FlushFile();
 
     // === Game chat logging ===

--- a/GWToolboxdll/MinimapPlugin.h
+++ b/GWToolboxdll/MinimapPlugin.h
@@ -15,19 +15,15 @@ class D3DVertexBuffer;
 #  endif
 #endif
 
-// Context structure that encapsulates all rendering parameters
 struct MinimapRenderContext : RectF {
-    // Position and size
     ImVec2 anchor_point = {}; // Center of minimap - this may not necessarily be the center point of the clipping rect
 
-    // Camera/view parameters
     GW::Vec2f translation = {}; // World-space translation (for panning)
     float zoom_scale = 1.f; // Zoom level (scale factor)
     float rotation = 1.5708f; // Map rotation in radians
 
     float base_scale = 1.f; // The size (in px) of the base scale to use before zooming. Minimap sets this to size.x
 
-    // Visual options
     bool circular_map = false; // Whether to render as circle or square
     bool draw_center_marker = false; // Whether to draw center marker when panned
     D3DCOLOR background_color = D3DCOLOR_ARGB(50, 0, 0, 0); // Background color (or 0 to use renderer's default)

--- a/GWToolboxdll/Modules/AudioSettings.cpp
+++ b/GWToolboxdll/Modules/AudioSettings.cpp
@@ -87,7 +87,6 @@ struct MusicData {
 
     bool force_play_sound = false;
 
-    // Helper function to handle common logic
     template <typename CallbackMap>
     GW::RecObject* PlayAudioInternal(wchar_t* filename, SoundProps* props, CallbackMap& callbacks, PlaySound_pt ret_func)
     {
@@ -95,12 +94,10 @@ struct MusicData {
         GW::RecObject* ret = nullptr;
         GW::HookStatus status;
 
-        // Execute callbacks
         for (auto& [_, cb] : callbacks) {
             cb(&status, filename, props);
         }
 
-        // Check if sound should be played
         if (!status.blocked) {
             if (!force_play_sound) {
                 bool found = std::ranges::find(blocked_sounds, filename) != blocked_sounds.end();
@@ -123,7 +120,6 @@ struct MusicData {
     GW::RecObject* OnPlaySound(wchar_t* filename, SoundProps* props)
     {
         auto handle = PlayAudioInternal(filename, props, play_sound_callbacks, PlaySound_Ret);
-        // Log sound if enabled
         if (log_sounds && std::ranges::find(logged_sounds, filename) == logged_sounds.end()) {
             logged_sounds.push_back(filename);
         }

--- a/GWToolboxdll/Modules/BackupModule.cpp
+++ b/GWToolboxdll/Modules/BackupModule.cpp
@@ -194,7 +194,6 @@ namespace {
                 continue;
             }
 
-            // Seek to local file header.
             fseek(f, static_cast<long>(local_off), SEEK_SET);
             uint32_t local_sig;
             if (!r32(f, local_sig) || local_sig != 0x04034B50u) {
@@ -281,7 +280,6 @@ namespace {
         return false;
     }
 
-    // Read a file in binary mode into a byte vector.
     static bool read_binary(const std::filesystem::path& path, std::vector<uint8_t>& out)
     {
         FILE* f = _wfopen(path.c_str(), L"rb");

--- a/GWToolboxdll/Modules/CameraUnlockModule.cpp
+++ b/GWToolboxdll/Modules/CameraUnlockModule.cpp
@@ -54,15 +54,9 @@ namespace {
         GW::Hook::LeaveHook();
     }
 
-    // Fix for a vanilla GW freeze: dying in first-person and then resurrecting can leave
-    // the camera's pitch_to_go as NaN (the death-orbit -> follow-cam transition clamps
-    // pitch against the wrong limits and pushes it out of its valid [-1,1] range). That
-    // NaN eases into pitch and then into the eye position; the game's terrain
-    // line-of-sight ray-march (Gw.exe @0x0070eb40) only exits on an *ordered* float
-    // compare, so a NaN coordinate makes it loop forever and the render thread hangs
-    // (recoverable only by dying again). We hook the per-frame "get camera eye" routine
-    // (Gw.exe @0x004f7b80, which asserts "*fov != 0.0f") and clamp pitch/pitch_to_go back
-    // into [-1,1] (mapping NaN -> 0) before the renderer and ray-march read the camera.
+    // Vanilla GW freeze fix: resurrecting after a first-person death can leave pitch/pitch_to_go NaN, which
+    // reaches the eye position and hangs the terrain ray-march (Gw.exe @0x0070eb40, ordered float compare only).
+    // Hook the per-frame get-camera-eye (Gw.exe @0x004f7b80) and clamp pitch back into [-1,1] (NaN -> 0).
     typedef void(__fastcall* GetCameraEye_pt)(void* cam, void* edx, uint32_t flag, void* out_pos, void* out_look, void* out_fov);
     GetCameraEye_pt GetCameraEye_Func = nullptr, GetCameraEye_Ret = nullptr;
 

--- a/GWToolboxdll/Modules/CartographerModule.cpp
+++ b/GWToolboxdll/Modules/CartographerModule.cpp
@@ -417,9 +417,6 @@ namespace {
     // Returns -1 when the map has no walkable ground anywhere near it.
     float MeasureCellReach(const int cx, const int cy)
     {
-        // Cheap pass first: if any part of the cell is standable, the answer is zero and no
-        // expensive search is needed. Only cells with no footing at all pay for the full
-        // nearest-ground lookup, and then just once.
         // Cheap pass: if any part of the cell is standable the answer is zero, no search needed.
         constexpr int kSamples = 4;
         for (int sy = 0; sy < kSamples; sy++) {
@@ -432,10 +429,8 @@ namespace {
                 if (WorldMapWidget::WorldMapToGamePos(wm, gp) && Pathing::IsPositionWalkable(gp)) return 0.f;
             }
         }
-        // No footing inside it, so find how far away the nearest is. Measured from several
-        // points across the cell, not just the middle: ground beside one corner is what you
-        // would actually walk to, and judging by the midpoint alone reports it as further away
-        // than it is and wrongly writes the cell off.
+        // No footing inside it: probe several points across the cell, not just the midpoint, which
+        // would report ground beside a corner as further away than you would actually walk.
         const GW::Vec2f probes[5] = {
             CellCenterWorldMap(cx, cy),
             {(cx + 0.1f) * kWorldMapUnitsPerCell, (cy + 0.1f) * kWorldMapUnitsPerCell},

--- a/GWToolboxdll/Modules/ChatCommands.cpp
+++ b/GWToolboxdll/Modules/ChatCommands.cpp
@@ -163,7 +163,6 @@ namespace {
 
     void TargetVipers()
     {
-        // target best vipers target (closest)
         GW::AgentArray* agents = GW::Agents::GetAgentArray();
         const GW::Agent* me = agents ? GW::Agents::GetControlledCharacter() : nullptr;
         if (me == nullptr) {
@@ -559,7 +558,6 @@ namespace {
     {
         const auto pref = static_cast<GW::UI::NumberPreference>(pref_id);
 
-        // Find value and set preference
         uint32_t value = 0xff;
         if (argc > 2 && TextUtils::ParseUInt(argv[2], &value)) {
             GW::GameThread::Enqueue([pref, value, pref_str = std::wstring(argv[1])] {
@@ -570,7 +568,6 @@ namespace {
             return;
         }
 
-        // Print current value
         if (argc < 3) {
             Log::InfoW(L"Current preference value for %s is %d", argv[1], GetPreference(pref));
         }
@@ -583,7 +580,6 @@ namespace {
     {
         const auto pref = static_cast<GW::UI::EnumPreference>(pref_id);
 
-        // Find value and set preference
         uint32_t value = 0xff;
         if (argc > 2 && TextUtils::ParseUInt(argv[2], &value)) {
             GW::GameThread::Enqueue([pref, value, pref_str = std::wstring(argv[1])] {
@@ -594,12 +590,10 @@ namespace {
             return;
         }
 
-        // Print current value
         if (argc < 3) {
             Log::InfoW(L"Current preference value for %s is %d", argv[1], GetPreference(pref));
         }
 
-        // Got this far; print out available values for this preference.
         uint32_t* values = nullptr;
         const auto available = GetPreferenceOptions(pref, &values);
         wchar_t available_vals_buffer[120];
@@ -618,7 +612,6 @@ namespace {
         const auto pref = static_cast<GW::UI::FlagPreference>(pref_id);
 
         if (argc > 2) {
-            // Setting value
             if (wcscmp(argv[2], L"toggle") == 0) {
                 SetPreference(pref, !GetPreference(pref));
                 return;
@@ -629,7 +622,6 @@ namespace {
             }
             return;
         }
-        // Print current value
         Log::InfoW(L"Current preference value for %s is %d", argv[1], GetPreference(pref));
     }
 
@@ -805,7 +797,6 @@ namespace {
 
         // Searching by name; offload this to decode agent names first.
         if (TextUtils::ParseUInt(model_id_or_name, &model_id)) {
-            // check if there's an index component
             if (const wchar_t* rest = GetRemainingArgsWstr(model_id_or_name, 1)) {
                 TextUtils::ParseUInt(rest, &index);
             }
@@ -817,7 +808,6 @@ namespace {
             }
         }
 
-        // target nearest agent
         const auto agents = GW::Agents::GetAgentArray();
         const auto me = agents ? GW::Agents::GetControlledCharacter() : nullptr;
         if (me == nullptr) {
@@ -832,7 +822,6 @@ namespace {
             if (agent == me || !GW::Agents::GetAgentMatchesFlags(agent, type)) continue;
             if (model_id && GetAgentModelId(agent) != model_id) continue;
             if (index == 0) {
-                // target closest
                 const float new_distance = GetSquareDistance(me->pos, agent->pos);
                 if (new_distance < distance) {
                     closest = agent->agent_id;
@@ -840,7 +829,6 @@ namespace {
                 }
             }
             else {
-                // target based on id
                 ++count;
                 if (count == index) {
                     closest = agent->agent_id;
@@ -872,7 +860,6 @@ namespace {
         GW::WorldContext* w = GW::GetWorldContext();
         GW::HeroFlagArray* flags = w ? &w->hero_flags : nullptr;
         if (!flags) return;
-        // Argument validation
         if (argc < 2) {
             return Log::Warning(CmdHeroBehaviour_syntax);
         }
@@ -887,7 +874,6 @@ namespace {
             effective_argc--;
         }
 
-        // set behavior based on command message
         auto behaviour = 0xff;
         const std::wstring arg1 = TextUtils::ToLower(argv[1]);
         if (arg1 == L"avoid") {
@@ -2193,7 +2179,6 @@ void SearchAgent::Update()
             return; // Not all decoded yet
         }
     }
-    // Do search
     float distance = GW::Constants::SqrRange::Compass;
     size_t closest = 0;
     const auto me = GW::Agents::GetControlledCharacter();
@@ -2647,7 +2632,6 @@ void CHAT_CMD_FUNC(ChatCommands::CmdToggle)
     }
     if (equipment_slot != GW::EquipmentType::Unknown) {
         GW::EquipmentStatus state = GW::Items::GetEquipmentVisibility(equipment_slot);
-        // Toggling visibility of equipment
         switch (action) {
             case On:
                 state = GW::EquipmentStatus::AlwaysShow;
@@ -2767,7 +2751,6 @@ void CHAT_CMD_FUNC(ChatCommands::CmdPingBuild)
         std::string content;
         if (!Resources::ReadFile(build_file, content)) return;
 
-        // If template file does not exist, skip
         GW::SkillbarMgr::SkillTemplate skill_template{};
         if (!DecodeSkillTemplate(skill_template, content.c_str())) {
             continue;

--- a/GWToolboxdll/Modules/ChatFilter.cpp
+++ b/GWToolboxdll/Modules/ChatFilter.cpp
@@ -44,7 +44,6 @@ namespace {
     // It can be re-ajusted to be more enjoyable.
     constexpr uint32_t NOISE_REDUCTION_DELAY_MS = 1000;
 
-    // Chat filter
     using Pattern = TextUtils::SearchPattern<wchar_t>;
 
     std::vector<Pattern> bycontent_words;
@@ -563,7 +562,6 @@ namespace {
         return false;
     }
 
-    // Should this message be ignored by content?
     // Check programmatic suppressions (e.g. /hero silent) — not gated by channel filter
     bool IsSuppressedMessage(const wchar_t* message)
     {

--- a/GWToolboxdll/Modules/ChatSettings.cpp
+++ b/GWToolboxdll/Modules/ChatSettings.cpp
@@ -23,7 +23,6 @@
 #include <GWCA/Utilities/MemoryPatcher.h>
 
 namespace {
-    // Settings
     ChatSettings::Settings settings;
 
     GW::MemoryPatcher bypass_chat_codepage_limitation;
@@ -54,7 +53,6 @@ namespace {
     std::map<std::wstring, GW::Chat::Color> chat_token_colors;
 
 
-    // Runtime
     bool ctrl_enter_whisper = false;
     std::wstring afk_message;
     clock_t afk_message_time = 0;
@@ -97,7 +95,6 @@ namespace {
     wchar_t* OnColorHexOrLabelToColor(wchar_t* token, GW::Chat::Color* color_out, uint32_t color_out_len) {
         GW::Hook::EnterHook();
         if (token && *token == L'@' && color_out_len == 1) {
-            // Replace
             const auto out = wcschr(token, L'>');
             const std::wstring token_label(&token[1], out);
             if (chat_token_colors.contains(token_label)) {
@@ -366,7 +363,6 @@ namespace {
                     settings.show_timestamps = packet->new_value ? true : false;
             } break;
             case GW::UI::UIMessage::kPreferenceValueChanged: {
-                // Remember user setting for chat timestamps
                 const auto packet = static_cast<GW::UI::UIPacket::kPreferenceValueChanged*>(wParam);
                 if (settings.clear_chat_message_when_hiding_chat && packet->preference_id == GW::UI::NumberPreference::ChatState && packet->new_value == 0) {
                     const auto frame = (GW::EditableTextFrame*)GW::UI::GetFrameByLabel(L"EditMessage");

--- a/GWToolboxdll/Modules/CrashHandler.cpp
+++ b/GWToolboxdll/Modules/CrashHandler.cpp
@@ -84,7 +84,6 @@ namespace {
 
         auto pContext = reinterpret_cast<PCONTEXT>(param_4);
 
-        // Create EXCEPTION_POINTERS structure
         EXCEPTION_RECORD exceptionRecord = {0};
         EXCEPTION_POINTERS exceptionPointers = {nullptr};
 
@@ -99,13 +98,11 @@ namespace {
             }
         }
 
-        // Fill in exception record with info from CONTEXT
         exceptionRecord.ExceptionCode = exception_code;
         exceptionRecord.ExceptionFlags = EXCEPTION_NONCONTINUABLE;
         exceptionRecord.ExceptionAddress = reinterpret_cast<PVOID>(pContext->Eip);
         exceptionRecord.NumberParameters = 0;
 
-        // Set up exception pointers
         exceptionPointers.ExceptionRecord = &exceptionRecord;
         exceptionPointers.ContextRecord = pContext;
 
@@ -269,8 +266,7 @@ void CrashHandler::FatalAssert(const char* expr, const char* file, const unsigne
 
         throw std::runtime_error(tb_exception_message);
     } __except (EXCEPT_EXPRESSION_ENTRY) {
-        // The Crash() function should have terminated the process
-        // If we somehow get here, force termination
+        // Crash() should already have terminated the process; force it if not.
         TerminateProcess(GetCurrentProcess(), 1);
     }
 

--- a/GWToolboxdll/Modules/DialogModule.cpp
+++ b/GWToolboxdll/Modules/DialogModule.cpp
@@ -71,7 +71,6 @@ namespace {
         }
     }
 
-    // Wipe dialog ready for new one
     void ResetDialog()
     {
         for (const auto d : dialog_buttons) {
@@ -370,7 +369,6 @@ uint32_t DialogModule::AcceptFirstAvailableQuest()
         if (!IsQuest(dialog_id)) {
             continue;
         }
-        // Quest related dialog
         uint32_t quest_id = GetQuestID(dialog_id);
         switch (GetQuestDialogType(dialog_id)) {
             case QuestDialogType::TAKE:

--- a/GWToolboxdll/Modules/DiscordModule.cpp
+++ b/GWToolboxdll/Modules/DiscordModule.cpp
@@ -197,10 +197,8 @@ namespace {
     IDiscordNetworkEvents network_events{};
     IDiscordCoreEvents core_events{};
 
-    // setting vars
     DiscordModule::Settings settings;
 
-    // runtime vars
     bool discord_connected = false;
     time_t zone_entered_time = 0;
     bool pending_activity_update = false;
@@ -256,7 +254,6 @@ namespace {
         Log::Log("Discord Log Level %d: %s\n", level, message);
     }
 
-    // Get pid from executable name (i.e. DiscordCanary.exe)
     DWORD GetProcId(const char* ProcName)
     {
         PROCESSENTRY32 pe32;
@@ -430,7 +427,6 @@ namespace {
             return false;
         }
 
-        // resolve function address here
         discordCreate = (DiscordCreate_pt)(uintptr_t)GetProcAddress(hGetProcIDDLL, "DiscordCreate");
         if (!discordCreate) {
             ASSERT(UnloadDll());
@@ -662,7 +658,6 @@ namespace {
             }
         }
         if (memcmp(&last_activity, &activity, sizeof(last_activity)) != 0) {
-            // Only update if activity is new.
             last_activity_update = time(nullptr);
             if (show_activity) {
                 Log::Log("Outgoing discord state = %s, %s\n", activity.details, activity.state);
@@ -698,7 +693,6 @@ void DiscordModule::Initialize()
 
     strcpy(activity.name, "Guild Wars");
     activity.application_id = DISCORD_APP_ID;
-    // Initialise discord objects
     memset(&app, 0, sizeof(app));
     memset(&activities_events, 0, sizeof(activities_events));
     memset(&network_events, 0, sizeof(network_events));

--- a/GWToolboxdll/Modules/GameSettings.cpp
+++ b/GWToolboxdll/Modules/GameSettings.cpp
@@ -520,13 +520,11 @@ namespace {
         const GW::Player* next_player = nullptr;
         const GW::AgentLiving* me = GW::Agents::GetControlledCharacter();
         if (!me) {
-            // Can't find myself
             Log::Error("Failed to find me");
             return pending_reinvite.reset();
         }
         GW::PartyInfo* party = GW::PartyMgr::GetPartyInfo();
         if (!party || !party->players.valid()) {
-            // Can't find party
             Log::Error("Failed to find party");
             return pending_reinvite.reset();
         }
@@ -1127,10 +1125,8 @@ namespace {
         if (!(sign_btn && sign_btn->IsVisible() && sign_btn->IsDisabled())) return; // If sign button isn't visible, the player doesn't have enough faction
         const auto name_input = static_cast<GW::EditableTextFrame*>(GW::UI::GetChildFrame(frame, 4, 2));
         if (!name_input) return;
-        // Prefill and hide the name input
         name_input->SetValue(GW::PlayerMgr::GetPlayerName());
         GW::UI::SetFrameVisible(name_input, false);
-        // Show and enable the "Sign" button
         GW::UI::SetFrameDisabled(sign_btn, false);
     }
 
@@ -1163,7 +1159,6 @@ namespace {
     {
         uint32_t level = 1; // This is correct - start at 0
         while (XpReqForLevel(level + 1) <= currentXp) {
-            // Check next level
             level++;
         }
         return level; // 1 Based
@@ -2471,7 +2466,6 @@ void GameSettings::OnWriteChat(GW::HookStatus* status, GW::UI::UIMessage, void* 
     lstrcpyW(ptr, file_path.c_str());
     GlobalUnlock(hGlobal);
 
-    // prepare the clipboard
     OpenClipboard(nullptr);
     EmptyClipboard();
     SetClipboardData(CF_HDROP, hGlobal);

--- a/GWToolboxdll/Modules/GameSettings.h
+++ b/GWToolboxdll/Modules/GameSettings.h
@@ -183,7 +183,6 @@ public:
     void Update(float delta) override;
     bool WndProc(UINT Message, WPARAM wParam, LPARAM lParam) override;
 
-    // callback functions
     static void OnPingWeaponSet(GW::HookStatus*, GW::UI::UIMessage, void*, void*);
     static void OnAgentLoopingAnimation(GW::HookStatus*, const GW::Packet::StoC::GenericValue*);
     static void OnAgentMarker(GW::HookStatus* status, GW::Packet::StoC::GenericValue* pak);

--- a/GWToolboxdll/Modules/GamepadModule.cpp
+++ b/GWToolboxdll/Modules/GamepadModule.cpp
@@ -66,7 +66,6 @@ bool GamepadModule::GetGamepadState(_XINPUT_GAMEPAD* gamepad)
     memset(&state, 0, sizeof(XINPUT_STATE));
     bool success = false;
 
-    // Check all 4 possible controllers
     for (DWORD i = 0; i < XUSER_MAX_COUNT; i++) {
         if (!(XInputGetState_Func && XInputGetState_Func(i, &state) == ERROR_SUCCESS)) continue;
         if (!success) {
@@ -114,7 +113,6 @@ void GamepadModule::Update(float delta)
         XINPUT_GAMEPAD_A_HELD = 0;
     }
     if (XINPUT_GAMEPAD_A_HELD && TIMER_DIFF(XINPUT_GAMEPAD_A_HELD) > 500) {
-        // A button held for more than 500ms
         const LPARAM mouse_lparam = MAKELPARAM(static_cast<int>(gamepad_cursor_pos_client.x), static_cast<int>(gamepad_cursor_pos_client.y));
         auto hwnd = GW::MemoryMgr::GetGWWindowHandle();
         SendMessage(hwnd, WM_GW_RBUTTONCLICK, 0, mouse_lparam);
@@ -128,9 +126,7 @@ void GamepadModule::Update(float delta)
         const auto prev_buttons_held = prev_state.wButtons;
         if (current_buttons_held != prev_buttons_held) {
             if ((current_buttons_held & XINPUT_GAMEPAD_A) != (prev_buttons_held & XINPUT_GAMEPAD_A)) {
-                // A Button state changed
                 if ((current_buttons_held & XINPUT_GAMEPAD_A)) {
-                    // A Button pressed
                     if (!XINPUT_GAMEPAD_A_HELD) {
                         XINPUT_GAMEPAD_A_HELD = TIMER_INIT();
                     }

--- a/GWToolboxdll/Modules/GuildWarsSettingsModule.cpp
+++ b/GWToolboxdll/Modules/GuildWarsSettingsModule.cpp
@@ -241,7 +241,6 @@ namespace {
         RECT gw_window_pos = { 0 };
     };
 
-    // Read preferences from in-game memory to a PreferencesStruct
     void GetPreferences(PreferencesStruct& out)
     {
         out.preference_values.resize(std::to_underlying(GW::UI::NumberPreference::Count), 0);
@@ -267,7 +266,7 @@ namespace {
         ASSERT(GetWindowRect(GW::MemoryMgr::GetGWWindowHandle(), &out.gw_window_pos));
     }
 
-    // Write preferences to the game from a PreferencesStruct. Run this on the game thread.
+    // Run this on the game thread.
     void SetPreferences(PreferencesStruct& in)
     {
         for (auto i = 0u; i < in.preference_values.size() && i < std::to_underlying(GW::UI::NumberPreference::Count); i++) {
@@ -296,7 +295,6 @@ namespace {
         }
     }
 
-    // Read preferences from an ini file to a PreferencesStruct
     void LoadPreferences(PreferencesStruct& prefs, const ToolboxIni& ini)
     {
         GetPreferences(prefs); // Use current settings as a default
@@ -334,7 +332,6 @@ namespace {
         prefs.gw_window_pos.bottom = ini.GetLongValue(ini_label_windows, "gw_window_bottom", 0);
     }
 
-    // Read preferences from a JSON preset to a PreferencesStruct
     void LoadPreferences(PreferencesStruct& prefs, const guild_wars_settings_json::PreferencesJson& json)
     {
         GetPreferences(prefs); // Use current settings as a default
@@ -365,7 +362,6 @@ namespace {
         prefs.gw_window_pos = {json.gw_window_left, json.gw_window_top, json.gw_window_right, json.gw_window_bottom};
     }
 
-    // Write preferences from a PreferencesStruct to a JSON preset
     void SavePreferences(const PreferencesStruct& prefs, guild_wars_settings_json::PreferencesJson& json)
     {
         for (size_t key = 0; key < prefs.preference_values.size(); key++) {
@@ -519,7 +515,6 @@ namespace {
             return false;
         IUnknown* dxvkInterface = nullptr;
 
-        // Use the locally defined GUID
         HRESULT hr = d3d9Device->QueryInterface(interface_iid, (void**)&dxvkInterface);
 
         if (SUCCEEDED(hr)) {
@@ -527,7 +522,6 @@ namespace {
             return true;
         }
 
-        // The device does not support the DXVK-specific interface.
         return false;
     }
 
@@ -544,7 +538,6 @@ namespace {
             return false;
         }
 
-        // Extract the base name using std::filesystem::path directly
         baseName = std::filesystem::path(dllPath).filename().string();
 
         DWORD dummy;
@@ -566,7 +559,6 @@ namespace {
         if (VerQueryValueA(versionInfo, "\\VarFileInfo\\Translation", &langCodepageInfo, &langCodepageSize)) {
             DWORD* langCodepage = static_cast<DWORD*>(langCodepageInfo);
 
-            // Get Product Name
             char nameQueryPath[256];
             snprintf(nameQueryPath, sizeof(nameQueryPath) / sizeof(nameQueryPath[0]), "\\StringFileInfo\\%04X%04X\\ProductName", LOWORD(*langCodepage), HIWORD(*langCodepage));
 
@@ -577,7 +569,6 @@ namespace {
                 productName.assign(static_cast<const char*>(productNameValue), productNameValueSize - 1);  // Exclude the null terminator
             }
 
-            // Get Product Version
             char versionQueryPath[256];
             snprintf(versionQueryPath, sizeof(versionQueryPath) / sizeof(versionQueryPath[0]), "\\StringFileInfo\\%04X%04X\\ProductVersion", LOWORD(*langCodepage), HIWORD(*langCodepage));
 

--- a/GWToolboxdll/Modules/GuildWarsUI_ToolboxSettings.cpp
+++ b/GWToolboxdll/Modules/GuildWarsUI_ToolboxSettings.cpp
@@ -23,19 +23,16 @@ namespace {
 
     bool waiting_for_login = true;
 
-    // Self-test for the close-then-reopen crash (P:\Code\Engine\Controls\CtlPage.cpp(558),
-    // assertion "btnFrame") - reproduces it automatically instead of needing a manual repro each
-    // build. See GuildWarsUIFrame.cpp's CreateNativeFrame comment for the fix under test.
+    // Self-test for the close-then-reopen crash (CtlPage.cpp(558), assertion "btnFrame"); see
+    // GuildWarsUIFrame.cpp's CreateNativeFrame comment for the fix under test.
     bool opened_once = false;
     bool closed_once = false;
     bool reopened_once = false;
     clock_t opened_at = 0;
     clock_t closed_at = 0;
 
-    // Diagnostic only: logs every native UI component creation while active, so we can compare
-    // what tab_index values GW's own real tabs (General/Graphics/...) use against ours (255/0xff)
-    // right up to the point of the reopen crash - the crash dump alone doesn't show this since the
-    // fault is inside the engine's own tab-button refresh code, not anything of ours on the stack.
+    // Diagnostic only: logs native UI component creations to compare GW's own tab_index values
+    // against ours (255/0xff) up to the reopen crash, which the crash dump alone doesn't show.
     bool log_create_ui = false;
     GW::HookEntry create_ui_hook;
 }
@@ -65,14 +62,8 @@ void GuildWarsUI_ToolboxSettings::Initialize()
 
 void GuildWarsUI_ToolboxSettings::Update(float)
 {
-    // Tried triggering this off kFrameVisibilityChanged instead of polling (GW::UI::
-    // RegisterFrameUIMessageCallback) - froze the game on opening Options. That hook fires for
-    // *every* frame in the game receiving the message, not just Options (confirmed via GWCA's own
-    // implementation, Source/UIMgr.cpp ~2191) - opening a window cascades visibility changes across
-    // dozens of children near-simultaneously, and our handler's GetOptionsTabs() walks Options'
-    // relation.children right as the engine may be mid-mutation of that same list from its own
-    // window-open cascade. Reverted to polling rather than chasing the exact reentrant mechanism
-    // further - Poll() itself already throttles and no-ops once active, so this is cheap.
+    // Poll rather than hook kFrameVisibilityChanged: that fires for every frame, and walking
+    // Options' relation.children mid open-cascade froze the game. Poll() throttles anyway.
     settings_tab.Poll(GetOptionsTabs());
 }
 
@@ -81,12 +72,8 @@ void GuildWarsUI_ToolboxSettings::SignalTerminate()
     ToolboxModule::SignalTerminate();
     terminating = true;
     GW::GameThread::Enqueue([]() {
-        // Close the Options window first if our tab is still showing under it - removing/destroying
-        // our tab while its parent window is open and visible leaves the TabsFrame mid-cascade for
-        // that same window (the same class of reentrancy that caused the kSetLayout freeze earlier
-        // in this file's history). Destroying the whole window first (see WorldMapWidget.cpp's
-        // TriggerWorldMapRedraw for the same DestroyUIComponent pattern) forces a clean teardown
-        // path before we touch our own tab at all.
+        // Destroy the visible Options window before removing our tab: pulling the tab out of a
+        // live TabsFrame leaves it mid-cascade (same reentrancy as the earlier kSetLayout freeze).
         if (settings_tab.IsActive()) {
             if (const auto options_frame = GW::UI::GetFrameByLabel(L"Options")) {
                 GW::UI::DestroyUIComponent(options_frame);
@@ -98,12 +85,7 @@ void GuildWarsUI_ToolboxSettings::SignalTerminate()
 
 bool GuildWarsUI_ToolboxSettings::CanTerminate()
 {
-    // Not blocking anything until SignalTerminate has actually been called (matches the original
-    // !terminating check for that case). Once it has, block DLL unload until our tab's native
-    // frame has genuinely been torn down - Remove() above only *requests* removal (TabsFrame::
-    // RemoveTab); the actual destruction, and our own kDestroyFrame handler nulling GuildWarsUI_
-    // Tab::frame (see HandleMessage), can lag a poll or two behind. Unloading before then leaves
-    // the engine holding a callback pointer (ItemCallback) into memory that's about to become
-    // invalid.
+    // Remove() only *requests* removal; the native frame teardown can lag a poll or two, and
+    // unloading before it completes leaves the engine holding our ItemCallback pointer.
     return !terminating || !settings_tab.IsActive();
 }

--- a/GWToolboxdll/Modules/GwDatModule.cpp
+++ b/GWToolboxdll/Modules/GwDatModule.cpp
@@ -200,7 +200,6 @@ namespace {
         return true;
     }
 
-    // Decodes file_id and converts it to greyscale A8R8G8B8 in place.
     bool DecodeGreyscaleToArgb(uint32_t file_id, std::vector<uint32_t>& argb, Vec2i& dims)
     {
         if (!file_id || !DecodeTextureToArgb(file_id, argb, dims) || !dims.x || !dims.y)

--- a/GWToolboxdll/Modules/HallOfMonumentsModule.h
+++ b/GWToolboxdll/Modules/HallOfMonumentsModule.h
@@ -256,7 +256,6 @@ struct HallOfMonumentsAchievements {
     uint32_t resilience_points[static_cast<size_t>(ResiliencePoints::Count)] = {0};
     // Total sum of armors dedicated
     uint32_t resilience_tally = 0;
-    // Total sum of points achieved in resilience
     uint32_t resilience_points_total = 0;
 
     // Details of which companions have or haven't been dedicated, indexed by FellowshipDetail
@@ -265,7 +264,6 @@ struct HallOfMonumentsAchievements {
     uint32_t fellowship_points[static_cast<size_t>(FellowshipPoints::Count)] = {0};
     // Total sum of companions dedicated
     uint32_t fellowship_tally = 0;
-    // Total sum of points achieved in fellowship
     uint32_t fellowship_points_total = 0;
 
     // Details of which titles have or haven't been dedicated, indexed by HonorDetail
@@ -274,7 +272,6 @@ struct HallOfMonumentsAchievements {
     uint32_t honor_points[static_cast<size_t>(HonorPoints::Count)] = {0};
     // Total sum of titles dedicated
     uint32_t honor_tally = 0;
-    // Total sum of points achieved in honor
     uint32_t honor_points_total = 0;
 
     // Details of which weapons have or haven't been dedicated, indexed by ValorDetail
@@ -283,7 +280,6 @@ struct HallOfMonumentsAchievements {
     uint32_t valor_points[static_cast<size_t>(ValorPoints::Count)] = {0};
     // Total sum of weapons dedicated
     uint32_t valor_tally = 0;
-    // Total sum of points achieved in valor
     uint32_t valor_points_total = 0;
 
     // Details of how many different types of minipet have or haven't been dedicated, indexed by DevotionDetail
@@ -292,7 +288,6 @@ struct HallOfMonumentsAchievements {
     uint32_t devotion_points[static_cast<size_t>(DevotionPoints::Count)] = {0};
     // Total sum of minipets dedicated
     uint32_t devotion_tally = 0;
-    // Total sum of points achieved in devotion
     uint32_t devotion_points_total = 0;
 };
 
@@ -333,6 +328,5 @@ public:
     static bool DecodeHomCode(const char* in, HallOfMonumentsAchievements* out);
     // Decode a zero terminated base64 encoded hom code
     static bool DecodeHomCode(HallOfMonumentsAchievements* out);
-    // Get the account achievements for the current player
     static void AsyncGetAccountAchievements(const std::wstring& character_name, HallOfMonumentsAchievements* out, OnAchievementsLoadedCallback = nullptr);
 };

--- a/GWToolboxdll/Modules/InventoryManager.cpp
+++ b/GWToolboxdll/Modules/InventoryManager.cpp
@@ -394,7 +394,6 @@ namespace {
         }
 
         const GW::Constants::Bag bag_id = (GW::Constants::Bag)((size_t)GW::Constants::Bag::Storage_1 + (size_t)page);
-        // if the item is stackable we try to complete stack that already exist in the current storage page
         if (remaining) {
             remaining -= complete_existing_stack(item, bag_id, bag_id, remaining);
         }
@@ -441,7 +440,6 @@ namespace {
 
         const uint16_t to_move = std::min<uint16_t>(item->quantity, quantity);
         uint16_t remaining = to_move;
-        // If item is stackable, try to complete similar stack
         remaining -= complete_existing_stack(item, GW::Constants::Bag::Backpack, GW::Constants::Bag::Bag_2, remaining);
         while (remaining) {
             const uint16_t moved = move_to_first_empty_slot(item, GW::Constants::Bag::Backpack, GW::Constants::Bag::Bag_2, remaining);
@@ -830,7 +828,6 @@ namespace {
     };
     std::queue<ButtonPress> queued_button_presses;
 
-    // Cycle through queued buttons, trigger as necessary
     void ProcessQueuedButtonPresses() {
         while (queued_button_presses.size()) {
             auto todo = queued_button_presses.front();
@@ -1080,7 +1077,6 @@ namespace {
         if (!is_identifying_all || is_identifying) {
             return;
         }
-        // Get next item to identify
         const auto unid = GetNextUnidentifiedItem();
         if (!unid) {
             // Log::Info("Identified %d items", identified_count);
@@ -1128,7 +1124,6 @@ namespace {
             case GW::UI::UIMessage::kVendorWindow: {
                 merchant_list_tab = *static_cast<uint32_t*>(wparam);
             } break;
-            // About to request a quote for an item
             case GW::UI::UIMessage::kSendMerchantRequestQuote: {
                 const auto packet = (GW::UI::UIPacket::kSendMerchantRequestQuote*)wparam;
                 requesting_quote_type = (GW::Merchant::TransactionType)0;
@@ -1143,7 +1138,6 @@ namespace {
                 show_transact_quantity_popup = true;
                 status->blocked = true;
             } break;
-            // About to move an item
             case GW::UI::UIMessage::kSendMoveItem: {
                 const auto packet = (GW::UI::UIPacket::kSendMoveItem*)wparam;
 
@@ -1155,7 +1149,6 @@ namespace {
                 status->blocked = true;
                 InventoryManager::MoveItem((InventoryManager::Item*)GW::Items::GetItemById(packet->item_id), static_cast<uint16_t>(packet->quantity));
             } break;
-            // Quote for item has been received
             case GW::UI::UIMessage::kVendorQuote: {
                 auto& transaction = pending_transaction;
                 if (!transaction.in_progress()) {
@@ -1179,11 +1172,9 @@ namespace {
                 pending_transaction_amount--;
                 transaction.setState(PendingTransaction::State::Pending);
             } break;
-            // Map left; cancel all actions
             case GW::UI::UIMessage::kMapChange: {
                 CancelAll();
             } break;
-            // Item moved; clear prompt
             case GW::UI::UIMessage::kMoveItem: {
                 stack_prompt_item_id = 0;
             } break;
@@ -1251,12 +1242,10 @@ namespace {
     void DrawMerchantHiddenItemsSettings()
     {
         ImGui::NewLine();
-        // Two-column layout for merchant items using tables
         if (ImGui::BeginTable("merchant_settings_table", 2, ImGuiTableFlags_Resizable | ImGuiTableFlags_BordersInnerV)) {
             ImGui::TableSetupColumn("Hidden from Merchant", ImGuiTableColumnFlags_WidthStretch);
             ImGui::TableSetupColumn("Ignored when Salvaging", ImGuiTableColumnFlags_WidthStretch);
 
-            // Header row
             ImGui::TableNextRow();
             ImGui::TableSetColumnIndex(0);
             ImGui::Text("Hidden items from merchant sell window:");
@@ -1267,10 +1256,8 @@ namespace {
             ImGui::SameLine();
             ImGui::TextDisabled("(Click on an item to remove it)");
 
-            // Content row
             ImGui::TableNextRow();
 
-            // Left column: Hidden items list
             ImGui::TableSetColumnIndex(0);
             ImGui::Separator();
             const float list_height = 100.f;
@@ -1282,12 +1269,10 @@ namespace {
 
                 const auto button_label = std::format("{} | X", item_name);
 
-                // Calculate if this button would exceed available width
                 const ImVec2 button_size = ImGui::CalcTextSize(button_label.c_str());
                 const float button_width = button_size.x + ImGui::GetStyle().FramePadding.x * 2.0f;
                 const float cursor_x = ImGui::GetCursorPosX();
 
-                // Wrap to next line if button would go past the edge
                 if (cursor_x + button_width > wrap_width && cursor_x > 0.0f) {
                     ImGui::NewLine();
                 }
@@ -1309,7 +1294,6 @@ namespace {
             ImGui::EndChild();
             ImGui::Text("To add an item to this list, right click the item from your inventory and select 'Hide this when selling'");
 
-            // Right column: Salvage ignore list
             ImGui::TableSetColumnIndex(1);
             ImGui::Separator();
             ImGui::BeginChild("block_from_being_salvaged", ImVec2(0.0F, list_height));
@@ -1321,12 +1305,10 @@ namespace {
 
                 const auto button_label = std::format("{} | X", it.second);
 
-                // Calculate if this button would exceed available width
                 const ImVec2 button_size = ImGui::CalcTextSize(button_label.c_str());
                 const float button_width = button_size.x + ImGui::GetStyle().FramePadding.x * 2.0f;
                 const float cursor_x = ImGui::GetCursorPosX();
 
-                // Wrap to next line if button would go past the edge
                 if (cursor_x + button_width > wrap_width2 && cursor_x > 0.0f) {
                     ImGui::NewLine();
                 }
@@ -1511,7 +1493,6 @@ namespace {
                     CancelTransaction();
                     return;
                 }
-                // Check if we need any more of this item; send quote if yes, complete if no.
                 if (pending_transaction_amount <= 0) {
                     Log::Flash("Transaction complete");
                     CancelTransaction();
@@ -1526,7 +1507,6 @@ namespace {
                 }
             } break;
             case PendingTransaction::State::Quoting:
-                // Check for timeout having asked for a quote.
                 if (TIMER_DIFF(pending_transaction.state_timestamp) > 3000) {
                     if (pending_transaction.retries > 0) {
                         Log::ErrorW(L"Timeout waiting for item quote");
@@ -1544,7 +1524,6 @@ namespace {
                     return;
                 }
                 Log::Log("PendingTransaction quoted %d, moving to buy/sell\n", pending_transaction.price);
-                // Got a quote; begin transaction
                 pending_transaction.setState(PendingTransaction::State::Transacting);
                 if (!GW::Merchant::TransactItems()) {
                     Log::ErrorW(L"Failed to transact items");
@@ -1553,7 +1532,6 @@ namespace {
                 }
             } break;
             case PendingTransaction::State::Transacting:
-                // Check for timeout having agreed to buy or sell
                 if (TIMER_DIFF(pending_transaction.state_timestamp) > 3000) {
                     if (pending_transaction.retries > 0) {
                         Log::ErrorW(L"Timeout waiting for item sell/buy");
@@ -1565,7 +1543,6 @@ namespace {
                 }
                 break;
             default:
-                // Anything else, cancel the transaction.
                 CancelTransaction();
         }
     }
@@ -2132,7 +2109,6 @@ void InventoryManager::Draw(IDirect3DDevice9*)
                     if (pending_transaction.selling()) {
                         const Item* item = pending_transaction.item();
                         if (item) {
-                            // Set initial transaction amount to be the entire stack
                             pending_transaction_amount = item->quantity;
                             if (item->GetIsMaterial() && !item->IsRareMaterial() && pending_transaction.type == GW::Merchant::TransactionType::TraderSell) {
                                 pending_transaction_amount = static_cast<int>(floor(pending_transaction_amount / 10));
@@ -2140,7 +2116,6 @@ void InventoryManager::Draw(IDirect3DDevice9*)
                         }
                     }
                 }
-                // Prompt user for amount
                 ImGui::Text(pending_transaction.selling() ? "Enter quantity to sell:" : "Enter quantity to buy:");
                 if (ImGui::InputInt("###transacting_quantity", &pending_transaction_amount, 1, 1)) {
                     if (pending_transaction_amount < 1) {
@@ -2188,7 +2163,6 @@ void InventoryManager::Draw(IDirect3DDevice9*)
             ImGui::CloseCurrentPopup();
         }
         else if (is_salvaging_all) {
-            // Salvage in progress
             ImGui::Text("Salvaging items...");
             if (ImGui::Button("Cancel", ImVec2(120, 0)) || ImGui::IsKeyPressed(ImGuiKey_Escape)) {
                 pending_cancel_salvage = true;
@@ -2554,7 +2528,6 @@ bool InventoryManager::DrawItemContextMenu(const bool open)
     return true;
 }
 
-// Move a whole stack into/out of storage
 uint16_t InventoryManager::MoveItem(const Item* item, const uint16_t quantity)
 {
     // Expected behaviors
@@ -2600,11 +2573,7 @@ void InventoryManager::ItemClickCallback(GW::HookStatus* status, GW::UI::UIPacke
         case GW::UI::UIPacket::ActionState::MouseClick:
         case GW::UI::UIPacket::ActionState::MouseUp: // Left click
             if (ImGui::IsKeyDown(ImGuiMod_Ctrl)) {
-                // Get any hovered item in order to get info about it for Ctrl+Click shortcuts.
-                // May be null, in which case said shortcuts are ignored.
-
                 if (item && settings.identify_all_on_ctrl_click && item->IsIdentificationKit() && ImGui::IsKeyDown(ImGuiMod_Ctrl)) {
-                    // Ctrl+Click on identification kit: Identify all items
                     ImGui::CloseCurrentPopup();
                     CancelIdentify();
                     if (context_item.set(item)) {
@@ -2616,7 +2585,6 @@ void InventoryManager::ItemClickCallback(GW::HookStatus* status, GW::UI::UIPacke
                     return;
                 }
                 else if (item && settings.salvage_all_on_ctrl_click && item->IsSalvageKit() && ImGui::IsKeyDown(ImGuiMod_Ctrl)) {
-                    // Ctrl+Click on salvage kit: Open salvage all window
                     ImGui::CloseCurrentPopup();
                     CancelSalvage();
                     if (context_item.set(item)) {
@@ -2627,7 +2595,6 @@ void InventoryManager::ItemClickCallback(GW::HookStatus* status, GW::UI::UIPacke
                     return;
                 }
                 else if (GameSettings::GetSettingBool("move_item_on_ctrl_click") && GW::Map::GetInstanceType() == GW::Constants::InstanceType::Outpost) {
-                    // Ctrl+Click: Move item to inventory/chest
                     if (ImGui::IsKeyDown(ImGuiMod_Shift) && item->quantity > 1) {
                         prompt_split_stack(item);
                     }
@@ -2638,7 +2605,6 @@ void InventoryManager::ItemClickCallback(GW::HookStatus* status, GW::UI::UIPacke
                 }
             }
             if (ImGui::IsKeyDown(ImGuiMod_Alt) && settings.move_to_trade_on_alt_click && IsTradeWindowOpen()) {
-                // Alt+Click: Add to trade window if available
                 if (!item || !item->CanOfferToTrade()) {
                     return;
                 }
@@ -2655,7 +2621,6 @@ void InventoryManager::ItemClickCallback(GW::HookStatus* status, GW::UI::UIPacke
         case GW::UI::UIPacket::ActionState::MouseDoubleClick: // Double click
             if (settings.move_to_trade_on_double_click && IsTradeWindowOpen()) {
                 status->blocked = true;
-                // Alt+Click: Add to trade window if available
                 if (!item || !item->CanOfferToTrade()) {
                     return;
                 }
@@ -2680,7 +2645,6 @@ void InventoryManager::ItemClickCallback(GW::HookStatus* status, GW::UI::UIPacke
                 return;
             }
 
-            // Context menu applies
             if (context_item.item_id == item->item_id && show_item_context_menu) {
                 return; // Double looped.
             }

--- a/GWToolboxdll/Modules/ItemDrops.cpp
+++ b/GWToolboxdll/Modules/ItemDrops.cpp
@@ -210,7 +210,6 @@ namespace {
     };
 
     std::filesystem::path GetItemDropCSVFilename() {
-        // Generate filename with current date
         const auto now = std::chrono::system_clock::now();
         const auto time = std::chrono::system_clock::to_time_t(now);
         std::tm tm = TextUtils::Time::SafeLocaltime(time);
@@ -326,7 +325,6 @@ namespace {
         }
         std::filesystem::create_directories(drops_filename.parent_path(),ec);
 
-        // Open file with nothrow
         std::wofstream my_file;
         my_file.exceptions(std::ios::goodbit); // Disable exceptions
         my_file.open(drops_filename.c_str(), std::ios::app);
@@ -336,7 +334,6 @@ namespace {
             return;
         }
 
-        // Write header if new file
         if (!file_exists) {
             my_file << ItemDrops::PendingDrop::GetCSVHeader() << L"\n";
             if (my_file.fail()) {
@@ -345,7 +342,6 @@ namespace {
             }
         }
 
-        // Write data
         for (const auto& pending : pending_write_to_csv) {
             my_file << pending->toCSV() << L"\n";
             if (my_file.fail()) {

--- a/GWToolboxdll/Modules/ItemTooltipModule.cpp
+++ b/GWToolboxdll/Modules/ItemTooltipModule.cpp
@@ -276,7 +276,6 @@ namespace {
         }
     }
 
-        // Check and re-render item tooltips if modifier key held
     void UpdateItemTooltip()
     {
         if (GetKeyState(modifier_key_item_descriptions) == modifier_key_item_descriptions_key_state) {

--- a/GWToolboxdll/Modules/MouseFix.cpp
+++ b/GWToolboxdll/Modules/MouseFix.cpp
@@ -148,7 +148,6 @@ namespace {
 
         const RAWINPUT* raw = reinterpret_cast<RAWINPUT*>(lpb);
         if ((raw->data.mouse.usFlags & MOUSE_MOVE_ABSOLUTE) == 0) {
-            // If its a relative mouse move, process the action
             if (gw_mouse_move->move_camera) {
                 rawInputRelativePosX += raw->data.mouse.lLastX;
                 rawInputRelativePosY += raw->data.mouse.lLastY;
@@ -210,9 +209,6 @@ namespace {
         }
     }
 
-    /*
-     *  Logic for scaling gw cursor up or down
-     */
     HBITMAP ScaleBitmap(const HBITMAP inBitmap, const int inWidth, const int inHeight, const int outWidth, const int outHeight)
     {
         // NB: We could use GDIPlus for this logic which has better image res handling etc, but no need
@@ -222,7 +218,6 @@ namespace {
         HBITMAP outBitmap = nullptr;
         HGDIOBJ oldDestBitmap = nullptr, oldSrcBitmap = nullptr;
 
-        // create a destination bitmap and DC with size w/h
         BITMAPINFO bmi;
         memset(&bmi, 0, sizeof(bmi));
         bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
@@ -254,7 +249,6 @@ namespace {
             goto cleanup;
         }
 
-        // copy and scaling to new width/height (w,h)
         if (SetStretchBltMode(destDC, WHITEONBLACK) == 0) {
             goto cleanup;
         }
@@ -349,11 +343,9 @@ namespace {
     {
         GW::Hook::EnterHook();
 
-        // Cache the cursor arguments before calling the original function
         if (bitmap_data && bitmap_mask && hotspot) {
             cached_cursor.cursor_type = cursor_type;
 
-            // Determine bitmap data size based on cursor type
             size_t bitmap_size;
             if (cursor_type == 0) {
                 bitmap_size = 32 * 32 * 4; // 32-bit color (RGBA)
@@ -365,15 +357,12 @@ namespace {
                 bitmap_size = 32 * 32 * 4; // Default to 32-bit
             }
 
-            // Cache bitmap data
             cached_cursor.bitmap_data.resize(bitmap_size);
             memcpy(cached_cursor.bitmap_data.data(), bitmap_data, bitmap_size);
 
-            // Cache mask data (always 32x32x4 for RGBA)
             cached_cursor.bitmap_mask.resize(32 * 32 * 4);
             memcpy(cached_cursor.bitmap_mask.data(), bitmap_mask, 32 * 32 * 4);
 
-            // Cache hotspot
             cached_cursor.hotspot[0] = hotspot[0];
             cached_cursor.hotspot[1] = hotspot[1];
 
@@ -382,7 +371,6 @@ namespace {
 
         ChangeCursorIcon_Ret(user_data, edx, cursor_type, bitmap_data, bitmap_mask, hotspot);
 
-        // Your existing cursor scaling logic...
         if (settings.cursor_size < 0 || settings.cursor_size > 64 || settings.cursor_size == 32) {
             return GW::Hook::LeaveHook();
         }
@@ -410,7 +398,6 @@ namespace {
         }
         *cursor = new_cursor;
         SetCursor(new_cursor);
-        // Also override the window class for the cursor
         SetClassLongA(*window_handle, GCL_HCURSOR, reinterpret_cast<LONG>(new_cursor));
         current_cursor = new_cursor;
         GW::Hook::LeaveHook();
@@ -419,7 +406,6 @@ namespace {
     void RedrawCursorIcon()
     {
         GW::GameThread::Enqueue([] {
-            // Force redraw
             const auto user_data = Win32WindowUserData::Instance();
             current_cursor = nullptr;
             if (user_data && ChangeCursorIcon_Func && cached_cursor.is_valid) {

--- a/GWToolboxdll/Modules/Obfuscator.cpp
+++ b/GWToolboxdll/Modules/Obfuscator.cpp
@@ -256,14 +256,11 @@ namespace {
     std::wstring speech_message_temp_message;
 
 
-    // List of obfuscated names, keyed by obfuscated
     std::map<std::wstring, std::wstring> obfuscated_by_obfuscation;
-    // List of obfuscated names, keyed by original
     std::map<std::wstring, std::wstring> obfuscated_by_original;
     // Current position in the list of obfuscated names
     size_t pool_index = 0;
 
-    // Current state
     enum class ObfuscatorState : uint8_t {
         Disabled,
         Enabled
@@ -574,7 +571,6 @@ namespace {
             }
             break;
             case GW::UI::UIMessage::kDialogBody: {
-                // Dialog body
                 const auto packet_actual = static_cast<GW::UI::DialogBodyInfo*>(wParam);
                 if (packet_actual->message_enc && ObfuscateMessage(packet_actual->message_enc, ui_message_temp_message)) {
                     packet_actual->message_enc = ui_message_temp_message.data();

--- a/GWToolboxdll/Modules/ObserverModule.cpp
+++ b/GWToolboxdll/Modules/ObserverModule.cpp
@@ -250,7 +250,6 @@ void ObserverModule::Terminate()
 }
 
 
-// Is the Module actively tracking agents?
 const bool ObserverModule::IsActive() const
 {
     // an observer match is considered an explorable area
@@ -258,7 +257,6 @@ const bool ObserverModule::IsActive() const
 }
 
 
-// Handle InstanceLoadInfo Packet
 void ObserverModule::HandleInstanceLoadInfo(const GW::HookStatus*, const GW::Packet::StoC::InstanceLoadInfo* packet)
 {
     is_explorable = packet->is_explorable;
@@ -270,7 +268,6 @@ void ObserverModule::HandleInstanceLoadInfo(const GW::HookStatus*, const GW::Pac
     observed_map_id = static_cast<GW::Constants::MapID>(packet->map_id);
 
     if (is_active) {
-        // Reset countdown flag for new map
         first_countdown_seen = false;
         // Don't call Reset() here to preserve match data for export after leaving the map
         // Users can explicitly call /observer:reset when they want to start tracking a new match
@@ -283,7 +280,6 @@ void ObserverModule::HandleInstanceLoadInfo(const GW::HookStatus*, const GW::Pac
 }
 
 
-// Handle a JumboMessage packet
 void ObserverModule::HandleJumboMessage(const uint8_t type, const uint32_t value)
 {
     switch (type) {
@@ -306,7 +302,6 @@ void ObserverModule::HandleJumboMessage(const uint8_t type, const uint32_t value
 }
 
 
-// Handle a GenericPacket of type float
 void ObserverModule::HandleGenericPacket(const uint32_t value_id, const uint32_t caster_id, const uint32_t target_id, const float value, const bool)
 {
     switch (value_id) {
@@ -334,7 +329,6 @@ void ObserverModule::HandleGenericPacket(const uint32_t value_id, const uint32_t
     }
 }
 
-// Handle a Generic Packet of type uint32_t
 void ObserverModule::HandleGenericPacket(const uint32_t value_id, const uint32_t caster_id, const uint32_t target_id, const uint32_t value, const bool no_target)
 {
     switch (value_id) {
@@ -348,7 +342,6 @@ void ObserverModule::HandleGenericPacket(const uint32_t value_id, const uint32_t
 
         case GW::Packet::StoC::GenericValueID::attack_started: {
             // swap target and caster for skill_activated
-            // log
             uint32_t _caster_id;
             uint32_t _target_id;
             if (no_target) {
@@ -361,7 +354,6 @@ void ObserverModule::HandleGenericPacket(const uint32_t value_id, const uint32_t
                 _caster_id = target_id;
                 _target_id = caster_id;
             }
-            // handle
             HandleAttackStarted(_caster_id, _target_id);
             break;
         }
@@ -384,7 +376,6 @@ void ObserverModule::HandleGenericPacket(const uint32_t value_id, const uint32_t
 
         case GW::Packet::StoC::GenericValueID::attack_skill_activated: {
             // swap target and caster for skill_activated
-            // log
             uint32_t _caster_id;
             uint32_t _target_id;
             if (no_target) {
@@ -397,7 +388,6 @@ void ObserverModule::HandleGenericPacket(const uint32_t value_id, const uint32_t
                 _caster_id = target_id;
                 _target_id = caster_id;
             }
-            // handle
             HandleAttackSkillStarted(_caster_id, _target_id, static_cast<GW::Constants::SkillID>(value));
             break;
         }
@@ -419,7 +409,6 @@ void ObserverModule::HandleGenericPacket(const uint32_t value_id, const uint32_t
             // or for no living agent...
 
             // swap target and caster for skill_activated
-            // log
             uint32_t _caster_id;
             uint32_t _target_id;
             if (no_target) {
@@ -439,7 +428,6 @@ void ObserverModule::HandleGenericPacket(const uint32_t value_id, const uint32_t
 }
 
 
-// Handle AgentState Packet
 // Fired when the server notifies us of an agent state change
 // Can tell us if the agent has just died or been resurrected
 void ObserverModule::HandleAgentState(const uint32_t agent_id, const uint32_t state)
@@ -454,13 +442,10 @@ void ObserverModule::HandleAgentState(const uint32_t agent_id, const uint32_t st
     // 16 = dead
     const bool is_now_dead = (state == 16);
     
-    // Check for resurrection (was dead, now alive)
     if (observable_agent->is_dead && !is_now_dead) {
         const uint32_t instance_time = GW::Map::GetInstanceTime();
-        // Use time relative to match start if available, otherwise use instance time
         const uint32_t match_time = match_start_instance_time > 0 ? (instance_time - match_start_instance_time) : instance_time;
         
-        // Determine resurrection type based on what caused the resurrection
         ResurrectionType res_type;
         uint32_t resurrector_id = NO_AGENT;
         
@@ -485,7 +470,6 @@ void ObserverModule::HandleAgentState(const uint32_t agent_id, const uint32_t st
         return; // Don't process as death
     }
     
-    // Check for death
     if (!is_now_dead) {
         return; // Not a death event
     }
@@ -501,9 +485,7 @@ void ObserverModule::HandleAgentState(const uint32_t agent_id, const uint32_t st
         return;
     }
 
-    // Record death event with timestamp and coordinates
     const uint32_t instance_time = GW::Map::GetInstanceTime();
-    // Use time relative to match start if available, otherwise use instance time
     const uint32_t match_time = match_start_instance_time > 0 ? (instance_time - match_start_instance_time) : instance_time;
     const GW::Agent* agent = GW::Agents::GetAgentByID(agent_id);
     float pos_x = 0.0f, pos_y = 0.0f;
@@ -523,7 +505,6 @@ void ObserverModule::HandleAgentState(const uint32_t agent_id, const uint32_t st
     
     observable_agent->is_dead = true; // Mark as dead
 
-    // notify the player
     observable_agent->stats.HandleDeath();
 
     // only grant a kill if the victim belonged to a party
@@ -546,7 +527,6 @@ void ObserverModule::HandleAgentState(const uint32_t agent_id, const uint32_t st
 }
 
 
-// Helper function to get or cache max HP for an agent
 // Returns 530 if unable to determine max HP
 // GWCA doesn't allow us to retrieve MAX Hp for every player, only currently observed player
 // as specified in the Agent.h structure.
@@ -560,7 +540,6 @@ uint32_t ObserverModule::GetNPCMaxHP(uint32_t agent_id)
         return 0;
     }
 
-    // Get sanitized name and compare against known NPC names
     const std::string name = agent->SanitizedName();
     
     if (name == "Footman" || name == "Archer" || name == "Knight" || name == "Bodyguard") {
@@ -599,7 +578,6 @@ uint32_t ObserverModule::GetOrCacheMaxHP(const uint32_t agent_id)
         return it->second;
     }
 
-    // Check for hardcoded NPC HP values
     const uint32_t npc_hp = GetNPCMaxHP(agent_id);
     if (npc_hp > 0) {
         agent_max_hp_cache[agent_id] = npc_hp;
@@ -614,7 +592,6 @@ uint32_t ObserverModule::GetOrCacheMaxHP(const uint32_t agent_id)
 }
 
 
-// Handle DamageDone (GenericModifier float Packet)
 void ObserverModule::HandleDamageDone(const uint32_t caster_id, const uint32_t target_id, const float amount_pc, const bool is_crit)
 {
     ObservableAgent* caster = GetObservableAgentById(caster_id);
@@ -625,7 +602,6 @@ void ObserverModule::HandleDamageDone(const uint32_t caster_id, const uint32_t t
         target->last_hit_by = caster->agent_id;
     }
 
-    // Calculate actual damage amount
     // @see GetOrCacheMaxHP to understand why we need to do that.
     uint32_t damage_amount = 0;
     if (amount_pc < 0 && target) {
@@ -647,14 +623,12 @@ void ObserverModule::HandleDamageDone(const uint32_t caster_id, const uint32_t t
             target->last_damage_skill_id = skill_id;
         }
 
-        // Update caster stats
         caster->stats.total_damage_dealt += damage_amount;
         if (target_party) {
             caster->stats.total_party_damage_dealt += damage_amount;
         }
         caster->stats.LazyGetDamageDealedAgainst(target_id) += damage_amount;
 
-        // Update caster party stats
         if (caster_party) {
             caster_party->stats.total_damage_dealt += damage_amount;
             if (target_party) {
@@ -662,14 +636,12 @@ void ObserverModule::HandleDamageDone(const uint32_t caster_id, const uint32_t t
             }
         }
 
-        // Update target stats
         target->stats.total_damage_received += damage_amount;
         if (caster_party) {
             target->stats.total_party_damage_received += damage_amount;
         }
         target->stats.LazyGetDamageReceivedFrom(caster_id) += damage_amount;
 
-        // Update target party stats
         if (target_party) {
             target_party->stats.total_damage_received += damage_amount;
             if (caster_party) {
@@ -677,13 +649,11 @@ void ObserverModule::HandleDamageDone(const uint32_t caster_id, const uint32_t t
             }
         }
 
-        // Track damage by skill
         if (skill_id != NO_SKILL) {
             caster->stats.LazyGetDamageBySkill(skill_id) += damage_amount;
             caster->stats.LazyGetDamageBySkillToAgent(target_id, skill_id) += damage_amount;
             target->stats.LazyGetDamageFromSkillFromAgent(caster_id, skill_id) += damage_amount;
 
-            // Also update the skill's ObservedAction if it exists
             auto it_skill = caster->stats.skills_used.find(skill_id);
             if (it_skill != caster->stats.skills_used.end()) {
                 it_skill->second->total_damage += damage_amount;
@@ -701,7 +671,6 @@ void ObserverModule::HandleDamageDone(const uint32_t caster_id, const uint32_t t
             target_party = GetObservablePartyById(target->party_id);
         }
 
-        // notify the caster
         if (caster) {
             caster->stats.total_crits_dealt += 1;
             if (target_party) {
@@ -709,7 +678,6 @@ void ObserverModule::HandleDamageDone(const uint32_t caster_id, const uint32_t t
             }
         }
 
-        // notify the caster_party
         if (caster_party) {
             caster_party->stats.total_crits_dealt += 1;
             if (target_party) {
@@ -717,7 +685,6 @@ void ObserverModule::HandleDamageDone(const uint32_t caster_id, const uint32_t t
             }
         }
 
-        // notify the target
         if (target) {
             target->stats.total_crits_received += 1;
             if (caster_party) {
@@ -725,7 +692,6 @@ void ObserverModule::HandleDamageDone(const uint32_t caster_id, const uint32_t t
             }
         }
 
-        // notify the target_party
         if (target_party) {
             target_party->stats.total_crits_received += 1;
             if (caster_party) {
@@ -736,13 +702,11 @@ void ObserverModule::HandleDamageDone(const uint32_t caster_id, const uint32_t t
 }
 
 
-// Handle HealingDone (GenericModifier float Packet)
 void ObserverModule::HandleHealingDone(const uint32_t caster_id, const uint32_t target_id, const float amount_pc)
 {
     ObservableAgent* caster = GetObservableAgentById(caster_id);
     ObservableAgent* target = GetObservableAgentById(target_id);
 
-    // Calculate actual healing amount
     // @see GetOrCacheMaxHP to understand why we need to do that.
     uint32_t healing_amount = 0;
     if (amount_pc > 0 && target) {
@@ -750,25 +714,21 @@ void ObserverModule::HandleHealingDone(const uint32_t caster_id, const uint32_t 
         healing_amount = static_cast<uint32_t>(std::lround(amount_pc * max_hp));
     }
 
-    // Track healing if we have a valid amount
     if (healing_amount > 0 && caster && target) {
         ObservableParty* caster_party = GetObservablePartyById(caster->party_id);
         ObservableParty* target_party = GetObservablePartyById(target->party_id);
 
-        // Get the skill being used (if any)
         GW::Constants::SkillID skill_id = NO_SKILL;
         if (caster->current_target_action && caster->current_target_action->is_skill) {
             skill_id = caster->current_target_action->skill_id;
         }
 
-        // Update caster stats
         caster->stats.total_healing_dealt += healing_amount;
         if (target_party) {
             caster->stats.total_party_healing_dealt += healing_amount;
         }
         caster->stats.LazyGetHealingDealedTo(target_id) += healing_amount;
 
-        // Update caster party stats
         if (caster_party) {
             caster_party->stats.total_healing_dealt += healing_amount;
             if (target_party) {
@@ -776,14 +736,12 @@ void ObserverModule::HandleHealingDone(const uint32_t caster_id, const uint32_t 
             }
         }
 
-        // Update target stats
         target->stats.total_healing_received += healing_amount;
         if (caster_party) {
             target->stats.total_party_healing_received += healing_amount;
         }
         target->stats.LazyGetHealingReceivedFrom(caster_id) += healing_amount;
 
-        // Update target party stats
         if (target_party) {
             target_party->stats.total_healing_received += healing_amount;
             if (caster_party) {
@@ -791,7 +749,6 @@ void ObserverModule::HandleHealingDone(const uint32_t caster_id, const uint32_t 
             }
         }
 
-        // Track healing by skill
         if (skill_id != NO_SKILL) {
             caster->stats.LazyGetHealingBySkill(skill_id) += healing_amount;
             caster->stats.LazyGetHealingBySkillToAgent(target_id, skill_id) += healing_amount;
@@ -801,7 +758,6 @@ void ObserverModule::HandleHealingDone(const uint32_t caster_id, const uint32_t 
 }
 
 
-// Handle AgentAdd Packet
 // Fired when an Agent is to be loaded into memory
 void ObserverModule::HandleAgentAdd(const uint32_t)
 {
@@ -810,7 +766,6 @@ void ObserverModule::HandleAgentAdd(const uint32_t)
 }
 
 
-// Handle AgentProjectileLaunched Packet
 // can be used to determine when a ranged attack has finished
 void ObserverModule::HandleAgentProjectileLaunched(const GW::Packet::StoC::AgentProjectileLaunched* packet)
 {
@@ -826,20 +781,17 @@ void ObserverModule::HandleAgentProjectileLaunched(const GW::Packet::StoC::Agent
 }
 
 
-// Handle AttackFinished Packet
 void ObserverModule::HandleAttackFinished(const uint32_t agent_id)
 {
     ReduceAction(GetObservableAgentById(agent_id), ActionStage::Finished);
 }
 
-// Handle AttackStopped Packet
 void ObserverModule::HandleAttackStopped(const uint32_t agent_id)
 {
     ReduceAction(GetObservableAgentById(agent_id), ActionStage::Stopped);
 }
 
 
-// Handle AttackStarted Packet
 void ObserverModule::HandleAttackStarted(const uint32_t caster_id, const uint32_t target_id)
 {
     const auto action = new TargetAction(caster_id, target_id, true, false, NO_SKILL);
@@ -849,27 +801,23 @@ void ObserverModule::HandleAttackStarted(const uint32_t caster_id, const uint32_
 }
 
 
-// Handle Interrupted Packet
 void ObserverModule::HandleInterrupted(const uint32_t agent_id)
 {
     ReduceAction(GetObservableAgentById(agent_id), ActionStage::Interrupted);
 }
 
-// Handle Attack SkillFinished Packet
 void ObserverModule::HandleAttackSkillFinished(const uint32_t agent_id)
 {
     ReduceAction(GetObservableAgentById(agent_id), ActionStage::Finished);
 }
 
 
-// Handle Attack SkillStopped Packet
 void ObserverModule::HandleAttackSkillStopped(const uint32_t agent_id)
 {
     ReduceAction(GetObservableAgentById(agent_id), ActionStage::Stopped);
 }
 
 
-// Handle InstantSkillActivated Packet
 void ObserverModule::HandleInstantSkillActivated(const uint32_t caster_id, const uint32_t target_id, const GW::Constants::SkillID skill_id)
 {
     // assuming there are no instant attack skills...
@@ -880,7 +828,6 @@ void ObserverModule::HandleInstantSkillActivated(const uint32_t caster_id, const
 }
 
 
-// Handle AttackSkillActivated Packet
 void ObserverModule::HandleAttackSkillStarted(const uint32_t caster_id, const uint32_t target_id, const GW::Constants::SkillID skill_id)
 {
     const auto action = new TargetAction(caster_id, target_id, true, true, skill_id);
@@ -890,21 +837,18 @@ void ObserverModule::HandleAttackSkillStarted(const uint32_t caster_id, const ui
 }
 
 
-// Handle AttackSkillFinished Packet
 void ObserverModule::HandleSkillFinished(const uint32_t agent_id)
 {
     ReduceAction(GetObservableAgentById(agent_id), ActionStage::Finished);
 }
 
 
-// Handle SkillFinished Packet
 void ObserverModule::HandleSkillStopped(const uint32_t agent_id)
 {
     ReduceAction(GetObservableAgentById(agent_id), ActionStage::Stopped);
 }
 
 
-// Handle SkillActivated Packet
 void ObserverModule::HandleSkillActivated(const uint32_t caster_id, const uint32_t target_id, const GW::Constants::SkillID skill_id)
 {
     const auto action = new TargetAction(caster_id, target_id, false, true, skill_id);
@@ -914,10 +858,8 @@ void ObserverModule::HandleSkillActivated(const uint32_t caster_id, const uint32
 }
 
 
-// Handle KnockedDown Packet
 void ObserverModule::HandleKnockedDown(const uint32_t agent_id, const float duration)
 {
-    // notify the agent
     ObservableAgent* agent = GetObservableAgentById(agent_id);
     if (!agent) {
         return;
@@ -925,7 +867,6 @@ void ObserverModule::HandleKnockedDown(const uint32_t agent_id, const float dura
     agent->stats.knocked_down_count += 1;
     agent->stats.knocked_down_duration += duration;
 
-    // notify the agents party
     ObservableParty* party = GetObservablePartyById(agent->party_id);
     if (!party) {
         return;
@@ -935,7 +876,6 @@ void ObserverModule::HandleKnockedDown(const uint32_t agent_id, const float dura
 }
 
 
-// Convert a JumboMessage value to a party_id
 uint32_t ObserverModule::JumboMessageValueToPartyId(const uint32_t value)
 {
     // TODO: handle maps with 3 parties where the JumboMessageValue's are different
@@ -950,46 +890,39 @@ uint32_t ObserverModule::JumboMessageValueToPartyId(const uint32_t value)
 }
 
 
-// Fired when a party receives a morale boost
 void ObserverModule::HandleMoraleBoost(ObservableParty* boosting_party)
 {
     if (!boosting_party) {
         return;
     }
     const uint32_t instance_time = GW::Map::GetInstanceTime();
-    // Use time relative to match start if available, otherwise use instance time
     const uint32_t match_time = match_start_instance_time > 0 ? (instance_time - match_start_instance_time) : instance_time;
     boosting_party->morale_boosts.emplace_back(match_time);
 }
 
 
-// Fired when a party captures a shrine
 void ObserverModule::HandleShrineCapture(ObservableParty* capturing_party)
 {
     if (!capturing_party) {
         return;
     }
     const uint32_t instance_time = GW::Map::GetInstanceTime();
-    // Use time relative to match start if available, otherwise use instance time
     const uint32_t match_time = match_start_instance_time > 0 ? (instance_time - match_start_instance_time) : instance_time;
     capturing_party->shrine_captures.emplace_back(match_time);
 }
 
 
-// Fired when a party captures a tower
 void ObserverModule::HandleTowerCapture(ObservableParty* capturing_party)
 {
     if (!capturing_party) {
         return;
     }
     const uint32_t instance_time = GW::Map::GetInstanceTime();
-    // Use time relative to match start if available, otherwise use instance time
     const uint32_t match_time = match_start_instance_time > 0 ? (instance_time - match_start_instance_time) : instance_time;
     capturing_party->tower_captures.emplace_back(match_time);
 }
 
 
-// Fired when a party is victorious
 void ObserverModule::HandleVictory(ObservableParty* winning_party)
 {
     // TODO: handle draws
@@ -1001,16 +934,12 @@ void ObserverModule::HandleVictory(ObservableParty* winning_party)
     //  - we can't set match_finished = true
     //  - we can't get the match duration
 
-    // match has concluded
-    // save winner and match duration
     match_finished = true;
 
-    // notify the winning party
     winning_party_id = winning_party->party_id;
     winning_party->is_defeated = false;
     winning_party->is_victorious = true;
 
-    // note the final game duration
     // Calculate from actual match start time if available, otherwise use 60s offset
     const uint32_t instance_time = GW::Map::GetInstanceTime();
     const uint32_t ms = match_start_instance_time > 0 
@@ -1023,7 +952,6 @@ void ObserverModule::HandleVictory(ObservableParty* winning_party)
     match_duration_mins = std::chrono::duration_cast<std::chrono::minutes>(match_duration_secs);
     match_duration_secs -= std::chrono::duration_cast<std::chrono::seconds>(match_duration_mins);
 
-    // notify other parties that they lost
     for (auto& [_, losing_party] : observable_parties) {
         if (losing_party && losing_party->party_id != winning_party->party_id) {
             losing_party->is_defeated = true;
@@ -1048,7 +976,6 @@ bool ObserverModule::ReduceAction(ObservableAgent* caster, const ActionStage sta
     // If starting a new action, delete the last stored action & store this new action
     if (new_action) {
         ASSERT(stage == ActionStage::Started || stage == ActionStage::Instant);
-        // starting a new action
 
         // "instant" actions do not persist (don't received a "finished" packet) so we don't store them on the agent
         // and they may be activateable while using other skills (e.g. shouts/stances) so we don't clear the current action
@@ -1097,8 +1024,6 @@ bool ObserverModule::ReduceAction(ObservableAgent* caster, const ActionStage sta
         target_party = GetObservablePartyById(target->party_id);
     }
 
-    // notify caster & caster_party of interrupt
-    //
     // interrupt packet comes after cancelled packet most of the time.
     //
     // Can received a "cancelled" packet after a "finished" packet for attack skills where the target
@@ -1133,7 +1058,6 @@ bool ObserverModule::ReduceAction(ObservableAgent* caster, const ActionStage sta
         }
     }
 
-    // notify & caster_party caster of cancel
     if (stage == ActionStage::Stopped) {
         if (caster) {
             caster->stats.cancelled_count += 1;
@@ -1151,9 +1075,7 @@ bool ObserverModule::ReduceAction(ObservableAgent* caster, const ActionStage sta
         }
     }
 
-    // handle attack
     if (action->is_attack) {
-        // update the caster
         if (caster) {
             caster->stats.total_attacks_dealt.Reduce(action, stage);
             if (target) {
@@ -1165,7 +1087,6 @@ bool ObserverModule::ReduceAction(ObservableAgent* caster, const ActionStage sta
             }
         }
 
-        // update the casters party
         if (caster_party) {
             caster_party->stats.total_attacks_dealt.Reduce(action, stage);
             // if the target belonged to a party, the casters party just attacked that other party
@@ -1174,7 +1095,6 @@ bool ObserverModule::ReduceAction(ObservableAgent* caster, const ActionStage sta
             }
         }
 
-        // update the target
         if (target) {
             target->stats.total_attacks_received.Reduce(action, stage);
             if (caster) {
@@ -1186,7 +1106,6 @@ bool ObserverModule::ReduceAction(ObservableAgent* caster, const ActionStage sta
             }
         }
 
-        // update the targets party
         if (target_party) {
             target_party->stats.total_attacks_received.Reduce(action, stage);
             // if the caster belonged to a party, the target_party was just attacked by that other party
@@ -1196,9 +1115,7 @@ bool ObserverModule::ReduceAction(ObservableAgent* caster, const ActionStage sta
         }
     }
 
-    // handle skill
     if (action->is_skill) {
-        // update skill
         ObservableSkill* skill = GetObservableSkillById(action->skill_id);
         ASSERT(skill != nullptr);
 
@@ -1245,10 +1162,8 @@ bool ObserverModule::ReduceAction(ObservableAgent* caster, const ActionStage sta
         const bool same_team = caster && target && caster->team_id != NO_TEAM && caster->team_id == target->team_id;
         const bool same_party = target_party && caster_party && target_party->party_id == caster_party->party_id;
 
-        // notify the skill
         skill->stats.total_usages.Reduce(action, stage);
         if (target) {
-            // target usages
             if (caster == target) {
                 skill->stats.total_self_usages.Reduce(action, stage);
             }
@@ -1256,7 +1171,6 @@ bool ObserverModule::ReduceAction(ObservableAgent* caster, const ActionStage sta
                 skill->stats.total_other_usages.Reduce(action, stage);
             }
 
-            // team usages
             if (same_team) {
                 skill->stats.total_own_team_usages.Reduce(action, stage);
             }
@@ -1265,7 +1179,6 @@ bool ObserverModule::ReduceAction(ObservableAgent* caster, const ActionStage sta
             }
         }
         if (target_party) {
-            // party usages
             if (caster_party == target_party) {
                 skill->stats.total_own_party_usages.Reduce(action, stage);
             }
@@ -1274,121 +1187,90 @@ bool ObserverModule::ReduceAction(ObservableAgent* caster, const ActionStage sta
             }
         }
 
-        // notify the caster
         if (caster) {
             caster->stats.total_skills_used.Reduce(action, stage);
             caster->stats.LazyGetSkillUsed(action->skill_id).Reduce(action, stage);
 
-            // used against a target?
             if (target) {
-                // use against agent
                 caster->stats.LazyGetSkillUsedOn(target->agent_id, action->skill_id).Reduce(action, stage);
 
-                // team:
-                // same team
                 if (same_team) {
                     caster->stats.total_skills_used_on_own_team.Reduce(action, stage);
                 }
-                // diff team
                 else {
                     caster->stats.total_skills_used_on_other_teams.Reduce(action, stage);
                 }
             }
 
-            // party:
             if (target_party) {
-                // same party
                 if (same_party) {
                     caster->stats.total_skills_used_on_own_party.Reduce(action, stage);
                 }
-                // diff party
                 else {
                     caster->stats.total_skills_used_on_other_parties.Reduce(action, stage);
                 }
             }
         }
 
-        // notify the caster_party
         if (caster_party) {
             caster_party->stats.total_skills_used.Reduce(action, stage);
 
-            // team
-            // same team
             if (same_team) {
                 caster_party->stats.total_skills_used_on_own_team.Reduce(action, stage);
             }
-            // diff team
             else {
                 caster_party->stats.total_skills_used_on_other_teams.Reduce(action, stage);
             }
 
-            // party:
             if (target_party) {
-                // same party
                 if (same_party) {
                     caster_party->stats.total_skills_used_on_own_party.Reduce(action, stage);
                 }
-                // diff party
                 else {
                     caster_party->stats.total_skills_used_on_other_parties.Reduce(action, stage);
                 }
             }
         }
 
-        // notify the target
         if (target) {
             target->stats.total_skills_received.Reduce(action, stage);
             target->stats.LazyGetSkillReceived(action->skill_id).Reduce(action, stage);
             // used from a living caster? (redundant)
             if (caster) {
-                // use against agent
                 target->stats.LazyGetSkillReceivedFrom(caster->agent_id, action->skill_id).Reduce(action, stage);
 
-                // team
-                // same team
                 if (same_team) {
                     target->stats.total_skills_received_from_own_team.Reduce(action, stage);
                 }
-                // diff team
                 else {
                     target->stats.total_skills_received_from_other_teams.Reduce(action, stage);
                 }
             }
 
-            // party:
             if (caster_party) {
-                // same party
                 if (same_party) {
                     target->stats.total_skills_received_from_own_party.Reduce(action, stage);
                 }
-                // diff party
                 else {
                     target->stats.total_skills_received_from_other_parties.Reduce(action, stage);
                 }
             }
         }
 
-        // notify the target_party
         if (target_party) {
             target_party->stats.total_skills_received.Reduce(action, stage);
 
-            // team:
-            // same team
             if (same_team) {
                 target_party->stats.total_skills_received_from_own_team.Reduce(action, stage);
             }
-            // diff team
             else {
                 target_party->stats.total_skills_received_from_other_teams.Reduce(action, stage);
             }
 
-            // party:
             if (caster_party) {
-                // same party
                 if (same_party) {
                     target_party->stats.total_skills_received_from_own_party.Reduce(action, stage);
                 }
-                // diff party
                 else {
                     target_party->stats.total_skills_received_from_other_parties.Reduce(action, stage);
                 }
@@ -1399,17 +1281,14 @@ bool ObserverModule::ReduceAction(ObservableAgent* caster, const ActionStage sta
     // Track resurrection attempts for resurrection skills
     // Set resurrector when skill STARTS on a dead target, so it's already marked when AgentState arrives
     if (action->is_skill && target && caster) {
-        // Common resurrection skill IDs
         const auto skill_id = action->skill_id;
         const bool is_resurrection_skill = IsResurrectionSkill(skill_id);
         
         if (is_resurrection_skill) {
             if (stage == ActionStage::Started && target->is_dead) {
-                // Mark resurrector when skill starts on dead target
                 target->last_resurrector = caster->agent_id;
             }
             else if (stage == ActionStage::Stopped || stage == ActionStage::Interrupted) {
-                // Clear resurrector if skill was stopped/interrupted
                 if (target->last_resurrector == caster->agent_id) {
                     target->last_resurrector = NO_AGENT;
                 }
@@ -1421,7 +1300,6 @@ bool ObserverModule::ReduceAction(ObservableAgent* caster, const ActionStage sta
 }
 
 
-// Module: Reset the Modules state
 void ObserverModule::Reset()
 {
     if (map) {
@@ -1434,7 +1312,6 @@ void ObserverModule::Reset()
         match_start_map = nullptr;
     }
 
-    // clear guild info
     observable_guild_ids.clear();
     for (const auto& [_, guild] : observable_guilds) {
         if (guild) {
@@ -1443,7 +1320,6 @@ void ObserverModule::Reset()
     }
     observable_guilds.clear();
 
-    // clear skill info
     observable_skill_ids.clear();
     for (const auto& [_, skill] : observable_skills) {
         if (skill) {
@@ -1452,7 +1328,6 @@ void ObserverModule::Reset()
     }
     observable_skills.clear();
 
-    // clear agent info
     observable_agent_ids.clear();
     for (const auto& [_, agent] : observable_agents) {
         if (agent) {
@@ -1461,7 +1336,6 @@ void ObserverModule::Reset()
     }
     observable_agents.clear();
 
-    // clear party info
     observable_party_ids.clear();
     for (const auto& [_, party] : observable_parties) {
         if (party) {
@@ -1470,7 +1344,6 @@ void ObserverModule::Reset()
     }
     observable_parties.clear();
 
-    // clear max HP cache
     agent_max_hp_cache.clear();
 }
 
@@ -1488,18 +1361,15 @@ bool ObserverModule::InitializeObserverSession(GW::Constants::MapID map_id)
         map_id = GW::Map::GetMapID();
     }
     
-    // load area info for the observed map
     const GW::AreaInfo* map_info = GW::Map::GetMapInfo(map_id);
     if (!map_info) {
         return false;
     }
 
-    // load parties
     if (!SynchroniseParties()) {
         return false;
     }
 
-    // load all other agents
     const GW::AgentArray* agents = GW::Agents::GetAgentArray();
     if (!agents) {
         return false;
@@ -1514,7 +1384,6 @@ bool ObserverModule::InitializeObserverSession(GW::Constants::MapID map_id)
         GetObservableAgentById(agent->agent_id);
     }
 
-    // initialise the map
 
     delete map;
     map = new ObservableMap(map_id, *map_info);
@@ -1527,7 +1396,6 @@ bool ObserverModule::InitializeObserverSession(GW::Constants::MapID map_id)
     match_duration_secs = std::chrono::seconds(0);
     match_duration_mins = std::chrono::minutes(0);
 
-    // Clear the max HP cache for new session
     agent_max_hp_cache.clear();
 
     observer_session_initialized = true;
@@ -1535,7 +1403,6 @@ bool ObserverModule::InitializeObserverSession(GW::Constants::MapID map_id)
 }
 
 
-// Synchronise known parties in the area
 bool ObserverModule::SynchroniseParties()
 {
     GW::PartyContext* party_ctx = GW::GetGameContext()->party;
@@ -1552,7 +1419,6 @@ bool ObserverModule::SynchroniseParties()
         if (!party_info) {
             continue;
         }
-        // load and synchronize the party
         ObservableParty* observable_party = GetObservablePartyByPartyInfo(*party_info);
         if (observable_party) {
             const bool party_synchronised = observable_party->SynchroniseParty();
@@ -1562,12 +1428,10 @@ bool ObserverModule::SynchroniseParties()
         }
     }
 
-    // success
     return true;
 }
 
 
-// Draw internal settings
 void ObserverModule::DrawSettingsInternal()
 {
     ImGui::Text("Enable data collection in Observer Mode.");
@@ -1590,13 +1454,10 @@ void ObserverModule::Update(const float)
         party_sync_timer = 0;
     }
 
-    // Record health snapshots every 15 seconds for all tracked agents
     if (TIMER_DIFF(health_snapshot_timer) > 15000) {
         const uint32_t instance_time = GW::Map::GetInstanceTime();
-        // Use time relative to match start if available, otherwise use instance time
         const uint32_t match_time = match_start_instance_time > 0 ? (instance_time - match_start_instance_time) : instance_time;
         
-        // Calculate aggregate party health for each party
         for (const auto& [party_id, party] : observable_parties) {
             if (!party) continue;
             
@@ -1604,7 +1465,6 @@ void ObserverModule::Update(const float)
             uint32_t total_max_hp = 0;
             int valid_agents = 0;
             
-            // Sum health across all agents in this party
             for (const auto agent_id : party->agent_ids) {
                 const GW::Agent* agent = GW::Agents::GetAgentByID(agent_id);
                 if (!agent) continue;
@@ -1620,7 +1480,6 @@ void ObserverModule::Update(const float)
                 valid_agents++;
             }
             
-            // Record aggregate party health snapshot
             if (valid_agents > 0 && total_max_hp > 0) {
                 const float hp_percentage = total_hp / total_max_hp;
                 const uint32_t hp_value = static_cast<uint32_t>(total_hp);
@@ -1645,13 +1504,11 @@ void ObserverModule::Update(const float)
         if (observed_agent) {
             const GW::AgentLiving* living = observed_agent->GetAsAgentLiving();
             if (living && living->max_hp > 0 && living->max_hp < 100000) {
-                // Cache max HP if we don't have it yet, or if the value has changed
                 auto it = agent_max_hp_cache.find(observing_id);
                 if (it == agent_max_hp_cache.end() || it->second != living->max_hp) {
                     agent_max_hp_cache[observing_id] = living->max_hp;
                 }
 
-                // Cache energy values as well
                 if (living->max_energy > 0) {
                     agent_cur_energy_cache[observing_id] = static_cast<uint32_t>(living->energy);
                     agent_max_energy_cache[observing_id] = living->max_energy;
@@ -1664,20 +1521,16 @@ void ObserverModule::Update(const float)
 // Lazy load an ObservableGuild using a guild_id
 ObserverModule::ObservableGuild* ObserverModule::GetObservableGuildById(const uint32_t guild_id)
 {
-    // shortcircuit for agent_id = 0
     if (guild_id == NO_GUILD) {
         return nullptr;
     }
 
-    // lazy load
     const auto it = observable_guilds.find(guild_id);
 
-    // found
     if (it != observable_guilds.end()) {
         return it->second;
     }
 
-    // create if active
     if (!IsActive()) {
         return nullptr;
     }
@@ -1695,9 +1548,7 @@ ObserverModule::ObservableGuild* ObserverModule::GetObservableGuildById(const ui
 // Do NOT call this if the Agent already exists, it will cause a memory leak
 ObserverModule::ObservableGuild* ObserverModule::CreateObservableGuild(const GW::Guild& guild)
 {
-    // create
     auto observable_guild = new ObservableGuild(*this, guild);
-    // cache
     observable_guilds.insert({observable_guild->guild_id, observable_guild});
     observable_guild_ids.push_back(observable_guild->guild_id);
     std::ranges::sort(observable_guild_ids);
@@ -1708,20 +1559,16 @@ ObserverModule::ObservableGuild* ObserverModule::CreateObservableGuild(const GW:
 // Lazy load an ObservableAgent using an agent_id
 ObserverModule::ObservableAgent* ObserverModule::GetObservableAgentById(const uint32_t agent_id)
 {
-    // shortcircuit for agent_id = 0
     if (agent_id == NO_AGENT) {
         return nullptr;
     }
 
-    // lazy load
     const auto it = observable_agents.find(agent_id);
 
-    // found
     if (it != observable_agents.end()) {
         return it->second;
     }
 
-    // create if active
     if (!IsActive()) {
         return nullptr;
     }
@@ -1744,11 +1591,9 @@ ObserverModule::ObservableAgent* ObserverModule::GetObservableAgentById(const ui
 // Do NOT call this if the Agent already exists, it will cause a memory leak
 ObserverModule::ObservableAgent* ObserverModule::CreateObservableAgent(const GW::AgentLiving& agent_living)
 {
-    // create
     // ensure the guild is loaded...
     GetObservableGuildById(agent_living.tags->guild_id);
     auto observable_agent = new ObservableAgent(*this, agent_living);
-    // cache
     observable_agents.insert({observable_agent->agent_id, observable_agent});
     observable_agent_ids.push_back(observable_agent->agent_id);
     std::ranges::sort(observable_agent_ids);
@@ -1759,20 +1604,16 @@ ObserverModule::ObservableAgent* ObserverModule::CreateObservableAgent(const GW:
 // Lazy load an ObservableSkill using a skill_id
 ObserverModule::ObservableSkill* ObserverModule::GetObservableSkillById(const GW::Constants::SkillID skill_id)
 {
-    // short circuit for skill_id = 0
     if (skill_id == NO_SKILL) {
         return nullptr;
     }
 
-    // find
     const auto it_existing = observable_skills.find(skill_id);
 
-    // found
     if (it_existing != observable_skills.end()) {
         return it_existing->second;
     }
 
-    // create if active
     if (!IsActive()) {
         return nullptr;
     }
@@ -1789,9 +1630,7 @@ ObserverModule::ObservableSkill* ObserverModule::GetObservableSkillById(const GW
 // Do NOT call this is if the Skill already exists, It will cause a memory leak
 ObserverModule::ObservableSkill* ObserverModule::CreateObservableSkill(const GW::Skill& gw_skill)
 {
-    // create
     auto observable_skill = new ObservableSkill(*this, gw_skill);
-    // cache
     observable_skills.insert({gw_skill.skill_id, observable_skill});
     observable_skill_ids.push_back(observable_skill->skill_id);
     std::ranges::sort(observable_skill_ids);
@@ -1802,14 +1641,11 @@ ObserverModule::ObservableSkill* ObserverModule::CreateObservableSkill(const GW:
 // Lazy load an ObservableParty using a PartyInfo
 ObserverModule::ObservableParty* ObserverModule::GetObservablePartyByPartyInfo(const GW::PartyInfo& party_info)
 {
-    // lazy load
     const auto it_observable_party = observable_parties.find(party_info.party_id);
-    // found
     if (it_observable_party != observable_parties.end()) {
         return it_observable_party->second;
     }
 
-    // create if active
     if (!IsActive()) {
         return nullptr;
     }
@@ -1821,20 +1657,16 @@ ObserverModule::ObservableParty* ObserverModule::GetObservablePartyByPartyInfo(c
 // Lazy load an ObservableParty using a party_id
 ObserverModule::ObservableParty* ObserverModule::GetObservablePartyById(const uint32_t party_id)
 {
-    // shortcircuit for party_id = 0
     if (party_id == NO_PARTY) {
         return nullptr;
     }
 
-    // try to find
     const auto it_party = observable_parties.find(party_id);
 
-    // found
     if (it_party != observable_parties.end()) {
         return it_party->second;
     }
 
-    // create if active
     if (!IsActive()) {
         return nullptr;
     }
@@ -1843,13 +1675,11 @@ ObserverModule::ObservableParty* ObserverModule::GetObservablePartyById(const ui
         return nullptr;
     }
 
-    // get all parties
     const GW::Array<GW::PartyInfo*>& parties = party_ctx->parties;
     if (!parties.valid()) {
         return nullptr;
     }
 
-    // check index
     if (party_id >= parties.size()) {
         return nullptr;
     }
@@ -1858,7 +1688,6 @@ ObserverModule::ObservableParty* ObserverModule::GetObservablePartyById(const ui
         return nullptr;
     }
 
-    // create
     ObservableParty* observable_party = CreateObservableParty(*party_info);
 
     return observable_party;
@@ -1869,9 +1698,7 @@ ObserverModule::ObservableParty* ObserverModule::GetObservablePartyById(const ui
 // Do NOT call this if the party already exists, will cause memory leak
 ObserverModule::ObservableParty* ObserverModule::CreateObservableParty(const GW::PartyInfo& party_info)
 {
-    // create
     auto observable_party = new ObservableParty(*this, party_info);
-    // cache
     observable_parties.insert({observable_party->party_id, observable_party});
     observable_party_ids.push_back(observable_party->party_id);
     std::ranges::sort(observable_party_ids);
@@ -1918,36 +1745,29 @@ void ObserverModule::ObservedAction::Reduce(const TargetAction* action, const Ac
             break;
     }
 
-    // re-calculate integrity
     integrity = started - finished - stopped - interrupted;
 }
 
 
-// fired when the Agent dies
 void ObserverModule::SharedStats::HandleDeath()
 {
     deaths += 1;
-    // recalculate kdr
     kdr_pc = static_cast<float>(kills) / deaths;
-    // get kdr string
     std::stringstream str;
     str << std::fixed << std::setprecision(2) << kdr_pc;
     kdr_str = str.str();
 }
 
 
-// fired when the agent scores a kill
 void ObserverModule::SharedStats::HandleKill()
 {
     kills += 1;
-    // recalculate kdr
     if (deaths < 1) {
         kdr_pc = static_cast<float>(kills);
     }
     else {
         kdr_pc = static_cast<float>(kills) / deaths;
     }
-    // get kdr string
     std::stringstream str;
     str << std::fixed << std::setprecision(2) << kdr_pc;
     kdr_str = str.str();
@@ -1956,7 +1776,6 @@ void ObserverModule::SharedStats::HandleKill()
 
 ObserverModule::ObservableAgentStats::~ObservableAgentStats()
 {
-    // attacks received (by agent)
     for (const auto& [_, o_atk] : attacks_received_from_agents) {
         if (o_atk) {
             delete o_atk;
@@ -1964,7 +1783,6 @@ ObserverModule::ObservableAgentStats::~ObservableAgentStats()
     }
     attacks_received_from_agents.clear();
 
-    // attacks dealed (by agent)
     for (const auto& [_, o_atk] : attacks_dealt_to_agents) {
         if (o_atk) {
             delete o_atk;
@@ -1972,7 +1790,6 @@ ObserverModule::ObservableAgentStats::~ObservableAgentStats()
     }
     attacks_dealt_to_agents.clear();
 
-    // skills used
     skill_ids_used.clear();
     for (const auto& [_, o_skill] : skills_used) {
         if (o_skill) {
@@ -1981,7 +1798,6 @@ ObserverModule::ObservableAgentStats::~ObservableAgentStats()
     }
     skills_used.clear();
 
-    // skills received
     skill_ids_received.clear();
     for (const auto& [_, o_skill] : skills_received) {
         if (o_skill) {
@@ -1990,7 +1806,6 @@ ObserverModule::ObservableAgentStats::~ObservableAgentStats()
     }
     skills_received.clear();
 
-    // skill received (by agent)
     for (auto& [_, skill_ids] : skill_ids_received_from_agents) {
         skill_ids.clear();
     }
@@ -2005,7 +1820,6 @@ ObserverModule::ObservableAgentStats::~ObservableAgentStats()
     }
     skills_received_from_agents.clear();
 
-    // skill used (by agent)
     for (auto& [_, skill_ids] : skill_ids_used_on_agents) {
         skill_ids.clear();
     }
@@ -2020,7 +1834,6 @@ ObserverModule::ObservableAgentStats::~ObservableAgentStats()
     }
     skills_used_on_agents.clear();
 
-    // damage tracking cleanup
     damage_dealt_to_agents.clear();
     damage_received_from_agents.clear();
     damage_by_skill.clear();
@@ -2043,7 +1856,6 @@ ObserverModule::ObservableAgentStats::~ObservableAgentStats()
     }
     damage_from_skill_from_agents.clear();
 
-    // healing tracking cleanup
     healing_dealt_to_agents.clear();
     healing_received_from_agents.clear();
     healing_by_skill.clear();
@@ -2068,83 +1880,62 @@ ObserverModule::ObservableAgentStats::~ObservableAgentStats()
 }
 
 
-// Get attacks dealed against this agent, by a caster_agent_id
-// Lazy initialises the caster_agent_id
 ObserverModule::ObservedAction& ObserverModule::ObservableAgentStats::LazyGetAttacksDealedAgainst(const uint32_t target_agent_id)
 {
     const auto it = attacks_dealt_to_agents.find(target_agent_id);
     if (it == attacks_dealt_to_agents.end()) {
-        // receiver not registered
         auto observed_action = new ObservedAction();
         attacks_dealt_to_agents.insert({target_agent_id, observed_action});
         return *observed_action;
     }
-    // receiver is already reigstered
     return *it->second;
 }
 
 
-// Get attacks dealed against this agent, by a caster_agent_id
-// Lazy initialises the caster_agent_id
 ObserverModule::ObservedAction& ObserverModule::ObservableAgentStats::LazyGetAttacksReceivedFrom(const uint32_t caster_agent_id)
 {
     const auto it = attacks_received_from_agents.find(caster_agent_id);
     if (it == attacks_received_from_agents.end()) {
-        // attacker not registered
         auto observed_action = new ObservedAction();
         attacks_received_from_agents.insert({caster_agent_id, observed_action});
         return *observed_action;
     }
-    // attacker is already reigstered
     return *it->second;
 }
 
 
-// Get skills used by this agent
-// Lazy initialises the skill_id
 ObserverModule::ObservedAction& ObserverModule::ObservableAgentStats::LazyGetSkillUsed(const GW::Constants::SkillID skill_id)
 {
     const auto it_skill = skills_used.find(skill_id);
     if (it_skill == skills_used.end()) {
-        // skill not registered
         skill_ids_used.push_back(skill_id);
-        // re-sort skills
         std::ranges::sort(skill_ids_used);
         auto observed_skill = new ObservedSkill(skill_id);
         skills_used.insert({skill_id, observed_skill});
         return *observed_skill;
     }
-    // skill already registered
     return *it_skill->second;
 }
 
 
-// Get skills used received by this agent
-// Lazy initialises the skill_id
 ObserverModule::ObservedAction& ObserverModule::ObservableAgentStats::LazyGetSkillReceived(const GW::Constants::SkillID skill_id)
 {
     const auto it_skill = skills_received.find(skill_id);
     if (it_skill == skills_received.end()) {
-        // skill not registered
         skill_ids_received.push_back(skill_id);
-        // re-sort skills
         std::ranges::sort(skill_ids_received);
         auto observed_skill = new ObservedSkill(skill_id);
         skills_received.insert({skill_id, observed_skill});
         return *observed_skill;
     }
-    // skill already registered
     return *it_skill->second;
 }
 
 
-// Get a skill received by this agent, from another agent
-// Lazy initialises the skill_id and caster_agent_id
 ObserverModule::ObservedSkill& ObserverModule::ObservableAgentStats::LazyGetSkillReceivedFrom(const uint32_t caster_agent_id, const GW::Constants::SkillID skill_id)
 {
     const auto it_caster = skills_received_from_agents.find(caster_agent_id);
     if (it_caster == skills_received_from_agents.end()) {
-        // receiver and his skills are not registered with this agent
         std::vector received_skill_ids = {skill_id};
         skill_ids_received_from_agents.insert({caster_agent_id, received_skill_ids});
         auto observed_skill = new ObservedSkill(skill_id);
@@ -2152,34 +1943,24 @@ ObserverModule::ObservedSkill& ObserverModule::ObservableAgentStats::LazyGetSkil
         skills_received_from_agents.insert({caster_agent_id, received_skills});
         return *observed_skill;
     }
-    // receiver is registered with this agent
     std::unordered_map<GW::Constants::SkillID, ObservedSkill*>& used_by_caster = it_caster->second;
     const auto it_observed_skill = used_by_caster.find(skill_id);
-    // does receiver have the skill registered from/against us?
     if (it_observed_skill == used_by_caster.end()) {
-        // caster hasn't registered this skill with this agent
-        // add & re-sort skill_ids by the caster
         std::vector<GW::Constants::SkillID>& skills_ids_received_by_agent_vec = skill_ids_received_from_agents.find(caster_agent_id)->second;
         skills_ids_received_by_agent_vec.push_back(skill_id);
-        // re-sort
         std::ranges::sort(skills_ids_received_by_agent_vec);
-        // add the observed skill for the caster
         auto observed_skill = new ObservedSkill(skill_id);
         used_by_caster.insert({skill_id, observed_skill});
         return *observed_skill;
     }
-    // receivers already registered this skill
     return *it_observed_skill->second;
 }
 
 
-// Get a skill received by this agent, from another agent
-// Lazy initialises the skill_id and caster_agent_id
 ObserverModule::ObservedSkill& ObserverModule::ObservableAgentStats::LazyGetSkillUsedOn(const uint32_t target_agent_id, const GW::Constants::SkillID skill_id)
 {
     const auto it_target = skills_used_on_agents.find(target_agent_id);
     if (it_target == skills_used_on_agents.end()) {
-        // receiver and his skills are not registered with this agent
         std::vector used_skill_ids = {skill_id};
         skill_ids_used_on_agents.insert({target_agent_id, used_skill_ids});
         auto observed_skill = new ObservedSkill(skill_id);
@@ -2188,28 +1969,19 @@ ObserverModule::ObservedSkill& ObserverModule::ObservableAgentStats::LazyGetSkil
         return *observed_skill;
     }
     std::unordered_map<GW::Constants::SkillID, ObservedSkill*>& used_on_target = it_target->second;
-    // receiver is registered with this agent
     const auto it_observed_skill = used_on_target.find(skill_id);
-    // does receiver have the skill registered from/against us?
     if (it_observed_skill == used_on_target.end()) {
-        // target hasn't registered this skill with this agent
-        // add & re-sort skill_ids by the caster
         std::vector<GW::Constants::SkillID>& skills_ids_used_on_agent_vec = skill_ids_used_on_agents.find(target_agent_id)->second;
         skills_ids_used_on_agent_vec.push_back(skill_id);
-        // re-sort
         std::ranges::sort(skills_ids_used_on_agent_vec);
-        // add the observed skill for the caster
         auto observed_skill = new ObservedSkill(skill_id);
         used_on_target.insert({skill_id, observed_skill});
         return *observed_skill;
     }
-    // receivers already registered this skill
     return *it_observed_skill->second;
 }
 
 
-// Get damage dealt to a target agent
-// Lazy initialises the target_agent_id
 uint32_t& ObserverModule::ObservableAgentStats::LazyGetDamageDealedAgainst(const uint32_t target_agent_id)
 {
     const auto it = damage_dealt_to_agents.find(target_agent_id);
@@ -2221,8 +1993,6 @@ uint32_t& ObserverModule::ObservableAgentStats::LazyGetDamageDealedAgainst(const
 }
 
 
-// Get damage received from a caster agent
-// Lazy initialises the caster_agent_id
 uint32_t& ObserverModule::ObservableAgentStats::LazyGetDamageReceivedFrom(const uint32_t caster_agent_id)
 {
     const auto it = damage_received_from_agents.find(caster_agent_id);
@@ -2234,8 +2004,6 @@ uint32_t& ObserverModule::ObservableAgentStats::LazyGetDamageReceivedFrom(const 
 }
 
 
-// Get damage dealt by a skill
-// Lazy initialises the skill_id
 uint32_t& ObserverModule::ObservableAgentStats::LazyGetDamageBySkill(const GW::Constants::SkillID skill_id)
 {
     const auto it = damage_by_skill.find(skill_id);
@@ -2247,24 +2015,19 @@ uint32_t& ObserverModule::ObservableAgentStats::LazyGetDamageBySkill(const GW::C
 }
 
 
-// Get damage dealt by a skill to a specific agent
-// Lazy initialises the target_agent_id and skill_id
 uint32_t& ObserverModule::ObservableAgentStats::LazyGetDamageBySkillToAgent(const uint32_t target_agent_id, const GW::Constants::SkillID skill_id)
 {
     const auto it_target = damage_by_skill_to_agents.find(target_agent_id);
     if (it_target == damage_by_skill_to_agents.end()) {
-        // target and skills are not registered
         std::vector skill_ids = {skill_id};
         skill_ids_damage_to_agents.insert({target_agent_id, skill_ids});
         std::unordered_map<GW::Constants::SkillID, uint32_t> skill_damage = {{skill_id, 0}};
         damage_by_skill_to_agents.insert({target_agent_id, skill_damage});
         return damage_by_skill_to_agents[target_agent_id][skill_id];
     }
-    // target is registered
     std::unordered_map<GW::Constants::SkillID, uint32_t>& damage_to_target = it_target->second;
     const auto it_skill = damage_to_target.find(skill_id);
     if (it_skill == damage_to_target.end()) {
-        // skill not registered for this target
         std::vector<GW::Constants::SkillID>& skill_ids_vec = skill_ids_damage_to_agents.find(target_agent_id)->second;
         skill_ids_vec.push_back(skill_id);
         std::ranges::sort(skill_ids_vec);
@@ -2275,24 +2038,19 @@ uint32_t& ObserverModule::ObservableAgentStats::LazyGetDamageBySkillToAgent(cons
 }
 
 
-// Get damage received from a skill from a specific agent
-// Lazy initialises the caster_agent_id and skill_id
 uint32_t& ObserverModule::ObservableAgentStats::LazyGetDamageFromSkillFromAgent(const uint32_t caster_agent_id, const GW::Constants::SkillID skill_id)
 {
     const auto it_caster = damage_from_skill_from_agents.find(caster_agent_id);
     if (it_caster == damage_from_skill_from_agents.end()) {
-        // caster and skills are not registered
         std::vector skill_ids = {skill_id};
         skill_ids_damage_from_agents.insert({caster_agent_id, skill_ids});
         std::unordered_map<GW::Constants::SkillID, uint32_t> skill_damage = {{skill_id, 0}};
         damage_from_skill_from_agents.insert({caster_agent_id, skill_damage});
         return damage_from_skill_from_agents[caster_agent_id][skill_id];
     }
-    // caster is registered
     std::unordered_map<GW::Constants::SkillID, uint32_t>& damage_from_caster = it_caster->second;
     const auto it_skill = damage_from_caster.find(skill_id);
     if (it_skill == damage_from_caster.end()) {
-        // skill not registered for this caster
         std::vector<GW::Constants::SkillID>& skill_ids_vec = skill_ids_damage_from_agents.find(caster_agent_id)->second;
         skill_ids_vec.push_back(skill_id);
         std::ranges::sort(skill_ids_vec);
@@ -2303,8 +2061,6 @@ uint32_t& ObserverModule::ObservableAgentStats::LazyGetDamageFromSkillFromAgent(
 }
 
 
-// Get healing dealt to a target agent
-// Lazy initialises the target_agent_id
 uint32_t& ObserverModule::ObservableAgentStats::LazyGetHealingDealedTo(const uint32_t target_agent_id)
 {
     const auto it = healing_dealt_to_agents.find(target_agent_id);
@@ -2316,8 +2072,6 @@ uint32_t& ObserverModule::ObservableAgentStats::LazyGetHealingDealedTo(const uin
 }
 
 
-// Get healing received from a caster agent
-// Lazy initialises the caster_agent_id
 uint32_t& ObserverModule::ObservableAgentStats::LazyGetHealingReceivedFrom(const uint32_t caster_agent_id)
 {
     const auto it = healing_received_from_agents.find(caster_agent_id);
@@ -2329,8 +2083,6 @@ uint32_t& ObserverModule::ObservableAgentStats::LazyGetHealingReceivedFrom(const
 }
 
 
-// Get healing dealt by a skill
-// Lazy initialises the skill_id
 uint32_t& ObserverModule::ObservableAgentStats::LazyGetHealingBySkill(const GW::Constants::SkillID skill_id)
 {
     const auto it = healing_by_skill.find(skill_id);
@@ -2342,24 +2094,19 @@ uint32_t& ObserverModule::ObservableAgentStats::LazyGetHealingBySkill(const GW::
 }
 
 
-// Get healing dealt by a skill to a specific agent
-// Lazy initialises the target_agent_id and skill_id
 uint32_t& ObserverModule::ObservableAgentStats::LazyGetHealingBySkillToAgent(const uint32_t target_agent_id, const GW::Constants::SkillID skill_id)
 {
     const auto it_target = healing_by_skill_to_agents.find(target_agent_id);
     if (it_target == healing_by_skill_to_agents.end()) {
-        // target and skills are not registered
         std::vector skill_ids = {skill_id};
         skill_ids_healing_to_agents.insert({target_agent_id, skill_ids});
         std::unordered_map<GW::Constants::SkillID, uint32_t> skill_healing = {{skill_id, 0}};
         healing_by_skill_to_agents.insert({target_agent_id, skill_healing});
         return healing_by_skill_to_agents[target_agent_id][skill_id];
     }
-    // target is registered
     std::unordered_map<GW::Constants::SkillID, uint32_t>& healing_to_target = it_target->second;
     const auto it_skill = healing_to_target.find(skill_id);
     if (it_skill == healing_to_target.end()) {
-        // skill not registered for this target
         std::vector<GW::Constants::SkillID>& skill_ids_vec = skill_ids_healing_to_agents.find(target_agent_id)->second;
         skill_ids_vec.push_back(skill_id);
         std::ranges::sort(skill_ids_vec);
@@ -2370,24 +2117,19 @@ uint32_t& ObserverModule::ObservableAgentStats::LazyGetHealingBySkillToAgent(con
 }
 
 
-// Get healing received from a skill from a specific agent
-// Lazy initialises the caster_agent_id and skill_id
 uint32_t& ObserverModule::ObservableAgentStats::LazyGetHealingFromSkillFromAgent(const uint32_t caster_agent_id, const GW::Constants::SkillID skill_id)
 {
     const auto it_caster = healing_from_skill_from_agents.find(caster_agent_id);
     if (it_caster == healing_from_skill_from_agents.end()) {
-        // caster and skills are not registered
         std::vector skill_ids = {skill_id};
         skill_ids_healing_from_agents.insert({caster_agent_id, skill_ids});
         std::unordered_map<GW::Constants::SkillID, uint32_t> skill_healing = {{skill_id, 0}};
         healing_from_skill_from_agents.insert({caster_agent_id, skill_healing});
         return healing_from_skill_from_agents[caster_agent_id][skill_id];
     }
-    // caster is registered
     std::unordered_map<GW::Constants::SkillID, uint32_t>& healing_from_caster = it_caster->second;
     const auto it_skill = healing_from_caster.find(skill_id);
     if (it_skill == healing_from_caster.end()) {
-        // skill not registered for this caster
         std::vector<GW::Constants::SkillID>& skill_ids_vec = skill_ids_healing_from_agents.find(caster_agent_id)->second;
         skill_ids_vec.push_back(skill_id);
         std::ranges::sort(skill_ids_vec);
@@ -2398,18 +2140,15 @@ uint32_t& ObserverModule::ObservableAgentStats::LazyGetHealingFromSkillFromAgent
 }
 
 
-// Constructor
 ObserverModule::ObservableParty::ObservableParty(ObserverModule& parent, const GW::PartyInfo& info) : party_id(info.party_id), parent(parent) {}
 
 
-// Destructor
 ObserverModule::ObservableParty::~ObservableParty()
 {
     agent_ids.clear();
 }
 
 
-// Synchronise the ObservableParty with its agents/members
 // Does not load Party Allies (others) (Pets, Guild Lord, Bodyguard, ...)
 bool ObserverModule::ObservableParty::SynchroniseParty()
 {
@@ -2439,18 +2178,12 @@ bool ObserverModule::ObservableParty::SynchroniseParty()
 
     size_t party_index = 0;
 
-    // ensure agent_ids size
     const size_t party_size = party_info->players.size() + party_info->heroes.size() + party_info->henchmen.size();
     if (party_size > agent_ids.size()) {
-        // agent_ids is too small
-        // add empty agent_ids
         agent_ids.resize(party_size, NO_AGENT);
     }
     else if (party_size < agent_ids.size()) {
-        // agent_ids is too large
-        // clear stale agent_ids
         for (size_t i = party_size; i < agent_ids.size(); i += 1) {
-            // clear old party member
             ObservableAgent* observable_agent_prev = parent.GetObservableAgentById(agent_ids[i]);
             if (observable_agent_prev) {
                 observable_agent_prev->party_id = NO_PARTY;
@@ -2460,27 +2193,22 @@ bool ObserverModule::ObservableParty::SynchroniseParty()
         agent_ids.resize(party_size, NO_AGENT);
     }
 
-    // fill agent_ids and notify the agents
     for (const GW::PlayerPartyMember& party_player : party_info->players) {
-        // notify the player of their party & position
         const GW::Player& player = players->at(party_player.login_number);
         if (player.agent_id != 0) {
             // if agent_id is 0, the agent either hasn't loaded or has disconnected
             // if the agent has simply disconnected we keep them from agent_ids
             // by avoiding this code block
             if (agent_ids[party_index] != player.agent_id) {
-                // clear old party member
                 ObservableAgent* observable_player_prev = parent.GetObservableAgentById(agent_ids[party_index]);
                 if (observable_player_prev) {
                     observable_player_prev->party_id = NO_PARTY;
                     observable_player_prev->party_index = 0;
                 }
             }
-            // add new party member
             agent_ids[party_index] = player.agent_id;
             ObservableAgent* observable_player = parent.GetObservableAgentById(player.agent_id);
             if (observable_player) {
-                // notify the player of their party & position
                 observable_player->party_id = party_id;
                 observable_player->party_index = party_index;
             }
@@ -2494,18 +2222,15 @@ bool ObserverModule::ObservableParty::SynchroniseParty()
                     // out of scope/compass for some reason if agent_id = 0;
                     // just leave the previous entry in our party
                     if (agent_ids[party_index] != hero.agent_id) {
-                        // clear old party member
                         ObservableAgent* observable_hero_prev = parent.GetObservableAgentById(agent_ids[party_index]);
                         if (observable_hero_prev) {
                             observable_hero_prev->party_id = NO_PARTY;
                             observable_hero_prev->party_index = 0;
                         }
                     }
-                    // add new party member
                     agent_ids[party_index] = hero.agent_id;
                     ObservableAgent* observable_hero = parent.GetObservableAgentById(hero.agent_id);
                     if (observable_hero) {
-                        // notify the hero of their party & position
                         observable_hero->party_id = party_id;
                         observable_hero->party_index = party_index;
                     }
@@ -2520,18 +2245,15 @@ bool ObserverModule::ObservableParty::SynchroniseParty()
             // out of scope/compass for some reason if agent_id = 0;
             // just leave the previous entry in our party
             if (agent_ids[party_index] != hench.agent_id) {
-                // clear old party member
                 ObservableAgent* observable_hench_prev = parent.GetObservableAgentById(agent_ids[party_index]);
                 if (observable_hench_prev) {
                     observable_hench_prev->party_id = NO_PARTY;
                     observable_hench_prev->party_index = 0;
                 }
             }
-            // add new party member
             agent_ids[party_index] = hench.agent_id;
             ObservableAgent* observable_hench = parent.GetObservableAgentById(hench.agent_id);
             if (observable_hench) {
-                // notify the henchman of their party & position
                 observable_hench->party_id = party_id;
                 observable_hench->party_index = party_index;
             }
@@ -2568,35 +2290,28 @@ bool ObserverModule::ObservableParty::SynchroniseParty()
         }
     }
 
-    // success
     return true;
 }
 
 
-// Constructor
 ObserverModule::ObservableSkill::ObservableSkill(ObserverModule& parent, const GW::Skill& _gw_skill) : parent(parent), gw_skill(_gw_skill)
 {
     skill_id = _gw_skill.skill_id;
-    // initialize the name asynchronously here
     if (!name_enc[0] && GW::UI::UInt32ToEncStr(gw_skill.name, name_enc, 16)) {
         GW::UI::AsyncDecodeStr(name_enc, name_dec, 256);
     }
 }
 
 
-// Name of the skill
 const std::string ObserverModule::ObservableSkill::Name()
 {
-    // cached?
     if (_name.length() > 0) {
         return _name;
     }
     std::string name = TextUtils::WStringToString(DecName());
-    // not ready to cache
     if (name.length() == 0) {
         return name;
     }
-    // ready to cache
     _name = name;
     return _name;
 }
@@ -2610,7 +2325,6 @@ std::string ObserverModule::ObservableSkill::DebugName()
 }
 
 
-// Constructor
 ObserverModule::ObservableGuild::ObservableGuild(ObserverModule& parent, const GW::Guild& guild)
     : parent(parent), guild_id(guild.index), key(guild.key), name(TextUtils::WStringToString(guild.name)), tag(TextUtils::WStringToString(guild.tag)), wrapped_tag("[" + tag + "]"), rank(guild.rank), rating(guild.rating), faction(guild.faction),
       faction_point(guild.faction_point), qualifier_point(guild.qualifier_point), cape_trim(guild.cape.cape_trim)
@@ -2619,7 +2333,6 @@ ObserverModule::ObservableGuild::ObservableGuild(ObserverModule& parent, const G
 }
 
 
-// Constructor
 ObserverModule::ObservableAgent::ObservableAgent(ObserverModule& parent, const GW::AgentLiving& agent_living)
     : parent(parent), agent_id(agent_living.agent_id), login_number(agent_living.login_number), state(agent_living.model_state), guild_id(static_cast<uint32_t>(agent_living.tags->guild_id)), team_id(agent_living.team_id),
       primary(static_cast<GW::Constants::Profession>(agent_living.primary)), secondary(static_cast<GW::Constants::Profession>(agent_living.secondary)), is_player(agent_living.IsPlayer()), is_npc(agent_living.IsNPC())
@@ -2638,7 +2351,6 @@ ObserverModule::ObservableAgent::ObservableAgent(ObserverModule& parent, const G
 };
 
 
-// Destructor
 ObserverModule::ObservableAgent::~ObservableAgent()
 {
     delete current_target_action;
@@ -2655,7 +2367,6 @@ std::string ObserverModule::ObservableAgent::DisplayName()
         return _display_name;
     }
 
-    // generate and cache display_name
     std::string next_display_name = RawName();
 
     // remove hench name
@@ -2667,7 +2378,6 @@ std::string ObserverModule::ObservableAgent::DisplayName()
         }
     }
 
-    // trim whitespace
     const size_t w_first = next_display_name.find_first_not_of(' ');
     const size_t w_last = next_display_name.find_last_not_of(' ');
     if (w_first != std::string::npos) {
@@ -2680,61 +2390,48 @@ std::string ObserverModule::ObservableAgent::DisplayName()
 }
 
 
-// Sanitized Name of the Agent (as std::string)
 std::string ObserverModule::ObservableAgent::SanitizedName()
 {
-    // has been cached
     if (_sanitized_name.length() > 0) {
         return _sanitized_name;
     }
     const std::wstring sanitized_name_w = SanitizedNameW();
-    // can't be cached yet
     if (sanitized_name_w.length() == 0) {
         return "";
     }
-    // can now be cached
     _sanitized_name = TextUtils::WStringToString(sanitized_name_w);
     return _sanitized_name;
 }
 
 
-// Sanitized Name of the Agent (as std::wstring)
 std::wstring ObserverModule::ObservableAgent::SanitizedNameW()
 {
-    // has been cached
     if (_sanitized_name_w.length() > 0) {
         return _sanitized_name_w;
     }
     const std::wstring raw_name_w = RawNameW();
-    // can't be cached yet
     if (raw_name_w.length() == 0) {
         return L"";
     }
-    // can now be cached
     _sanitized_name_w = TextUtils::SanitizePlayerName(raw_name_w);
     return _sanitized_name_w;
 }
 
 
-// Name of the Agent (as std::string)
 std::string ObserverModule::ObservableAgent::RawName()
 {
-    // has been cached
     if (_raw_name.length() > 0) {
         return _raw_name;
     }
     const std::wstring raw_name_w = RawNameW();
-    // can't be cached yet
     if (raw_name_w.length() == 0) {
         return "";
     }
-    // can now be cached
     _raw_name = TextUtils::WStringToString(raw_name_w);
     return _raw_name;
 }
 
 
-// Name of the Agent (un-edited as wstring)
 std::wstring ObserverModule::ObservableAgent::RawNameW()
 {
     // rely on the constructor initialising the name...
@@ -2750,22 +2447,18 @@ std::string ObserverModule::ObservableAgent::DebugName()
 }
 
 
-// Constructor
 ObserverModule::ObservableMap::ObservableMap(const GW::Constants::MapID map_id, const GW::AreaInfo& area_info)
     : map_id(map_id), campaign(area_info.campaign), continent(area_info.continent), region(area_info.region), type(area_info.type), flags(area_info.flags), name_id(area_info.name_id), description_id(area_info.description_id)
 {
-    // async initialise the name
     if (GW::UI::UInt32ToEncStr(area_info.name_id, name_enc, 8)) {
         GW::UI::AsyncDecodeStr(name_enc, &name_w);
     }
 
-    // async initialise the description
     if (GW::UI::UInt32ToEncStr(area_info.description_id, description_enc, 8)) {
         GW::UI::AsyncDecodeStr(description_enc, &description_w);
     }
 }
 
-// Cache & return name
 std::string ObserverModule::ObservableMap::Name()
 {
     if (name.length() > 0) {
@@ -2775,7 +2468,6 @@ std::string ObserverModule::ObservableMap::Name()
     return name;
 }
 
-// Cache & return description
 std::string ObserverModule::ObservableMap::Description()
 {
     if (description.length() > 0) {

--- a/GWToolboxdll/Modules/ObserverModule.h
+++ b/GWToolboxdll/Modules/ObserverModule.h
@@ -62,7 +62,6 @@ public:
         Interrupted // "Interrupted" is received after "Stopped"
     };
 
-    // Death event tracking
     struct DeathEvent {
         uint32_t timestamp_ms;      // Match time when death occurred
         float position_x;           // X coordinate of death
@@ -75,7 +74,6 @@ public:
             : timestamp_ms(ts), position_x(x), position_y(y), killer_agent_id(killer), killing_skill_id(skill), is_npc(npc) {}
     };
 
-    // Morale boost event tracking
     struct MoraleBoostEvent {
         uint32_t timestamp_ms;      // Match time when morale boost occurred
         
@@ -251,10 +249,8 @@ public:
         // skills received from other team (inc. npcs)
         ObservedAction total_skills_received_from_other_teams;
 
-        // fired when the agent dies
         void HandleDeath();
 
-        // fired when the agent scores a kill
         void HandleKill();
     };
 
@@ -402,10 +398,8 @@ public:
         // Track the skill that last damaged this agent (for death tracking)
         GW::Constants::SkillID last_damage_skill_id = NO_SKILL;
 
-        // Track if agent is currently dead
         bool is_dead = false;
         
-        // Track who last used a resurrection skill on this agent
         uint32_t last_resurrector = NO_AGENT;
 
         // TODO: last_hit_at to limit the kill window
@@ -413,13 +407,10 @@ public:
         bool is_player;
         bool is_npc;
 
-        // stats:
         ObservableAgentStats stats;;
 
-        // Death event (if agent died)
         std::vector<DeathEvent> death_events;
         
-        // Resurrection events (if agent was resurrected)
         std::vector<ResurrectionEvent> resurrection_events;
 
         // name fns with excessive caching & lazy loading
@@ -519,7 +510,6 @@ public:
 
         bool SynchroniseParty();
 
-        // agent_ids representing the players
         std::vector<uint32_t> agent_ids = {};
 
         // Aggregate party health snapshots (every 15 seconds)
@@ -672,7 +662,6 @@ private:
     void HandleHealingDone(uint32_t caster_id, uint32_t target_id, float amount_pc);
     void HandleAgentAdd(uint32_t agent_id);
 
-    // Helper function to get or cache max HP for an agent
     uint32_t GetOrCacheMaxHP(uint32_t agent_id);
 
     void HandleAttackFinished(uint32_t agent_id);

--- a/GWToolboxdll/Modules/PartyWindowModule.cpp
+++ b/GWToolboxdll/Modules/PartyWindowModule.cpp
@@ -387,7 +387,6 @@ namespace {
                 wcsncpy(prev_name, enc_name, _countof(prev_name) - 1);
             }
         }
-        // 1. Remove NPC from window.
         GW::StoC::EmulatePacket(&packet);
         SetAgentName(agent_id, prev_name);
         const auto it = std::ranges::find(allies_added_to_party, agent_id);
@@ -416,7 +415,6 @@ namespace {
         packet.agent_type = p.player_number | 0x20000000;
         packet.allegiance_bits = 1886151033;
 
-        // 1. Remove NPC from window.
         GW::StoC::EmulatePacket(&packet);
         SetAgentName(p.agent_id, prev_name);
 
@@ -479,19 +477,16 @@ namespace {
                     match_quality++; // Secondary match is worth 1 point
                 }
 
-                // Choose this position if it's a better match than what we have
                 if (match_quality > *match_quality_out || (match_quality == *match_quality_out && i < *sort_pos_out)) {
                     *sort_pos_out = i;
                     *match_quality_out = match_quality;
                 }
             }
         };
-        // Find best match for first player
         size_t p1_sort_pos = SIZE_MAX;
         int p1_match_quality = -1; // Higher = better match
         CalcSortPos(p1, &p1_sort_pos, &p1_match_quality);
 
-        // Find best match for second player
         size_t p2_sort_pos = SIZE_MAX;
         int p2_match_quality = -1;
         CalcSortPos(p2, &p2_sort_pos, &p2_match_quality);
@@ -671,7 +666,6 @@ namespace {
             auto& sorting = party_sortings[i];
             ImGui::PushID(static_cast<int>(i));
 
-            // Map name
             const char* map_name = "Any Map";
             if (sorting.map_id != GW::Constants::MapID::None) {
                 auto* enc_name = Resources::GetMapName(sorting.map_id);
@@ -687,7 +681,6 @@ namespace {
             ImGui::TextUnformatted(map_name);
             ImGui::SameLine(sort_cols[0]);
 
-            // Party size
             if (sorting.party_size == 0) {
                 ImGui::Text("Any");
             }
@@ -696,7 +689,6 @@ namespace {
             }
             ImGui::SameLine(sort_cols[1]);
 
-            // Sort order display
             std::string sort_display;
             for (size_t j = 0; j < sorting.sorting_by_profession.size(); j++) {
                 if (j > 0) sort_display += " -> ";
@@ -708,7 +700,6 @@ namespace {
 
             ImGui::SameLine(sort_cols[2]);
 
-            // Edit button
             if (ImGui::Button("Edit")) {
                 edit_sorting_index = i;
                 edit_map_id = static_cast<int>(sorting.map_id);
@@ -717,7 +708,6 @@ namespace {
             }
             ImGui::SameLine();
 
-            // Delete button
             if (ImGui::Button("Delete")) {
                 party_sortings.erase(party_sortings.begin() + i);
                 if (chosen_sorting_vector == &sorting) {
@@ -737,11 +727,9 @@ namespace {
 
 
 
-        // Add/Edit party sorting
         const bool is_editing = (edit_sorting_index >= 0);
         ImGui::Text(is_editing ? "Edit Party Sorting:" : "Add New Party Sorting:");
 
-        // Map selection
         ImGui::Text("Map ID (0 = Any):");
         ImGui::SameLine(200.0f * fontScale);
         ImGui::SetNextItemWidth(100.0f * fontScale);
@@ -750,7 +738,6 @@ namespace {
             ImGui::SameLine();
             ImGui::TextDisabled(Resources::GetMapName((GW::Constants::MapID)edit_map_id)->string().c_str());
         }
-        // Party size
         ImGui::Text("Party Size (0 = Any):");
         ImGui::SameLine(200.0f * fontScale);
         ImGui::SetNextItemWidth(100.0f * fontScale);
@@ -758,7 +745,6 @@ namespace {
         if (edit_party_size < 0) edit_party_size = 0;
         if (edit_party_size > 12) edit_party_size = 12;
 
-        // Profession order
         ImGui::Text("Profession Order:");
         ImGui::BeginChild("profession_order_edit", ImVec2(0, 150.0f), true);
 
@@ -771,7 +757,6 @@ namespace {
             ImGui::Text("%zu.", i + 1);
             ImGui::SameLine();
 
-            // Primary profession combo
             ImGui::SetNextItemWidth(120.0f * fontScale);
             if (ImGui::BeginCombo("##primary", ToolboxUtils::GetProfessionAcronym(static_cast<GW::Constants::Profession>(primary))->string().c_str())) {
                 for (uint8_t prof = 0; prof <= 10; prof++) {
@@ -788,7 +773,6 @@ namespace {
             ImGui::Text("/");
             ImGui::SameLine();
 
-            // Secondary profession combo
             ImGui::SetNextItemWidth(120.0f * fontScale);
             if (ImGui::BeginCombo("##secondary", ToolboxUtils::GetProfessionAcronym(static_cast<GW::Constants::Profession>(secondary))->string().c_str())) {
                 for (uint8_t prof = 0; prof <= 10; prof++) {
@@ -803,7 +787,6 @@ namespace {
 
             
 
-            // Move up button
             ImGui::SameLine();
             if (ImGui::Button(ICON_FA_ARROW_UP) && i > 0) 
                 std::swap(edit_profession_order[i], edit_profession_order[i - 1]);
@@ -813,7 +796,6 @@ namespace {
                 std::swap(edit_profession_order[i], edit_profession_order[i + 1]);
 
             ImGui::SameLine();
-            // Remove button
             if (ImGui::Button("Remove")) {
                 edit_profession_order.erase(edit_profession_order.begin() + i);
                 ImGui::PopID();
@@ -824,14 +806,12 @@ namespace {
         }
         ImGui::EndChild();
 
-        // Add profession button
         if (ImGui::Button("Add Profession")) {
             edit_profession_order.push_back(0); // Any/Any
         }
 
         ImGui::SameLine();
 
-        // Save button
         if (ImGui::Button(is_editing ? "Save Changes" : "Add Sorting")) {
             if (edit_profession_order.empty()) {
                 Log::Error("At least one profession entry is required");
@@ -852,7 +832,6 @@ namespace {
                     Log::Flash("Added new party sorting");
                 }
 
-                // Clear edit state
                 edit_map_id = 0;
                 edit_party_size = 0;
                 edit_profession_order.clear();
@@ -1120,7 +1099,6 @@ void PartyWindowModule::LoadSettings(SettingsDoc& doc, ToolboxIni* legacy)
         }
     }
     else if (legacy) {
-        // get all keys in a section
         TNamesDepend keys;
         legacy->GetAllKeys(Name(), keys);
         if (keys.empty()) {
@@ -1169,7 +1147,6 @@ void PartyWindowModule::LoadSettings(SettingsDoc& doc, ToolboxIni* legacy)
         }
     }
     else if (legacy) {
-        // Load party sorting configurations
         party_sortings.clear();
         long sorting_count = legacy->GetLongValue(Name(), "party_sorting_count", 0);
 
@@ -1178,11 +1155,9 @@ void PartyWindowModule::LoadSettings(SettingsDoc& doc, ToolboxIni* legacy)
 
             PartySorting sorting;
 
-            // Load map ID and party size
             sorting.map_id = static_cast<GW::Constants::MapID>(legacy->GetLongValue(Name(), (prefix + "map_id").c_str(), 0));
             sorting.party_size = static_cast<uint32_t>(legacy->GetLongValue(Name(), (prefix + "party_size").c_str(), 0));
 
-            // Load profession order
             long profession_count = legacy->GetLongValue(Name(), (prefix + "profession_count").c_str(), 0);
             sorting.sorting_by_profession.reserve(profession_count);
 
@@ -1192,7 +1167,6 @@ void PartyWindowModule::LoadSettings(SettingsDoc& doc, ToolboxIni* legacy)
                 sorting.sorting_by_profession.push_back(profession_combo);
             }
 
-            // Only add if we have at least one profession entry
             if (!sorting.sorting_by_profession.empty()) {
                 party_sortings.push_back(sorting);
             }

--- a/GWToolboxdll/Modules/PluginModule.cpp
+++ b/GWToolboxdll/Modules/PluginModule.cpp
@@ -266,7 +266,6 @@ void PluginModule::LoadSettings(SettingsDoc& doc, ToolboxIni* legacy)
         auto matching_plugins = std::views::filter(plugins_available, [filename](auto plugin) {
             return plugin->path.filename() == filename;
         });
-        // Find any matching plugins and load them
         for (const auto plugin : matching_plugins) {
             if (!LoadPlugin(plugin)) {
                 continue;

--- a/GWToolboxdll/Modules/QuestModule.cpp
+++ b/GWToolboxdll/Modules/QuestModule.cpp
@@ -438,14 +438,12 @@ namespace {
 
     bool is_spoofing_quest_update = false;
 
-    // Settings
     GW::GamePos* GetPlayerPos()
     {
         const auto p = GW::Agents::GetControlledCharacter();
         return p ? &p->pos : nullptr;
     }
 
-    // Cast helper
     float GetSquareDistance(const GW::GamePos& a, const GW::GamePos& b)
     {
         return GetSquareDistance(static_cast<GW::Vec2f>(a), static_cast<GW::Vec2f>(b));

--- a/GWToolboxdll/Modules/QuestModule.h
+++ b/GWToolboxdll/Modules/QuestModule.h
@@ -17,11 +17,9 @@ namespace GuiUtils {
 struct QuestObjective {
     QuestObjective(GW::Constants::QuestID quest_id, const wchar_t* objective_enc, bool is_completed);
     ~QuestObjective() = default;
-    // copy not allowed
     QuestObjective(const QuestObjective& other) = delete;
     QuestObjective(QuestObjective&& other) noexcept = default;
 
-    // copy not allowed
     QuestObjective& operator=(const QuestObjective& other) = delete;
     QuestObjective& operator=(QuestObjective&& other) noexcept = default;
 

--- a/GWToolboxdll/Modules/Resources.cpp
+++ b/GWToolboxdll/Modules/Resources.cpp
@@ -50,7 +50,6 @@
 
 
 namespace {
-    // Define the IID if not already defined
 
     DXGI_FORMAT ConvertD3D9FormatToDXGI(D3DFORMAT d3d9Format)
     {
@@ -163,7 +162,6 @@ namespace {
     IDirect3DTexture9* empty_texture_ptr = nullptr;
     bool should_stop = false;
 
-    // snprintf error message, pass to callback as a failure. Used internally.
     void trigger_failure_callback(const std::function<void(bool, const std::wstring&)>& callback, const wchar_t* format, ...)
     {
         std::wstring out;
@@ -378,26 +376,17 @@ HRESULT Resources::ResolveShortcut(const std::filesystem::path& in_shortcut_path
     }
     IShellLink* psl = nullptr;
 
-    // buffer that receives the null-terminated string
-    // for the drive and path
     TCHAR szPath[MAX_PATH];
-    // buffer that receives the null-terminated
-    // string for the description
     TCHAR szDesc[MAX_PATH];
-    // structure that receives the information about the shortcut
     WIN32_FIND_DATA wfd{};
 
-    // Get a pointer to the IShellLink interface
     hRes = CoCreateInstance(CLSID_ShellLink, nullptr, CLSCTX_INPROC_SERVER, IID_IShellLink, (void**)&psl);
     if (!SUCCEEDED(hRes)) {
         return hRes;
     }
-    // Get a pointer to the IPersistFile interface
     IPersistFile* ppf = nullptr;
     psl->QueryInterface(IID_IPersistFile, reinterpret_cast<void**>(&ppf));
 
-    // IPersistFile is using LPCOLESTR,
-    // Open the shortcut file and initialize it from its contents
     hRes = ppf->Load(in_shortcut_path.wstring().c_str(), STGM_READ);
     if (!SUCCEEDED(hRes)) {
         return hRes;
@@ -408,13 +397,11 @@ HRESULT Resources::ResolveShortcut(const std::filesystem::path& in_shortcut_path
     if (!SUCCEEDED(hRes)) {
         return hRes;
     }
-    // Get the path to the shortcut target
     hRes = psl->GetPath(szPath, MAX_PATH, &wfd, SLGP_RAWPATH);
     if (!SUCCEEDED(hRes)) {
         return hRes;
     }
 
-    // Get the description of the target
     hRes = psl->GetDescription(szDesc, MAX_PATH);
     if (!SUCCEEDED(hRes)) {
         return hRes;
@@ -615,7 +602,6 @@ void Resources::Download(const std::filesystem::path& path_to_file, const std::s
     EnqueueWorkerTask([this, path_to_file, url, callback] {
         std::wstring error_message;
         bool success = Download(path_to_file, url, error_message);
-        // and call the callback in the main thread
         if (callback) {
             EnqueueMainTask([callback, success, error_message] {
                 callback(success, error_message);
@@ -715,7 +701,6 @@ void Resources::Download(const std::string& url, AsyncLoadMbCallback callback, v
             const std::string http = "http://";
             const std::string https = "https://";
 
-            // Check if the URL starts with http:// or https:// and remove it
             if (url.substr(0, http.size()) == http) {
                 return url.substr(http.size());
             }
@@ -1031,7 +1016,6 @@ IDirect3DTexture9** Resources::GetGuildWarsWikiImage(const char* filename, size_
         return texture;
     }
     const auto path_to_file = std::format("{}\\{}", path.string(), filename_sanitised);
-    // Check for local file
     if (std::filesystem::exists(path_to_file)) {
         LoadTexture(texture, path_to_file, callback);
         return texture;
@@ -1070,7 +1054,6 @@ IDirect3DTexture9** Resources::GetGuildWarsWikiImage(const char* filename, size_
                 }
             }
 
-            // Ensure the image URL is absolute
             if (!image_url.starts_with("http")) {
                 image_url = std::format("https://wiki.guildwars.com{}", image_url);
             }
@@ -1134,13 +1117,11 @@ IDirect3DTexture9** Resources::GetSkillImageFromGWW(GW::Constants::SkillID skill
         return texture;
     }
     wchar_t path_to_file[MAX_PATH];
-    // Check for local jpg file
     swprintf(path_to_file, _countof(path_to_file), L"%s\\%d.jpg", path.wstring().c_str(), skill_id);
     if (std::filesystem::exists(path_to_file)) {
         LoadTexture(texture, path_to_file, callback);
         return texture;
     }
-    // Check for local png file
     swprintf(path_to_file, _countof(path_to_file), L"%s\\%d.png", path.wstring().c_str(), skill_id);
     if (std::filesystem::exists(path_to_file)) {
         LoadTexture(texture, path_to_file, callback);
@@ -1427,7 +1408,6 @@ IDirect3DTexture9** Resources::GetItemImage(const std::wstring& item_name)
     ASSERT(EnsureFolderExists(path));
 
     wchar_t path_to_file[MAX_PATH];
-    // Check for local png image
     swprintf(path_to_file, _countof(path_to_file), L"%s\\%s.png", path.c_str(), item_name.c_str());
     if (std::filesystem::exists(path_to_file)) {
         LoadTexture(texture, path_to_file, callback);
@@ -1469,11 +1449,9 @@ IDirect3DTexture9** Resources::GetItemImage(const std::wstring& item_name)
         swprintf(path_to_file, _countof(path_to_file), L"%s\\%s%S", path.c_str(), item_name.c_str(), image_extension.c_str());
         char url[128];
         if (strncmp(image_path.c_str(), "http", 4) == 0) {
-            // Image URL is absolute
             snprintf(url, _countof(url), "%s%s", image_path.c_str(), image_extension.c_str());
         }
         else {
-            // Image URL is relative to domain
             snprintf(url, _countof(url), "https://wiki.guildwars.com%s%s", image_path.c_str(), image_extension.c_str());
         }
         LoadTexture(texture, path_to_file, url, callback);
@@ -1499,7 +1477,6 @@ bool Resources::SaveTextureToFile(IDirect3DTexture9* texture, const std::filesys
     std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
 
     if (ext == ".dds") {
-        // Original DDS path
         D3DLOCKED_RECT lockedRect;
         hr = texture->LockRect(0, &lockedRect, nullptr, D3DLOCK_READONLY);
         if (FAILED(hr)) {
@@ -1524,7 +1501,6 @@ bool Resources::SaveTextureToFile(IDirect3DTexture9* texture, const std::filesys
         }
     }
     else if (ext == ".png" || ext == ".jpg" || ext == ".jpeg" || ext == ".bmp") {
-        // Lock the texture
         D3DLOCKED_RECT lockedRect;
         hr = texture->LockRect(0, &lockedRect, nullptr, D3DLOCK_READONLY);
         if (FAILED(hr)) {
@@ -1548,12 +1524,10 @@ bool Resources::SaveTextureToFile(IDirect3DTexture9* texture, const std::filesys
 
         DirectX::ScratchImage scratchImage;
 
-        // Check if format needs decompression
         if (DirectX::IsCompressed(srcImage.format)) {
             hr = DirectX::Decompress(srcImage, DXGI_FORMAT_R8G8B8A8_UNORM, scratchImage);
         }
         else {
-            // Just copy the image data
             hr = scratchImage.InitializeFromImage(srcImage);
         }
 
@@ -1564,7 +1538,6 @@ bool Resources::SaveTextureToFile(IDirect3DTexture9* texture, const std::filesys
             return false;
         }
 
-        // Determine codec GUID
         GUID guid;
         if (ext == ".png") {
             guid = GUID_ContainerFormatPng;
@@ -1734,7 +1707,6 @@ uint32_t Resources::GetTexmodHashCube(IDirect3DCubeTexture9* cubeTexture)
     // CRITICAL: Only hash the POSITIVE_X face to match gmod behavior!
     // gmod's uMod_IDirect3DCubeTexture9::GetHash() only hashes D3DCUBEMAP_FACE_POSITIVE_X
     if (cubeTexture->LockRect(D3DCUBEMAP_FACE_POSITIVE_X, 0, &d3dlr, nullptr, D3DLOCK_READONLY) != D3D_OK) {
-        // Try via surface level as fallback
         if (cubeTexture->GetCubeMapSurface(D3DCUBEMAP_FACE_POSITIVE_X, 0, &pResolvedSurface) != D3D_OK) {
             Log::Warning("GetTexmodHashCube: Failed to get cube map surface");
             return 0;
@@ -1761,10 +1733,8 @@ uint32_t Resources::GetTexmodHashCube(IDirect3DCubeTexture9* cubeTexture)
         offset += row_size;
     }
 
-    // Hash the compact data (without pitch padding)
     uint32_t hash = GetTexmodHash(reinterpret_cast<const char*>(compact_data.data()), compact_data.size());
 
-    // Cleanup
     if (pResolvedSurface != nullptr) {
         pResolvedSurface->UnlockRect();
         pResolvedSurface->Release();

--- a/GWToolboxdll/Modules/Resources.h
+++ b/GWToolboxdll/Modules/Resources.h
@@ -152,11 +152,8 @@ public:
     void Download(const std::filesystem::path& path_to_file, const std::string& url, const AsyncLoadCallback& callback) const;
     // download to memory, blocking. If an error occurs, details are held in response string
     static bool Download(const std::string& url, std::string& response);
-    // Read file on disk
     static bool ReadFile(const std::filesystem::path& path, std::string& response);
-    // Read file on disk
     static bool ReadFile(const std::filesystem::path& path, std::wstring& response);
-    // Write file to disk
     static bool WriteFile(const std::filesystem::path& path_to_file, const std::string& content, bool append = false);
 
     // download to memory, blocking. If an error occurs, details are held in response string

--- a/GWToolboxdll/Modules/Teamspeak5Module.cpp
+++ b/GWToolboxdll/Modules/Teamspeak5Module.cpp
@@ -359,7 +359,6 @@ namespace {
             const auto& connection = payload.connections[connection_id];
             const auto teamspeak_server = UpsertServer(connection.properties, static_cast<uint32_t>(connection_id));
             teamspeak_server->my_client_id = connection.clientId;
-            // Cycle and find our channel
             for (const auto& client : connection.clientInfos) {
                 if (client.id == teamspeak_server->my_client_id) {
                     teamspeak_server->my_channel_id = client.channelId;

--- a/GWToolboxdll/Modules/TeamspeakModule.cpp
+++ b/GWToolboxdll/Modules/TeamspeakModule.cpp
@@ -337,7 +337,6 @@ namespace {
         }
         Log::Log("Teamspeak 3 welcome message:\n%s", response->content.c_str());
 
-        // Send auth message
         const std::string to_send = std::format("auth apikey={}\r\n", settings.teamspeak3_api_key);
         response = PollSocket(to_send);
         if (!response) {

--- a/GWToolboxdll/Modules/TexmodModule.cpp
+++ b/GWToolboxdll/Modules/TexmodModule.cpp
@@ -884,14 +884,12 @@ namespace {
 
     IDirect3DTexture9* LastCreatedTexture = nullptr;
 
-    // Hook Release to clean up tracking
     ULONG WINAPI OnD3D9TextureRelease(IDirect3DTexture9* texture)
     {
         GW::Hook::EnterHook();
         ULONG ref = TextureRelease_Ret(texture);
         if (ref == 0) {
             if (texture == LastCreatedTexture) LastCreatedTexture = 0;
-            // Remove from hash map if present
             for (auto it = dx9_textures_created_by_hash.begin(); it != dx9_textures_created_by_hash.end();) {
                 if (it->second == texture) {
                     it = dx9_textures_created_by_hash.erase(it);
@@ -923,7 +921,6 @@ namespace {
 
         // Only track managed/system-mem textures (lockable, survive reset); skip D3DPOOL_DEFAULT (unsafe to lock, and a held ref would block device reset).
         if (SUCCEEDED(result) && *ppTexture && Pool != D3DPOOL_DEFAULT) {
-            // Hook Release on first texture creation
             if (!TextureRelease_Func) {
                 uintptr_t* texture_vtable = *reinterpret_cast<uintptr_t**>(*ppTexture);
                 constexpr int RELEASE_INDEX = 2;
@@ -946,7 +943,6 @@ namespace {
             if (!CreateDx9Texture_Func) {
                 IDirect3DDevice9* device = GW::Render::GetDevice();
                 if (!device) return;
-                // Get vtable pointer
                 uintptr_t* vtable = *reinterpret_cast<uintptr_t**>(device);
                 // CreateTexture is at index 23 in IDirect3DDevice9 vtable
                 constexpr int CREATE_TEXTURE_INDEX = 23;
@@ -955,7 +951,6 @@ namespace {
                 GW::Hook::EnableHooks(CreateDx9Texture_Func);
             }
 
-            // Hook texture Release to track when textures are destroyed
             if (!TextureRelease_Func) {
                 // Create a temporary dummy texture to get its vtable.
                 IDirect3DTexture9* temp_texture = nullptr;

--- a/GWToolboxdll/Modules/TextToSpeechModule.cpp
+++ b/GWToolboxdll/Modules/TextToSpeechModule.cpp
@@ -77,7 +77,6 @@ namespace {
         return nullptr;
     }
 
-    // API Configuration structure
     struct APIConfig {
         GenerateVoiceCallback callback;
         const char* name;
@@ -771,7 +770,6 @@ Gender GetGenderByFileId(const uint32_t file_id)
     GW::HookEntry UIMessage_HookEntry;
     GW::HookEntry PreUIMessage_HookEntry;
 
-    // Forward declaration
     void GenerateVoice(std::shared_ptr<PendingNPCAudio> audio);
 
     void GenerateVoiceFromDecodedString(std::shared_ptr<PendingNPCAudio> audio)

--- a/GWToolboxdll/Modules/ToastNotifications.h
+++ b/GWToolboxdll/Modules/ToastNotifications.h
@@ -67,7 +67,6 @@ public:
         WinToastLib::WinToastTemplate* toast_template = nullptr;
         Toast(const std::wstring& _title, const std::wstring& _message);
         ~Toast() override;
-        // Public interfaces
         void toastActivated() const override;
         void toastActivated(int) const override;
         void toastDismissed(WinToastDismissalReason) const override;

--- a/GWToolboxdll/Modules/ToolboxTheme.cpp
+++ b/GWToolboxdll/Modules/ToolboxTheme.cpp
@@ -273,9 +273,7 @@ void ToolboxTheme::LoadUILayout()
     if (!ImGui::GetCurrentContext()) {
         return;
     }
-    // Copy theme over
     ImGui::GetStyle() = ini_style;
-    // Copy window positions over
     ImGui::GetStyle().FontScaleMain = font_scale_main;
 
     layout.clear();

--- a/GWToolboxdll/Modules/TwitchModule.cpp
+++ b/GWToolboxdll/Modules/TwitchModule.cpp
@@ -206,7 +206,6 @@ namespace {
     int OnConnected(const char* params, irc_reply_data*, void* wparam)
     {
         const auto conn = static_cast<IRC*>(wparam);
-        // Set the username to be the connected name.
         settings.irc_username = params;
         settings.irc_username.erase(settings.irc_username.find_first_of(' '));
         // Channel == username. This could be changed to connect to other Twitch channels/IRC channels.
@@ -364,7 +363,6 @@ bool TwitchModule::Connect()
         printf("Invalid username!\n");
         return false;
     }*/
-    // Sanitise strings to lower case
     std::ranges::transform(
         settings.irc_server, settings.irc_server.begin(),
         [](const char c) -> char {

--- a/GWToolboxdll/Modules/Updater.cpp
+++ b/GWToolboxdll/Modules/Updater.cpp
@@ -59,7 +59,6 @@ namespace {
 
     GWToolboxRelease* GetLatestRelease(GWToolboxRelease* release)
     {
-        // Get list of releases
         std::string response;
         unsigned int tries = 0;
         const auto url = "https://api.github.com/repos/gwdevhub/GWToolboxpp/releases";
@@ -112,13 +111,11 @@ namespace {
     {
         int written = 0;
         if (latest_release.version == current_release.version && latest_release.size != current_release.size) {
-            // Version matches, but file size is different
             written = snprintf(update_available_text, sizeof(update_available_text) - 1, "GWToolbox++ version %s (%.2f kb) is available! You have %s (%.2f kb)",
                                latest_release.version.c_str(), latest_release.size > 0 ? latest_release.size / 1024.f : 0.f,
                                current_release.version.c_str(), current_release.size > 0 ? current_release.size / 1024.f : 0.f);
         }
         else {
-            // Version mismatch
             written = snprintf(update_available_text, sizeof(update_available_text) - 1, "GWToolbox++ version %s is available! You have %s", latest_release.version.c_str(), current_release.version.c_str());
         }
         ASSERT(written > 0);
@@ -146,7 +143,6 @@ namespace {
         }
         Log::Log("dll file name is %s\n", dllfile);
 
-        // Get name of dll from path
         const std::wstring dll_path(dllfile);
         std::wstring dll_name;
         wchar_t sep = '/';
@@ -253,7 +249,6 @@ const std::string& Updater::GetServerVersion()
 
 const GWToolboxRelease* Updater::GetCurrentVersionInfo(GWToolboxRelease* out)
 {
-    // server and client versions match
     wchar_t path[MAX_PATH];
     if (GetModuleFileNameW(GWToolbox::GetDLLModule(), path, _countof(path)) == 0) {
         return nullptr;
@@ -347,7 +342,6 @@ void Updater::CheckForUpdate(const bool forced)
 
         if (latest_release.version == current_release.version
             && latest_release.size == current_release.size) {
-            // Version and size match
             step = Done;
             is_latest_version = true;
             if (forced) {
@@ -394,7 +388,6 @@ void Updater::Draw(IDirect3DDevice9*)
             step = Done;
             break;
         case CheckAndAsk: {
-            // check and ask
             if (!visible) {
                 visible = true;
             }

--- a/GWToolboxdll/Modules/VendorFix.cpp
+++ b/GWToolboxdll/Modules/VendorFix.cpp
@@ -16,12 +16,8 @@ namespace {
     void RefreshVendorItems(GW::UI::Frame* frame) {
         if (!frame) return;
         /*
-        If the vendor frame has just been created, look at our inventory.
-        Any valid item ID after thr 56th item won't be found immediately by a collector.
-
-        Fortunately, triggering ui message GW::UI::UIMessage::kInventorySlotUpdated on the slot seems to work.
-
-        Identify the "problem" slots, and let the vendor know by spoofing the packet.
+        A freshly created vendor frame doesn't pick up inventory items past the 56th slot;
+        spoofing kInventorySlotUpdated for those slots makes the collector see them.
         */
 
         const auto inventory = GW::Items::GetInventory();

--- a/GWToolboxdll/Modules/WeatherModule.cpp
+++ b/GWToolboxdll/Modules/WeatherModule.cpp
@@ -274,7 +274,6 @@ namespace {
         return false;
     }
 
-    // Climate for a specific map.
     Climate ClimateForMap(const GW::Constants::MapID map_id)
     {
         // @Enhancement: We could handle edge case maps by inspecting textures used by the DAT file matching the map and counting stuff like sand, snow etc, but thats overkill atm.
@@ -958,7 +957,6 @@ namespace {
         return true;
     }
 
-    // Advance every active condition and accumulate its geometry, then upload once per frame.
     // Build a soft round puff texture at runtime (no .dat asset): white RGB with a smooth radial alpha falloff,
     // so overlapping cloud billboards blend into a continuous fog bank instead of showing hard quad edges.
     bool BuildCloudTexture(IDirect3DDevice9* device)

--- a/GWToolboxdll/Timer.h
+++ b/GWToolboxdll/Timer.h
@@ -3,13 +3,7 @@
 #include <ctime>
 
 /*
-This class makes using timers easier
-
-clock type is clock_t
-
-create a timer with TIMER_INIT()
-
-find the difference in milliseconds with TIMER_DIFF(clock_t timer)
+clock_t based timers: TIMER_DIFF(t) returns the elapsed time in milliseconds since TIMER_INIT().
 */
 
 inline clock_t TIMER_INIT()

--- a/GWToolboxdll/ToolboxBreakoutWindow.cpp
+++ b/GWToolboxdll/ToolboxBreakoutWindow.cpp
@@ -70,7 +70,6 @@ bool ToolboxBreakoutWindow::CreateDeviceD3D()
     if ((g_pD3D = Direct3DCreate9_Func(D3D_SDK_VERSION)) == nullptr)
     return false;
 
-    // Create the D3DDevice
     g_d3dpp = { 0 };
     g_d3dpp.Windowed = TRUE;
     g_d3dpp.SwapEffect = D3DSWAPEFFECT_DISCARD;
@@ -112,7 +111,6 @@ int ToolboxBreakoutWindow::CreateOSWindow() {
         Log::Error("Failed to CreateWindowW in ToolboxUIElement; GetLastError %p", GetLastError());
         return 1;
     }
-    // Initialize Direct3D
     if (!CreateDeviceD3D())
     {
         CleanupDeviceD3D();
@@ -123,11 +121,9 @@ int ToolboxBreakoutWindow::CreateOSWindow() {
 
     breakout_windows_by_handle[window_handle] = this;
 
-    // Show the window
     ::ShowWindow(window_handle, SW_SHOWDEFAULT);
     ::UpdateWindow(window_handle);
 
-    // Setup Dear ImGui context
     IMGUI_CHECKVERSION();
     ImGui::CreateContext();
     ImGuiIO& io = ImGui::GetIO(); (void)io;
@@ -138,7 +134,6 @@ int ToolboxBreakoutWindow::CreateOSWindow() {
     //io.ConfigViewportsNoAutoMerge = true;
     //io.ConfigViewportsNoTaskBarIcon = true;
 
-    // Setup Dear ImGui style
     ImGui::StyleColorsDark();
     //ImGui::StyleColorsLight();
 
@@ -150,7 +145,6 @@ int ToolboxBreakoutWindow::CreateOSWindow() {
         style.Colors[ImGuiCol_WindowBg].w = 1.0f;
     }
 
-    // Setup Platform/Renderer backends
     ImGui_ImplWin32_Init(window_handle);
     ImGui_ImplDX9_Init(g_pd3dDevice);
 
@@ -170,16 +164,13 @@ int ToolboxBreakoutWindow::CreateOSWindow() {
     //ImFont* font = io.Fonts->AddFontFromFileTTF("c:\\Windows\\Fonts\\ArialUni.ttf", 18.0f, nullptr, io.Fonts->GetGlyphRangesJapanese());
     //IM_ASSERT(font != nullptr);
 
-    // Our state
     bool show_demo_window = true;
     bool show_another_window = false;
     ImVec4 clear_color = ImVec4(0.45f, 0.55f, 0.60f, 1.00f);
 
-    // Main loop
     bool done = false;
     while (!done)
     {
-        // Poll and handle messages (inputs, window resize, etc.)
         // See the WndProc() function below for our to dispatch events to the Win32 backend.
         MSG msg;
         while (::PeekMessage(&msg, nullptr, 0U, 0U, PM_REMOVE))
@@ -192,7 +183,6 @@ int ToolboxBreakoutWindow::CreateOSWindow() {
         if (done)
             break;
 
-        // Handle lost D3D9 device
         if (g_DeviceLost)
         {
             HRESULT hr = g_pd3dDevice->TestCooperativeLevel();
@@ -218,16 +208,13 @@ int ToolboxBreakoutWindow::CreateOSWindow() {
         window_mutex.unlock();
 
 
-        // Start the Dear ImGui frame
         ImGui_ImplDX9_NewFrame();
         ImGui_ImplWin32_NewFrame();
         ImGui::NewFrame();
 
-        // 1. Show the big demo window (Most of the sample code is in ImGui::ShowDemoWindow()! You can browse its code to learn more about Dear ImGui!).
         if (show_demo_window)
             ImGui::ShowDemoWindow(&show_demo_window);
 
-        // 2. Show a simple window that we create ourselves. We use a Begin/End pair to create a named window.
         {
             static float f = 0.0f;
             static int counter = 0;
@@ -250,7 +237,6 @@ int ToolboxBreakoutWindow::CreateOSWindow() {
             ImGui::End();
         }
 
-        // 3. Show another simple window.
         if (show_another_window)
         {
             ImGui::Begin("Another Window", &show_another_window);   // Pass a pointer to our bool variable (the window will have a closing button that will clear the bool when clicked)
@@ -260,7 +246,6 @@ int ToolboxBreakoutWindow::CreateOSWindow() {
             ImGui::End();
         }
 
-        // Rendering
         ImGui::EndFrame();
         g_pd3dDevice->SetRenderState(D3DRS_ZENABLE, FALSE);
         g_pd3dDevice->SetRenderState(D3DRS_ALPHABLENDENABLE, FALSE);
@@ -274,7 +259,6 @@ int ToolboxBreakoutWindow::CreateOSWindow() {
             g_pd3dDevice->EndScene();
         }
 
-        // Update and Render additional Platform Windows
         if (io.ConfigFlags & ImGuiConfigFlags_ViewportsEnable)
         {
             ImGui::UpdatePlatformWindows();
@@ -286,7 +270,6 @@ int ToolboxBreakoutWindow::CreateOSWindow() {
             g_DeviceLost = true;
     }
 
-    // Cleanup
     ImGui_ImplDX9_Shutdown();
     ImGui_ImplWin32_Shutdown();
     ImGui::DestroyContext();

--- a/GWToolboxdll/ToolboxBreakoutWindow.h
+++ b/GWToolboxdll/ToolboxBreakoutWindow.h
@@ -16,7 +16,6 @@ protected:
 
     std::recursive_mutex window_mutex;
 
-    // Forward declarations of helper functions
     bool CreateDeviceD3D();
     void CleanupDeviceD3D();
     void ResetDevice();

--- a/GWToolboxdll/ToolboxIni.cpp
+++ b/GWToolboxdll/ToolboxIni.cpp
@@ -56,7 +56,6 @@ std::pair<FastIniEntry&, bool> FastIniSection::findOrCreate(std::string_view key
         return {vec.back(), true};
     }
     if (multiKey) {
-        // Append a new slot for this duplicate key
         vec.emplace_back();
         return {vec.back(), false}; // section existed, key existed → SI_UPDATED
     }
@@ -212,7 +211,6 @@ SI_Error ToolboxIni::LoadFile(const std::filesystem::path& a_pwszFile)
     SI_Error res = SI_FAIL;
 
     Reset();
-    // 3 tries to load from disk
     for (auto i = 0; i < 3 && res != SI_OK; i++) {
         res = LoadFileRaw(a_pwszFile) ? SI_OK : SI_FAIL;
     }

--- a/GWToolboxdll/ToolboxModule.cpp
+++ b/GWToolboxdll/ToolboxModule.cpp
@@ -15,7 +15,6 @@ namespace {
     }
 #endif
 
-    // static function to register content
     std::unordered_map<std::string, SectionDrawCallbackList> settings_draw_callbacks{};
     std::unordered_map<std::string, const char*> settings_icons{};
     std::unordered_map<std::string, ToolboxModule*> modules_loaded{};
@@ -48,7 +47,6 @@ void ToolboxModule::SaveSettings(SettingsDoc& doc)
 void ToolboxModule::Terminate()
 {
     SettingsRegistry::Unregister(this);
-    // Remove any settings draw callbacks associated with this module
     auto callbacks_it = settings_draw_callbacks.begin();
     while (callbacks_it != settings_draw_callbacks.end()) {
         auto modules_it = callbacks_it->second.begin();

--- a/GWToolboxdll/ToolboxModule.h
+++ b/GWToolboxdll/ToolboxModule.h
@@ -31,44 +31,32 @@ public:
     // name of the window and the ini section
     [[nodiscard]] virtual const char* Name() const = 0;
 
-    // something to make sense of this module to actual human beings that don't have time to read source code
     [[nodiscard]] virtual const char* Description() const { return nullptr; }
 
-    // Icon for this module (if any).
     [[nodiscard]] virtual const char* Icon() const { return nullptr; }
 
-    // name of the setting section
     [[nodiscard]] virtual const char* SettingsName() const { return Name(); }
 
-    // Type of module
     [[nodiscard]] virtual const char* TypeName() const { return "module"; }
 
     // register settings callbacks. Override this to add your settings into different sections.
     virtual void RegisterSettingsContent();
 
-    // Readable array of setting callbacks registered.
     static const std::unordered_map<std::string, SectionDrawCallbackList>& GetSettingsCallbacks();
     static const std::unordered_map<std::string, const char*>& GetSettingsIcons();
 
-    // Readable array of modules currently loaded
     static const std::unordered_map<std::string, ToolboxModule*>& GetModulesLoaded();
 
-    // Initialize module
     virtual void Initialize();
 
-    // Send termination signal to module.
     virtual void SignalTerminate() { }
 
-    // Draw help section
     virtual void DrawHelp() { }
 
-    // Can we terminate this module?
     virtual bool CanTerminate() { return true; }
 
-    // Does this module have settings?
     virtual bool HasSettings() { return true; }
 
-    // Terminate module
     virtual void Terminate();
 
     // Update. Will always be called once every frame. Delta in seconds
@@ -86,14 +74,12 @@ public:
     // Load registered settings from the JSON doc, falling back to the legacy ini for missing keys
     virtual void LoadSettings(SettingsDoc& doc, ToolboxIni* legacy);
 
-    // Save registered settings to the JSON doc
     virtual void SaveSettings(SettingsDoc& doc);
 
     // Draw settings interface. Will be called if the setting panel is visible, calls DrawSettingsInternal()
     //virtual void DrawSettings();
     virtual void DrawSettingsInternal() { }
 
-    // Register settings content
     void RegisterSettingsContent(
         const char* section, const char* icon, const SectionDrawCallback& callback, float weighting);
 

--- a/GWToolboxdll/ToolboxUIElement.cpp
+++ b/GWToolboxdll/ToolboxUIElement.cpp
@@ -287,7 +287,6 @@ void ToolboxUIElement::OnMobileModeChanged(const bool is_mobile)
 {
     const auto window = ImGui::FindWindowByName(Name());
     if (is_mobile) {
-        // Save current (normal) position before switching
         if (window) {
             normal_pos[0] = window->Pos.x;
             normal_pos[1] = window->Pos.y;
@@ -295,14 +294,12 @@ void ToolboxUIElement::OnMobileModeChanged(const bool is_mobile)
             normal_size[1] = window->SizeFull.y;
             has_normal_layout = true;
         }
-        // Apply stored mobile position if available
         if (has_mobile_layout && window) {
             ImGui::SetWindowPos(window, {mobile_pos[0], mobile_pos[1]});
             ImGui::SetWindowSize(window, {mobile_size[0], mobile_size[1]});
         }
     }
     else {
-        // Save current (mobile) position before switching
         if (window) {
             mobile_pos[0] = window->Pos.x;
             mobile_pos[1] = window->Pos.y;
@@ -310,13 +307,11 @@ void ToolboxUIElement::OnMobileModeChanged(const bool is_mobile)
             mobile_size[1] = window->SizeFull.y;
             has_mobile_layout = true;
         }
-        // Restore stored normal position if available
         if (has_normal_layout && window) {
             ImGui::SetWindowPos(window, {normal_pos[0], normal_pos[1]});
             ImGui::SetWindowSize(window, {normal_size[0], normal_size[1]});
         }
     }
-    // Reset settings tab to reflect new mode
     settings_active_tab = is_mobile ? 1 : 0;
 }
 
@@ -331,7 +326,6 @@ void ToolboxUIElement::DrawSizeAndPositionSettings()
 
     const auto window = ImGui::FindWindowByName(Name());
 
-    // Sync the current mode's stored positions from the live window
     if (window) {
         if (is_mobile) {
             mobile_pos[0] = window->Pos.x;
@@ -420,13 +414,11 @@ void ToolboxUIElement::DrawSizeAndPositionSettings()
         const bool pos_disabled = !is_movable || lm;
         ImGui::BeginDisabled(pos_disabled);
         if (!snap.empty()) {
-            // Show relative offset to the snapped GW frame
             if (ImGui::DragFloat2("Snap Offset", snap_off, 1.0f, 0.0f, 0.0f, "%.0f")) {
                 needs_init_ref = false; // user explicitly set offset; cancel pending init
             }
         }
         else {
-            // Show absolute screen coordinates
             if (ImGui::DragFloat2("Position", cur_pos, 1.0f, 0.0f, 0.0f, "%.0f")) {
                 if (window) {
                     ImGui::SetWindowPos(window, {cur_pos[0], cur_pos[1]});
@@ -450,7 +442,6 @@ void ToolboxUIElement::DrawSizeAndPositionSettings()
         }
     }
 
-    // Size
     {
         const bool size_disabled = !is_resizable || ls || as_;
         ImGui::BeginDisabled(size_disabled);
@@ -476,7 +467,6 @@ void ToolboxUIElement::DrawSizeAndPositionSettings()
         }
     }
 
-    // Lock / auto checkboxes
     ImGui::StartSpacedElements(180.f);
 
     ImGui::NextSpacedElement();

--- a/GWToolboxdll/Unused/ChatLog.cpp
+++ b/GWToolboxdll/Unused/ChatLog.cpp
@@ -135,7 +135,6 @@ namespace {
 
     }
 
-    // Check outgoing log to see if message has already been added
     bool IsAdded(wchar_t* _message, uint32_t addr)
     {
         if (!addr) {
@@ -155,7 +154,6 @@ namespace {
         return false;
     }
 
-    // Path to chat log file on disk
     std::filesystem::path LogPath(const wchar_t* prefix)
     {
         wchar_t fn[128];
@@ -164,7 +162,6 @@ namespace {
         return Resources::GetPath(L"chat logs", fn);
     }
 
-    // Remove message from incoming log
     void Remove(const TBChatMessage* message)
     {
         if (message == recv_first) {
@@ -185,7 +182,6 @@ namespace {
         delete message;
     }
     
-    // Add message to incoming log
     void Add(wchar_t* _message, const uint32_t _channel, const FILETIME _timestamp)
     {
         if (injecting || !enabled) {
@@ -197,7 +193,6 @@ namespace {
         const auto new_message = new TBChatMessage(_message, _channel, _timestamp);
         TBChatMessage* inject = recv_last;
         if (!recv_first) {
-            // No first element; log is empty.
             new_message->prev = new_message->next = recv_first = recv_last = new_message;
             goto trim_log;
         }
@@ -206,7 +201,6 @@ namespace {
             switch (CompareFileTime(&inject->timestamp, &_timestamp)) {
             case 0: // Equal; check message cmp
                 if (wcscmp(_message, inject->msg.c_str()) == 0) {
-                    // Duplicate message?
                     return;
                 }
             case 1: // new_message is earlier; keep going back
@@ -248,14 +242,12 @@ namespace {
             Remove(recv_first);
         }
     }
-    // Add message to incoming log
     void Add(GW::Chat::ChatMessage* in)
     {
         Add(in->message, in->channel, in->timestamp);
     }
 
 
-    // Remove message from outgoing log
     void RemoveSent(const TBSentMessage* message)
     {
         if (message == sent_first) {
@@ -276,7 +268,6 @@ namespace {
         delete message;
     }
 
-    // Add message to outgoing log
     void AddSent(wchar_t* _message, const uint32_t addr = 0)
     {
         if (!(IsValidPtr(_message) && _message[0])) {
@@ -289,7 +280,6 @@ namespace {
         const auto new_message = new TBSentMessage(_message, addr);
         TBSentMessage* inject = sent_last;
         if (!sent_first) {
-            // No first element; log is empty.
             new_message->prev = new_message->next = sent_first = sent_last = new_message;
             goto trim_log;
         }
@@ -470,11 +460,9 @@ namespace {
             injecting = false;
             return;
         }
-        // Fill chat log
         TBSentMessage* sent = sent_first;
         while (sent) {
             if (sent->msg.data() && sent->msg.length()) {
-                // Only add to log if the message has content
                 AddToSentLog_Func(sent->msg.data());
                 if (!out_log) {
                     out_log = GetSentLog();
@@ -502,7 +490,6 @@ namespace {
             InitChatLog();
 
             auto log = GW::Chat::GetChatLog();
-            // Fill chat log
             size_t log_pos = log ? log->next : 0;
             injecting = true;
 

--- a/GWToolboxdll/Unused/ExtraWeaponSets.cpp
+++ b/GWToolboxdll/Unused/ExtraWeaponSets.cpp
@@ -227,7 +227,6 @@ namespace {
                 // TODO: Switch for whether this weapon set is supposed to be selected!
                 OnWeaponSetUICallback_Ret(message, wparam, lparam);
 
-                // Swap it back when done
                 *overwrite_weapon_set = original_overwrite_weapon_set;
                 context->this_weapon_set_id = original_weapon_set_id;
             } break;

--- a/GWToolboxdll/Unused/FavorTrackerModule.h
+++ b/GWToolboxdll/Unused/FavorTrackerModule.h
@@ -31,6 +31,5 @@ public:
     static const wchar_t* GetFavorMessageW();
     static const char* GetFavorMessage();
 
-    // Returns true if favor is currently active
     static bool HasFavor();
 };

--- a/GWToolboxdll/Unused/GWFileRequester.cpp
+++ b/GWToolboxdll/Unused/GWFileRequester.cpp
@@ -135,10 +135,8 @@ int GWFileRequester::connect(uint32_t server_num) {
     }
     // TODO: Cycle this for each domain 1 to 12?
     ASSERT(snprintf(socket_domain, sizeof(socket_domain), "file%d.arenanetworks.com", server_num) != -1);
-    //Ensure that servinfo is clear
     memset(&hints, 0, sizeof hints); //make sure the struct is empty
 
-    //setup hints
     hints.ai_family = AF_UNSPEC;    //IPv4 or IPv6 doesnt matter
     hints.ai_socktype = SOCK_STREAM;        //TCP stream socket
 
@@ -156,21 +154,18 @@ int GWFileRequester::connect(uint32_t server_num) {
         return 1;
     }
 
-    //setup socket
     if ((fs_socket = socket(servinfo->ai_family, servinfo->ai_socktype, servinfo->ai_protocol)) == INVALID_SOCKET) {
         log(L"Failed to socket: %d", WSAGetLastError());
         disconnect();
         return 1;
     }
 
-    //Connect
     if (::connect(fs_socket, servinfo->ai_addr, servinfo->ai_addrlen) == SOCKET_ERROR) {
         log(L"Failed to connect: %d", WSAGetLastError());
         disconnect();
         return 1;
     }
 
-    //We dont need this anymore
     freeaddrinfo(servinfo);
 
     // Handshake
@@ -311,10 +306,8 @@ int GWFileRequester::process_resource_request(GWResourceRequest* file_request) {
         gw_resource.data_len = file_manifest.size_decompressed;
         gw_resource.data = d.DecompressFile((unsigned int*)compressed, file_manifest.size_compressed, (int&)(gw_resource.data_len));
         if (!gw_resource.data) {
-            // failed to decompress
             goto complete_file_request;
         }
-        // Write to file
         {
             std::ofstream fout(path, std::ofstream::out);
             fout.write((char*)gw_resource.data, gw_resource.data_len);

--- a/GWToolboxdll/Unused/GWFileRequester.h
+++ b/GWToolboxdll/Unused/GWFileRequester.h
@@ -92,7 +92,6 @@ private:
         int asset_manifest_file() { return data[1]; }
         int exe_file() { return data[2]; }
     };
-    // Keep a copy of main manifest in memory.
     FStoC_MainManifest main_manifest;
 
     // Note: Multiple file hashs can be appended to this packet, but a minimum of two is always required.

--- a/GWToolboxdll/Unused/HeroEquipmentModule.cpp
+++ b/GWToolboxdll/Unused/HeroEquipmentModule.cpp
@@ -24,7 +24,6 @@ namespace {
     std::map<uint32_t, GW::UI::FramePosition> frame_layouts_by_child_id;
 
     IDirect3DTexture9** icon_texture = nullptr;
-    // Precompute UV coordinates for each state
     ImVec2 uv_normal[2], uv_hover[2], uv_active[2];
 
     constexpr char hero_index_max = 7;
@@ -359,16 +358,13 @@ void HeroEquipmentModule::Initialize()
         GW::UI::RegisterUIMessageCallback(&ChatCmdEntry, message_id, OnPostUIMessage, 0x4000);
     }
 
-    // Calculate icon uv coords
     icon_texture = GwDatModule::LoadTextureFromFileId(0x231a5);
     constexpr float icon_uv_size = 23.5f / 256.f; // An icon is 23px of the 256px texture
 
-    // Define the indices for button states
     constexpr int normal_index = 4; // Normal state (image 4)
     constexpr int hover_index = 5;  // Hovered state (image 5)
     constexpr int active_index = 6; // Clicked/Active state (image 6)
 
-    // Helper function to calculate UV coordinates for an icon index
     auto calcUV = [icon_uv_size](int index, ImVec2* uv) {
         int row = index / 10;
         int col = index % 10;
@@ -445,7 +441,6 @@ void HeroEquipmentModule::Draw(IDirect3DDevice9*)
     char btn_label[] = "##HeroEquipBtn0";
     wchar_t inventory_window_label[] = L"HeroInventory_0";
 
-    // Load the texture once outside the loop
 
     if (!(icon_texture && *icon_texture)) return;
 
@@ -473,21 +468,18 @@ void HeroEquipmentModule::Draw(IDirect3DDevice9*)
 
         ImVec2 btn_size = ImVec2(btn_height, btn_height);
 
-        // Adjust window position
         ImGui::SetNextWindowPos({content_bottom_right.x - btn_height * 2.f, top_left.y + frame_height * .1f});
         ImGui::SetNextWindowSize(btn_size);
 
         if (!ImGui::Begin(window_label, nullptr, GetWinFlags() | ImGuiWindowFlags_AlwaysAutoResize)) continue;
         ImVec2 btn_pos = ImGui::GetCursorScreenPos();
 
-        // Create invisible button for interaction
         if (ImGui::InvisibleButton(btn_label, btn_size)) {
             ToggleHeroInventoryWindow(i + 1);
         }
         bool hovered = ImGui::IsItemHovered();
         bool active = ImGui::IsItemActive();
 
-        // Determine which texture to use based on button state
         auto uv_min = &uv_normal[0];
         auto uv_max = &uv_normal[1];
 
@@ -500,7 +492,6 @@ void HeroEquipmentModule::Draw(IDirect3DDevice9*)
             uv_max = &uv_hover[1];
         }
 
-        // Draw the button texture
         ImGui::SetCursorScreenPos(btn_pos);
         ImGui::Image(*icon_texture, btn_size, *uv_min, *uv_max);
 

--- a/GWToolboxdll/Utils/ArenaNetFileParser.cpp
+++ b/GWToolboxdll/Utils/ArenaNetFileParser.cpp
@@ -12,7 +12,6 @@ namespace {
 
     static constexpr uint32_t fvf_array_2[16] = {0x0, 0xC, 0x4, 0x10, 0xC, 0x18, 0x10, 0x1C, 0x4, 0x10, 0x8, 0x14, 0x10, 0x1C, 0x14, 0x20};
 
-    // Helper functions
     uint32_t getFVF(uint32_t dat_fvf) {
         return ((dat_fvf & 0xff0) << 4) | ((dat_fvf >> 8) & 0x30) | (dat_fvf & 0xf);
     }
@@ -76,7 +75,6 @@ namespace ArenaNetFileParser {
     {
         ASSERT(isValid());
         size_t offset = 5;
-        // Parse chunk headers and record their locations
         while (offset + 8 <= data_size) {
             const auto chunk = (Chunk*)&data[offset];
             if (chunk->chunk_id == chunk_type)

--- a/GWToolboxdll/Utils/ArenaNetFileParser.h
+++ b/GWToolboxdll/Utils/ArenaNetFileParser.h
@@ -217,12 +217,10 @@ enum class ChunkType : uint32_t {
         uint32_t unk;
         uint32_t num_filenames;
         FileName filenames[];
-        // FileName array follows...
     };
     struct FileNamesChunkWithoutLength : Chunk {
         FileName filenames[];
         size_t num_filenames() { return chunk_size / sizeof(FileName); };
-        // FileName array follows...
     };
     struct ChunkFA1 : Chunk {
         ChunkFA1Sub1 sub_1;
@@ -252,14 +250,12 @@ enum class ChunkType : uint32_t {
 
     struct ArenaNetFile : GameAssetFile {
 
-        // Copy parent constructors
         ArenaNetFile() : GameAssetFile() {}
         ArenaNetFile(std::vector<uint8_t>& _data) : ArenaNetFile() { parse(_data); }
 
         const uint8_t getFFNAType() const;
 
         const bool isValid() override;
-        // Get chunk by type
         const Chunk* FindChunk(ChunkType chunk_type);
     };
 

--- a/GWToolboxdll/Utils/FontLoader.cpp
+++ b/GWToolboxdll/Utils/FontLoader.cpp
@@ -153,7 +153,6 @@ namespace {
         return font_data;
     }
 
-    // Build a single font by merging all available font files.
     ImFont* BuildFont(const float size, const bool default_only = false)
     {
         ImFontAtlas* atlas = ImGui::GetIO().Fonts;
@@ -176,7 +175,6 @@ namespace {
         }
 
         ImFont* font = nullptr;
-        // Load fonts from disk, merging glyph ranges
         for (const auto& [glyph_ranges, font_name] : GetFontData()) {
             size_t data_size;
 
@@ -190,7 +188,6 @@ namespace {
             cfg.MergeMode = true;
         }
 
-        // Merge fontawesome icons
         cfg.MergeMode = true;
         cfg.GlyphExcludeRanges = nullptr;
         atlas->AddFontFromMemoryCompressedTTF(fontawesome5_compressed_data, fontawesome5_compressed_size, size, &cfg, fontawesome5_glyph_ranges.data());
@@ -201,7 +198,6 @@ namespace {
 }
 
 namespace FontLoader {
-    // Has LoadFonts() finished?
     bool FontsLoaded()
     {
         return fonts_loaded;

--- a/GWToolboxdll/Utils/GuiUtils.cpp
+++ b/GWToolboxdll/Utils/GuiUtils.cpp
@@ -134,7 +134,6 @@ namespace GuiUtils {
 
     bool IconButton(const char* label, GwButtonIcon icon, const ImVec2& size, const ImGuiButtonFlags flags)
     {
-        // Icons from GW_BUTTON_ICONS_FILE_ID
         if (icon == GwButtonIcon::ChatIcon) {
             IDirect3DTexture9** tex = GwDatModule::LoadTextureFromFileId(GW_BUTTON_ICONS_FILE_ID);
             if (!tex || !*tex) return false;
@@ -151,7 +150,6 @@ namespace GuiUtils {
             return ImGui::CompositeIconButton(label, &tex_id, 1, size, flags, ICON_SIZE, uv0, uv1);
         }
 
-        // Icons from TEMPLATE_ICONS_FILE_ID
         IDirect3DTexture9** tex = GwDatModule::LoadTextureFromFileId(TEMPLATE_ICONS_FILE_ID);
         if (!tex || !*tex) return false;
 

--- a/GWToolboxdll/Utils/GuiUtils.h
+++ b/GWToolboxdll/Utils/GuiUtils.h
@@ -110,7 +110,6 @@ namespace GuiUtils {
     void FlashWindow(bool force = false);
     void FocusWindow();
 
-    // Create an ImGui representation of the skill bar
     void DrawSkillbar(const char* build_code, bool show_attributes = true);
 
     void DrawSkillbar(const GW::SkillbarMgr::SkillTemplate* skill_template_pt, bool show_attributes = true);

--- a/GWToolboxdll/Utils/TeamBuild.cpp
+++ b/GWToolboxdll/Utils/TeamBuild.cpp
@@ -652,7 +652,6 @@ void TeamBuild::DrawPlayerBuildsContent(bool& builds_modified, bool editable)
             }
         }
         else {
-            // Static display — click to show skillbar tooltip
             ImGui::PushItemWidth(name_width);
             const auto& disp = !build.name.empty() ? build.name : build.GetFallbackBuildName();
             ImGui::TextUnformatted(disp.c_str());
@@ -1007,7 +1006,6 @@ void TeamBuild::DrawHeroBuildsContent(bool& builds_modified, bool editable)
         // ---- Expanded edit section ----
         if (editing) {
             if (!is_player) {
-                // Hero selector
                 const auto& sorted_heroes = SortedHeroIDs();
                 const auto hero_it = std::ranges::find(sorted_heroes, build.hero_id);
                 int combo_idx = hero_it != sorted_heroes.end() ? static_cast<int>(std::distance(sorted_heroes.begin(), hero_it)) : -1;
@@ -1027,7 +1025,6 @@ void TeamBuild::DrawHeroBuildsContent(bool& builds_modified, bool editable)
                 }
                 ImGui::PopItemWidth();
 
-                // Show panel toggle
                 ImGui::SameLine(0, spacing);
                 const auto* panel_icon = reinterpret_cast<const char*>(build.show_panel ? ICON_FA_EYE : ICON_FA_EYE_SLASH);
                 if (ImGui::Button(panel_icon, icon_btn_size)) {
@@ -1035,7 +1032,6 @@ void TeamBuild::DrawHeroBuildsContent(bool& builds_modified, bool editable)
                 }
                 if (ImGui::IsItemHovered()) ImGui::SetTooltip(build.show_panel ? "Hero panel: Show" : "Hero panel: Hide");
 
-                // Behavior toggle
                 ImGui::SameLine(0, spacing);
                 const char* behavior_icon = reinterpret_cast<const char*>(ICON_FA_SHIELD_ALT);
                 const char* behavior_tooltip = "Hero behaviour: Guard";
@@ -1054,7 +1050,6 @@ void TeamBuild::DrawHeroBuildsContent(bool& builds_modified, bool editable)
                 }
                 if (ImGui::IsItemHovered()) ImGui::SetTooltip(behavior_tooltip);
 
-                // Disabled skills
                 ImGui::SameLine(0, spacing);
                 int enabled_count = 8;
                 for (int k = 0; k < 8; k++)
@@ -1098,7 +1093,6 @@ void TeamBuild::DrawHeroBuildsContent(bool& builds_modified, bool editable)
                 }
             }
 
-            // Pcons (player slot only)
             if (is_player) {
                 ImGui::TextUnformatted("Pcons:");
                 ImGui::ShowHelp("Enable or disable pcons when this build is loaded");
@@ -1193,7 +1187,6 @@ bool TeamBuild::DrawEditWindow(size_t index, std::vector<TeamBuild>& all_builds,
 
     ImGui::Spacing();
 
-    // Teambuild reordering and deletion
     if (ImGui::Button("Up") && index > 0) {
         std::swap(all_builds[index - 1], all_builds[index]);
         builds_modified = true;

--- a/GWToolboxdll/Utils/TeamBuildEncoder.cpp
+++ b/GWToolboxdll/Utils/TeamBuildEncoder.cpp
@@ -302,7 +302,6 @@ namespace TeamBuildEncoder {
     // attributes' skills get the lowest indices.
     static void SortAttrsByInvestment(Attribute attrs[], int count, const GW::SkillbarMgr::SkillTemplate& tmpl)
     {
-        // Build investment lookup
         uint32_t investment[11] = {};
         for (uint32_t i = 0; i < tmpl.attributes_count; i++)
             investment[static_cast<int>(tmpl.attribute_ids[i])] = tmpl.attribute_values[i];

--- a/GWToolboxdll/Utils/TextUtils.cpp
+++ b/GWToolboxdll/Utils/TextUtils.cpp
@@ -312,7 +312,6 @@ namespace TextUtils {
                ) == 11;
     }
 
-    // Convert an UTF8 string to a wide Unicode String
     std::wstring StringToWString(const std::string_view str)
     {
         if (str.empty()) {
@@ -334,7 +333,6 @@ namespace TextUtils {
         return std::regex_replace(subject_str, regex, replacement);
     }
 
-    // Convert a wide Unicode string to an UTF8 string
     std::string WStringToString(const std::wstring_view str)
     {
         if (str.empty()) {
@@ -502,7 +500,6 @@ namespace TextUtils {
     std::wstring RemoveDiacritics(const std::wstring_view s)
     {
         if (diacritics_charmap.empty()) {
-            // Build static diacritics map if not already done so
             for (size_t i = 0; i < diacritics.size(); i++) {
                 for (size_t j = 1; diacritics[i][j]; j++) {
                     diacritics_charmap[diacritics[i][j]] = diacritics[i][0];

--- a/GWToolboxdll/Utils/TextUtils.h
+++ b/GWToolboxdll/Utils/TextUtils.h
@@ -440,21 +440,15 @@ namespace TextUtils {
         result.reserve(input.size());
         size_t last_pos = 0;
 
-        // Iterate through all matches
         for (auto match : ctre::search_all<Pattern, Modifiers...>(input)) {
-            // Get the matched substring and its position
             auto matched = match.template get<0>().to_view();
             auto pos = std::distance(input.begin(), match.template get<0>().begin());
 
-            // Append text before the match
             result.append(input.substr(last_pos, pos - last_pos));
-            // Apply custom formatter and append
             result.append(formatter(match));
-            // Update position
             last_pos = pos + matched.length();
         }
 
-        // Append the remaining text
         if (last_pos < input.size()) {
             result.append(input.substr(last_pos));
         }

--- a/GWToolboxdll/Utils/ToolboxUtils.cpp
+++ b/GWToolboxdll/Utils/ToolboxUtils.cpp
@@ -318,13 +318,11 @@ namespace GW {
 
             // Navigate to target character by selecting previous/next until we reach it
             while (target_idx < selected_idx) {
-                // Need to go backwards - select the previous character
                 if (selected_idx == 0) break; // Can't go before first character
                 if (!select_char(selected_idx - 1)) return false;
             }
 
             while (target_idx > selected_idx) {
-                // Need to go forwards - select the next character
                 const auto chars_size = ctx->chars.size();
                 if (!chars_size || selected_idx + 1 >= chars_size) break; // Can't go past last character
                 if (!select_char(selected_idx + 1)) return false;
@@ -1578,7 +1576,6 @@ namespace ToolboxUtils {
         if (item->customized && ctre::search<dmg_plus_20_pattern>(original)) {
             // Remove "\nDamage +20%" > "\n"
             original = TextUtils::ctre_regex_replace<dmg_plus_20_pattern, L"">(original);
-            // Append "Customized"
             original += L"\x2\x102\x2\x108\x107"
                         L"Customized\x1";
         }

--- a/GWToolboxdll/Widgets/AlcoholWidget.cpp
+++ b/GWToolboxdll/Widgets/AlcoholWidget.cpp
@@ -109,10 +109,8 @@ void AlcoholWidget::AlcUpdate(GW::HookStatus*, const GW::Packet::StoC::PostProce
     if (packet->level > instance.alcohol_level) {
         // if the player already had a drink going
         if (instance.alcohol_level) {
-            // set remaining time
             instance.alcohol_time = static_cast<int>(instance.alcohol_time + static_cast<long>(instance.last_alcohol) - static_cast<long>(time(nullptr)));
         }
-        // add drink time
         instance.alcohol_time += 60 * static_cast<int>(packet->level - instance.alcohol_level);
         instance.last_alcohol = time(nullptr);
     }

--- a/GWToolboxdll/Widgets/DistanceWidget.cpp
+++ b/GWToolboxdll/Widgets/DistanceWidget.cpp
@@ -99,7 +99,6 @@ void DistanceWidget::Draw(IDirect3DDevice9*)
 
             ImVec2 cur = ImGui::GetCursorPos();
             constexpr auto background = ImColor(Colors::Black());
-            // 'distance'
             if (settings.font_size_header > 0.f && show_titlebar) {
                 ImGui::PushFont(FontLoader::GetFont(), static_cast<float>(FontLoader::FontSize::header1));
                 ImGui::SetCursorPos(ImVec2(cur.x + 1, cur.y + 1));
@@ -109,7 +108,6 @@ void DistanceWidget::Draw(IDirect3DDevice9*)
                 ImGui::PopFont();
             }
 
-            // perc
             if (settings.font_size_perc_value > 0.f) {
                 ImGui::PushFont(FontLoader::GetFont(), settings.font_size_perc_value);
                 cur = ImGui::GetCursorPos();
@@ -121,7 +119,6 @@ void DistanceWidget::Draw(IDirect3DDevice9*)
                 ImGui::PopFont();
             }
 
-            // abs
             if (settings.font_size_abs_value > 0.f) {
                 ImGui::PushFont(FontLoader::GetFont(), settings.font_size_abs_value);
                 cur = ImGui::GetCursorPos();

--- a/GWToolboxdll/Widgets/EffectsMonitorWidget.cpp
+++ b/GWToolboxdll/Widgets/EffectsMonitorWidget.cpp
@@ -187,7 +187,6 @@ namespace {
 
         GW::Vec2f label_size = ImGui::CalcTextSize(text);
         if (label_size.x > skill_frame_size.x) {
-            // If the label is wider than the frame, scale text size.
             const auto scale_factor = skill_frame_size.x / label_size.x;
             const auto scaled_size = scale_factor * settings.font_effects;
             overridden_font = FontLoader::GetFont();

--- a/GWToolboxdll/Widgets/HealthWidget.cpp
+++ b/GWToolboxdll/Widgets/HealthWidget.cpp
@@ -218,7 +218,6 @@ void HealthWidget::Draw(IDirect3DDevice9*)
 
             ImVec2 cur = ImGui::GetCursorPos();
             if (settings.font_size_header > 0.f && show_titlebar) {
-                // 'health'
                 ImGui::PushFont(FontLoader::GetFont(), settings.font_size_header);
                 ImGui::SetCursorPos(ImVec2(cur.x + 1, cur.y + 1));
                 ImGui::TextColored(background, "Health");
@@ -227,7 +226,6 @@ void HealthWidget::Draw(IDirect3DDevice9*)
                 ImGui::PopFont();
             }
 
-            // perc
             if (settings.font_size_perc_value > 0.f) {
                 ImGui::PushFont(FontLoader::GetFont(), settings.font_size_perc_value);
                 cur = ImGui::GetCursorPos();
@@ -239,7 +237,6 @@ void HealthWidget::Draw(IDirect3DDevice9*)
                 ImGui::PopFont();
             }
 
-            // abs
             if (settings.font_size_abs_value > 0.f) {
                 ImGui::PushFont(FontLoader::GetFont(), settings.font_size_abs_value);
                 cur = ImGui::GetCursorPos();

--- a/GWToolboxdll/Widgets/Minimap/AgentRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/AgentRenderer.cpp
@@ -141,7 +141,6 @@ namespace {
     void CHAT_CMD_FUNC(CmdMarkTarget)
     {
         if (argc > 1 && wcscmp(argv[1], L"clearall") == 0) {
-            // /marktarget clearall
             RemoveMarkedTarget();
             return;
         }
@@ -150,7 +149,6 @@ namespace {
             return;
         }
         if (argc > 1 && (wcscmp(argv[1], L"clear") == 0 || wcscmp(argv[1], L"remove") == 0)) {
-            // /marktarget clear
             RemoveMarkedTarget(agent->agent_id);
             return;
         }
@@ -889,7 +887,6 @@ void AgentRenderer::Render(IDirect3DDevice9* device)
             }
         }
 
-        // get stuff
         GW::AgentArray* agents = GW::Agents::GetAgentArray();
         if (!agents) {
             return;
@@ -952,7 +949,6 @@ void AgentRenderer::Render(IDirect3DDevice9* device)
 
         target_drawn = false;
 
-        // some helper lambads
 
         const auto add_custom_agents_to_draw = [this](const GW::Agent* agent) -> bool {
             const auto custom_agents_for_this_agent = GetCustomAgentsToDraw(agent);
@@ -995,7 +991,6 @@ void AgentRenderer::Render(IDirect3DDevice9* device)
             });
         };
 
-        // Sort through all agents, fill out arrays
         for (const auto agent : *agents) {
             if (!agent) {
                 continue;
@@ -1055,7 +1050,6 @@ void AgentRenderer::Render(IDirect3DDevice9* device)
             if (!agent->GetIsAlive()) {
                 continue;
             }
-            // Apply custom size/shape if defined && marked_target_inherit_custom_agents == true
             const auto* cas = GetCustomAgentsToDraw(agent);
             const auto* ca = cas && !cas->empty() ? cas->front() : nullptr;
             const auto size = marked_target_inherit_custom_agents && ca && ca->size_active && ca->size >= 0 ? ca->size : size_marked_target;
@@ -1073,7 +1067,6 @@ void AgentRenderer::Render(IDirect3DDevice9* device)
                 }
             }
             if (marked) {
-                // Apply custom size/shape if defined && marked_target_inherit_custom_agents == true
                 const auto* ca = custom_agents_for_this_agent && !custom_agents_for_this_agent->empty() ? custom_agents_for_this_agent->front() : nullptr;
                 const auto size = marked_target_inherit_custom_agents && ca && ca->size_active && ca->size >= 0 ? ca->size : size_marked_target;
                 const auto shape = marked_target_inherit_custom_agents && ca && ca->shape_active ? ca->shape : default_shape;
@@ -1159,7 +1152,6 @@ Color AgentRenderer::GetColor(const GW::Agent* agent, const CustomAgent* ca) con
         }
     }
 
-    // hostiles
     if (living->allegiance == GW::Constants::Allegiance::Enemy) {
         if (living->GetIsDead()) {
             return color_hostile_dead;
@@ -1221,7 +1213,6 @@ Color AgentRenderer::GetColor(const GW::Agent* agent, const CustomAgent* ca) con
         return Colors::Sub(*c, color_agent_damaged_modifier);
     }
 
-    // neutrals
     if (living->allegiance == GW::Constants::Allegiance::Neutral) {
         return color_neutral;
     }
@@ -1459,11 +1450,9 @@ void AgentRenderer::Enqueue(const Shape_e shape, const GW::Agent* agent, const f
         if (is_target && target_drawn) {
             return; // Don't draw target twice
         }
-        // Add agent border if applicable
         if (agent_border_thickness != 0.f && agent->GetIsLivingType()) {
             Enqueue(shape, pos, size + agent_border_thickness, Colors::ARGB(static_cast<int>(alpha * 0.8), 0, 0, 0));
         }
-        // Add target highlight if applicable
         if (is_target) {
             Enqueue(shape, pos, size + target_border_thickness, color_target);
             target_drawn = true;

--- a/GWToolboxdll/Widgets/Minimap/CustomRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/CustomRenderer.cpp
@@ -75,7 +75,6 @@ void CustomRenderer::RegisterSettings(ToolboxModule* module)
 
 void CustomRenderer::LoadMarkers()
 {
-    // clear current markers
     lines.clear();
     markers.clear();
     polygons.clear();
@@ -1006,17 +1005,14 @@ void CustomRenderer::DrawCustomMarkers(IDirect3DDevice9* device)
         return;
     }
 
-    // Custom polygons
     for (CustomPolygon& polygon : polygons) {
         polygon.Render(device);
     }
 
-    // Custom markers
     for (CustomMarker& marker : markers) {
         marker.Render(device);
     }
 
-    // Hero flag circles
     hero_circles_.Update(color_hero_flags_, hero_flag_line_thickness_, gwinches_per_pixel_);
     if (GW::HeroFlagArray& flags = GW::GetGameContext()->world->hero_flags; flags.valid()) {
         for (const auto& flag : flags) {

--- a/GWToolboxdll/Widgets/Minimap/GameWorldRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/GameWorldRenderer.cpp
@@ -182,12 +182,8 @@ namespace {
             const auto& ln = b.lines[b.build_cursor];
             const float dx = ln.b.x - ln.a.x, dy = ln.b.y - ln.a.y;
             const int steps = std::max(1, static_cast<int>(std::sqrt(dx * dx + dy * dy) / spacing));
-            // Drape each sample on the edge's OWN plane. A navmesh edge lies on a single trapezoid, so its surface IS
-            // that plane's heightfield (which ramps/steps where the floor does). Querying the plane directly per point —
-            // not the globally-closest surface — makes the line ride that surface: flat stays flat, a ramp rises, a
-            // deck stays on the deck, and an edge under a bridge stays on the ground rather than snapping to the deck.
-            // Sampling density is `spacing` gw; each surface query is exact at that point, so the only error is the chord
-            // between samples — tighten `spacing` to shrink it.
+            // Drape each sample on the edge's OWN plane (an edge lies on a single trapezoid, so that plane's heightfield
+            // IS its surface): unlike a globally-closest query, an edge under a bridge stays on the ground.
             const uint32_t plane = ln.a.zplane; // == ln.b.zplane: both verts come from the same trapezoid
             auto surfaceZ = [&](float x, float y, float fallback) -> float {
                 const float a = TerrainDrape::QueryAltAt(x, y, plane);
@@ -316,12 +312,9 @@ namespace {
                 vertices[i].z = HighestSurfaceZ(vertices[i].x, vertices[i].y, candidate_planes);
         }
         else {
-            // Ordered, densely-sampled path: drape on the navmesh-walkable plane at each sample (point-location),
-            // choosing the surface closest to the running height. This follows the surface the path actually walks —
-            // e.g. up onto a monument plane between two ground hops — instead of sinking onto the ground beneath it,
-            // which the old all-planes "closest surface" did because plane 0's heightfield still reports the floor
-            // under the monument. Falls back to that all-planes query when the navmesh isn't built yet or no walkable
-            // plane covers the sample (so cross-plane edges with no waypoint on the higher plane still drape sanely).
+            // Ordered path: drape on the navmesh-walkable plane at each sample, closest to the running height, so it
+            // rides what the path walks (e.g. a monument) instead of the floor beneath. Falls back to an all-planes
+            // query when the navmesh isn't built or no walkable plane covers the sample.
             auto* nav = PathfindingWindow::GetResidentNavMesh();
             GW::GamePos seed_pos = poly.points.empty() ? GW::GamePos{} : poly.points.front();
             float prev = TerrainDrape::QueryAltAt(seed_pos.x, seed_pos.y, seed_pos.zplane);

--- a/GWToolboxdll/Widgets/Minimap/GameWorldRenderer.h
+++ b/GWToolboxdll/Widgets/Minimap/GameWorldRenderer.h
@@ -24,7 +24,6 @@ public:
         GenericPolyRenderable(GW::Constants::MapID map_id, const std::vector<GW::GamePos>& points, unsigned int col, bool filled) noexcept;
         ~GenericPolyRenderable() noexcept;
 
-        // copy not allowed
         GenericPolyRenderable(const GenericPolyRenderable& other) = delete;
 
         GenericPolyRenderable(GenericPolyRenderable&& other) noexcept
@@ -42,7 +41,6 @@ public:
             other.vertices.clear();
         }
 
-        // copy not allowed
         GenericPolyRenderable& operator=(const GenericPolyRenderable& other) = delete;
 
         GenericPolyRenderable& operator=(GenericPolyRenderable&& other) noexcept

--- a/GWToolboxdll/Widgets/Minimap/Minimap.cpp
+++ b/GWToolboxdll/Widgets/Minimap/Minimap.cpp
@@ -76,7 +76,6 @@ namespace {
     GW::UI::UIInteractionCallback OnCompassFrame_UICallback_Ret = nullptr, OnCompassFrame_UICallback_Func = nullptr;
     bool compass_position_dirty = true;
 
-    // Flagged when terminating minimap
     bool terminating = false;
     bool cardinal_upright = false;
 
@@ -89,7 +88,6 @@ namespace {
 
     Vec2i drag_start;
 
-    // vars for minimap movement
     clock_t last_moved = 0;
 
     /**
@@ -236,19 +234,15 @@ namespace {
         constexpr float w = 5000.0f;
         v *= 2.0f * w / size.x;
 
-        // translate by camera
         v -= translation;
 
-        // scale by camera
         v /= scale;
 
-        // rotate by current camera rotation
         const float angle = default_minimap_context.rotation - DirectX::XM_PIDIV2;
         const float x1 = v.x * std::cos(angle) - v.y * std::sin(angle);
         const float y1 = v.x * std::sin(angle) + v.y * std::cos(angle);
         v = GW::Vec2f(x1, y1);
 
-        // translate by character position
         v += me->pos;
 
         return v;
@@ -559,7 +553,6 @@ namespace {
     }
 
 
-    // Callbacks
     void OnKeydown(GW::HookStatus*, const uint32_t key)
     {
         if (key == GW::UI::ControlAction_ReverseCamera) {
@@ -613,19 +606,12 @@ namespace {
     {
         if ((context.cardinal_color & IM_COL32_A_MASK) == 0) return;
         // -------------------------------------------------------------------------
-        // Cardinal direction labels (N / S / E / W) — ImGui background draw list
-        //
-        // Font is dynamically scaled via ImGui 1.92's dynamic font atlas.
-        //
-        // Two modes controlled by cardinal_upright:
-        //   true  — labels always read upright relative to the screen (default).
-        //   false — labels rotate with the minimap; each letter faces outward
-        //           from the compass centre so it reads correctly when the map
-        //           is rotated.
+        // Cardinal direction labels (N / S / E / W) — ImGui background draw list.
+        // cardinal_upright: true = labels always read upright on screen (default);
+        // false = labels rotate with the map, each letter facing outward from the centre.
         // -------------------------------------------------------------------------
         ImDrawList* draw_list = ImGui::GetBackgroundDrawList();
 
-        // Single font with dynamic scaling to the desired cardinal size.
         ImFont* font = FontLoader::GetFont();
         const float render_size = cardinal_font_size;
         ImFontBaked* baked = font->GetFontBaked(render_size);
@@ -636,15 +622,8 @@ namespace {
         const ImU32 label_col = context.cardinal_color;
         const ImU32 shadow_col = IM_COL32(0, 0, 0, (context.cardinal_color >> 24) & 0xFF);
 
-        // GW world axes: +X = east, +Y = north.
-        // label_angle: the angle (screen-space, CW from up) that this label's
-        //   top should point toward when in rotated mode.
-        //   N faces map-up   → base map angle
-        //   E faces map-right → base + PI/2
-        //   S faces map-down  → base + PI
-        //   W faces map-left  → base + 3*PI/2
-        //
-        // In upright mode label_angle is unused.
+        // GW world axes: +X = east, +Y = north. label_angle is the screen-space angle (CW from up)
+        // the label's top points toward in rotated mode (N = map angle, E/S/W offset by PI/2 each); unused when upright.
         const float map_angle = context.rotation - DirectX::XM_PIDIV2;
 
         struct Cardinal {
@@ -687,7 +666,6 @@ namespace {
                 const float ca = std::cos(angle);
                 const float sa = std::sin(angle);
 
-                // Rotate local offset (ox, oy) around pivot
                 auto rot = [&](float ox, float oy) -> ImVec2 {
                     return {pivot.x + ox * ca - oy * sa, pivot.y + ox * sa + oy * ca};
                 };
@@ -1329,7 +1307,6 @@ void Minimap::Draw(IDirect3DDevice9* device)
         return;
     }
 
-    // Check shadowstep location
     if (shadowstep_location.x != 0.0f || shadowstep_location.y != 0.0f) {
         GW::EffectArray* effects = GW::Effects::GetPlayerEffects();
         if (!effects) {
@@ -1518,13 +1495,11 @@ void Minimap::Render(IDirect3DDevice9* device, const MinimapRenderContext& conte
         return;
     }
 
-    // Backup the DX9 state
     IDirect3DStateBlock9* d3d9_state_block = nullptr;
     if (device->CreateStateBlock(D3DSBT_ALL, &d3d9_state_block) < 0) {
         return;
     }
 
-    // Backup the DX9 transform
     D3DMATRIX reset_world;
     D3DMATRIX reset_view;
     D3DMATRIX reset_projection;
@@ -1572,17 +1547,13 @@ void Minimap::Render(IDirect3DDevice9* device, const MinimapRenderContext& conte
         device->DrawPrimitiveUP(D3DPT_TRIANGLEFAN, res, vertices, sizeof(D3DVertex));
     };
 
-    // Use context instead of RenderSetupProjection()
     RenderSetupProjection(device, context);
 
-    // Use context background color (or from pmap_renderer if 0)
     auto& instance = Instance();
-    // Use context clipping rect instead of global
     const auto rect = context.rect();
     device->SetScissorRect(&rect);
     device->SetRenderState(D3DRS_SCISSORTESTENABLE, true);
 
-    // Use context.circular_map instead of global
     if (context.draw_background) {
         if (context.circular_map) {
             device->SetRenderState(D3DRS_STENCILENABLE, true);
@@ -1608,13 +1579,10 @@ void Minimap::Render(IDirect3DDevice9* device, const MinimapRenderContext& conte
 
     auto translate_char = DirectX::XMMatrixTranslation(-me->pos.x, -me->pos.y, 0);
 
-    // Use context.rotation instead of GetMapRotation()
     const auto rotate_char = DirectX::XMMatrixRotationZ(-context.rotation + DirectX::XM_PIDIV2);
 
-    // Use context.zoom_scale instead of global scale
     const auto scaleM = DirectX::XMMatrixScaling(context.zoom_scale, context.zoom_scale, 1.0f);
 
-    // Use context.translation instead of global translation
     const auto translationM = DirectX::XMMatrixTranslation(context.translation.x, context.translation.y, 0);
 
     const auto view = translate_char * rotate_char * scaleM * translationM;
@@ -1642,7 +1610,6 @@ void Minimap::Render(IDirect3DDevice9* device, const MinimapRenderContext& conte
     }
 
 
-    // Use context.draw_center_marker or check context.translation
     if (context.draw_center_marker || context.translation.x) {
         const auto view2 = scaleM;
         device->SetTransform(D3DTS_VIEW, reinterpret_cast<const D3DMATRIX*>(&view2));
@@ -1671,12 +1638,10 @@ void Minimap::Render(IDirect3DDevice9* device, const MinimapRenderContext& conte
         device->SetRenderState(D3DRS_STENCILENABLE, false);
     }
 
-    // Restore the DX9 transform
     device->SetTransform(D3DTS_WORLD, &reset_world);
     device->SetTransform(D3DTS_VIEW, &reset_view);
     device->SetTransform(D3DTS_PROJECTION, &reset_projection);
 
-    // Restore the DX9 state
     d3d9_state_block->Apply();
     d3d9_state_block->Release();
 }
@@ -1923,7 +1888,6 @@ bool Minimap::OnMouseWheel(const UINT, const WPARAM wParam, const LPARAM)
 
 bool Minimap::IsInside(const int x, const int y) const
 {
-    // if outside the minimap window rect, return false
     const auto& tl = default_minimap_context.top_left;
     const auto& br = default_minimap_context.bottom_right;
     if (static_cast<float>(x) < tl.x || static_cast<float>(x) > br.x ||

--- a/GWToolboxdll/Widgets/Minimap/Minimap.h
+++ b/GWToolboxdll/Widgets/Minimap/Minimap.h
@@ -58,7 +58,6 @@ public:
     // check this first, as the render resources don't exist while the module is off.
     static bool IsEnabled();
 
-    // Setup projection matrix for a given context
     static void RenderSetupProjection(IDirect3DDevice9* device, const MinimapRenderContext& context);
 
     // Current runtime render context (colours etc.) for surfaces reusing the pipeline
@@ -105,7 +104,6 @@ private:
     static void RegisterRenderer(MinimapRenderer* renderer);
     static void UnregisterRenderer(MinimapRenderer* renderer);
     [[nodiscard]] bool IsInside(int x, int y) const;
-    // returns true if the map is visible, valid, not loading, etc
 
     static size_t GetPlayerHeroes(const GW::PartyInfo* party, std::vector<GW::AgentID>& _player_heroes, bool* has_flags = nullptr);
 

--- a/GWToolboxdll/Widgets/Minimap/PingsLinesRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/PingsLinesRenderer.cpp
@@ -486,7 +486,6 @@ bool PingsLinesRenderer::OnMouseMove(const float x, const float y)
 
     drawings[my_player_id].player = my_player_id;
     if (!mouse_moved) {
-        // first time
         mouse_moved = true;
         BumpSessionID();
         drawings[my_player_id].session = static_cast<DWORD>(session_id);

--- a/GWToolboxdll/Widgets/MissionMapWidget.cpp
+++ b/GWToolboxdll/Widgets/MissionMapWidget.cpp
@@ -262,10 +262,8 @@ namespace {
     }
 
     // --- Walkable terrain overlay -----------------------------------------------
-    // Shades non-walkable parts of the map grey and outlines walkable terrain.
-    // Unlike the Vanquish overlay's map grid, this has no reachability/BFS, no
-    // fog-of-war and no enemy tracking — it's a static rasterization of every
-    // trapezoid in the pathing map, independent of the Vanquish widget entirely.
+    // Static rasterization of every pathing-map trapezoid; unlike the Vanquish overlay
+    // there is no reachability/BFS, fog-of-war or enemy tracking, and no shared state.
     constexpr float TERRAIN_CELL_SIZE = GW::Constants::Range::Adjacent / 2.f;
 
     struct TerrainTrapezoidSnapshot {

--- a/GWToolboxdll/Widgets/PartyDamage.cpp
+++ b/GWToolboxdll/Widgets/PartyDamage.cpp
@@ -28,9 +28,6 @@ constexpr const wchar_t* JSON_FILENAME = L"healthlog.json";
 namespace {
     GW::HookEntry ChatCmd_HookEntry;
 
-    // damage values
-
-
     uint32_t total = 0;
     uint32_t total_healing = 0;
 
@@ -75,7 +72,6 @@ namespace {
         return -1;
     }
 
-    // Finalize damage for all active conditions on a tracker, then remove it
     void FinalizeAndRemoveTracker(uint32_t ti) {
         if (ti >= cond_tracker_count) return;
         const clock_t now = TIMER_INIT();
@@ -107,7 +103,6 @@ namespace {
     std::map<DWORD, DWORD> hp_map_hm{};
     const std::pair<const char*, std::map<DWORD, DWORD>*> section_maps[] = {{"health_nm", &hp_map_nm}, {"health_hm", &hp_map_hm}};
 
-    // main routine variables
     bool in_explorable = false;
     clock_t send_timer = 0;
     std::queue<std::wstring> send_queue{};
@@ -163,7 +158,6 @@ void PartyDamage::ReconcileDamageIndices()
     if (party_agent_ids_by_index == prev_party_agent_ids) return;
     prev_party_agent_ids = party_agent_ids_by_index;
 
-    // Map old agent_id -> index in current damage array
     std::unordered_map<uint32_t, uint32_t> old_agent_to_idx;
     for (uint32_t i = 0; i < damage.size(); i++) {
         if (damage[i].agent_id != 0) old_agent_to_idx[damage[i].agent_id] = i;
@@ -182,7 +176,6 @@ void PartyDamage::ReconcileDamageIndices()
         if (new_idx >= new_damage.size()) continue;
         if (new_idx >= pets_start_idx) continue;
 
-        // Try matching by agent_id first
         auto it = old_agent_to_idx.find(agent_id);
         if (it != old_agent_to_idx.end()) {
             new_damage[new_idx] = damage[it->second];
@@ -195,7 +188,6 @@ void PartyDamage::ReconcileDamageIndices()
         if (new_idx < party_names_by_index.size()) {
             const auto& name = party_names_by_index[new_idx]->wstring();
             if (!name.empty()) {
-                // Check departed entries
                 auto dit = departed_by_name.find(name);
                 if (dit != departed_by_name.end()) {
                     new_damage[new_idx] = departed_damage[dit->second];
@@ -203,7 +195,6 @@ void PartyDamage::ReconcileDamageIndices()
                     departed_damage[dit->second].Reset();
                     continue;
                 }
-                // Check old damage entries by name
                 for (uint32_t i = 0; i < damage.size(); i++) {
                     if (!claimed_old_indices.count(i) && damage[i].name == name && !damage[i].name.empty()) {
                         new_damage[new_idx] = damage[i];
@@ -216,7 +207,6 @@ void PartyDamage::ReconcileDamageIndices()
         }
     }
 
-    // Move unclaimed entries with data to departed
     for (uint32_t i = 0; i < damage.size(); i++) {
         if (claimed_old_indices.count(i)) continue;
         if (damage[i].damage > 0 || damage[i].healing > 0)
@@ -368,7 +358,6 @@ void PartyDamage::ConditionValueCallback(GW::HookStatus*, const GW::Packet::StoC
         const double elapsed = static_cast<double>(now - cond_trackers[ti].apply_time[ci]) / 1000.0;
         cond_damage[ci] += static_cast<double>(CONDITION_DPS_RATES[ci]) * elapsed;
         cond_trackers[ti].apply_time[ci] = 0; // clear it
-        // If all conditions cleared, remove tracker
         bool all_cleared = true;
         for (int cj = 0; cj < 4; cj++) {
             if (cond_trackers[ti].apply_time[cj] != 0) { all_cleared = false; break; }
@@ -383,7 +372,6 @@ void PartyDamage::ConditionValueCallback(GW::HookStatus*, const GW::Packet::StoC
 
 void PartyDamage::DamagePacketCallback(GW::HookStatus*, const GW::Packet::StoC::GenericModifier* packet)
 {
-    // ignore non-damage/heal packets
     switch (packet->type) {
         case GW::Packet::StoC::P156_Type::damage:
         case GW::Packet::StoC::P156_Type::critical:
@@ -592,7 +580,6 @@ void PartyDamage::Update(const float)
         }
     }
 
-    // reset recent if needed
     for (auto& entry : damage) {
         if (TIMER_DIFF(entry.last_damage) > settings.recent_max_time) {
             entry.recent_damage = 0;
@@ -615,7 +602,6 @@ void PartyDamage::Update(const float)
             damage[party_idx].name = decoded;
         }
 
-        // Restore departed entry if this slot is empty but a departed member matches by name
         if (damage[party_idx].damage == 0 && damage[party_idx].healing == 0) {
             for (auto& dep : departed_damage) {
                 if (dep.name == decoded && (dep.damage > 0 || dep.healing > 0)) {
@@ -725,7 +711,6 @@ void PartyDamage::Draw(IDirect3DDevice9*)
         constexpr size_t buffer_size = 16;
         char buffer[buffer_size];
 
-        // Condition DPS header row
         if (settings.show_condition_dps) {
             const struct { uint32_t color; const char* icon; int ci; } conds[] = {
                 {IM_COL32(200, 50, 50, 255), ICON_FA_TINT, 0},
@@ -760,15 +745,12 @@ void PartyDamage::Draw(IDirect3DDevice9*)
             const auto x = damage_top_left.x;
 
             const float damage_float = static_cast<float>(entry->damage);
-            // Total damage bar
             DrawGradientBar(draw_list, x, width, damage_top_left.y, damage_bottom_right.y, settings.bars_left, max > 0 ? damage_float / max : 0, damage_col_from, damage_col_to);
 
-            // Recent damage bar (bottom)
             if (settings.show_damage && entry->recent_damage) {
                 DrawGradientBar(draw_list, x, width, damage_bottom_right.y - 6, damage_bottom_right.y, settings.bars_left, max_recent > 0 ? static_cast<float>(entry->recent_damage) / max_recent : 0, damage_recent_from, damage_recent_to);
             }
 
-            // Recent healing bar (top)
             if (settings.show_healing && entry->recent_healing) {
                 DrawGradientBar(draw_list, x, width, damage_top_left.y, damage_top_left.y + 6, settings.bars_left, max_recent_healing > 0 ? static_cast<float>(entry->recent_healing) / max_recent_healing : 0, healing_from, healing_to);
             }
@@ -781,7 +763,6 @@ void PartyDamage::Draw(IDirect3DDevice9*)
                 FormatValueString(buffer, buffer_size, damage_float);
                 draw_list->AddText(ImVec2(x + ImGui::GetStyle().ItemSpacing.x, text_y), IM_COL32(255, 255, 255, 255), buffer);
 
-                // Damage percentage
                 if (!settings.show_healing) {
                     const float perc_of_total = GetPercentageOfTotal(entry->damage);
                     snprintf(buffer, buffer_size, "%.1f %%", perc_of_total);
@@ -802,7 +783,6 @@ void PartyDamage::Draw(IDirect3DDevice9*)
                 const float heal_text_x = settings.show_damage ? x + width / 2 : x + ImGui::GetStyle().ItemSpacing.x;
                 draw_list->AddText(ImVec2(heal_text_x, text_y), settings.color_healing, buffer);
 
-                // Healing percentage
                 if (!settings.show_damage) {
                     const float perc_of_total_heal = GetPercentageOfTotalHealing(entry->healing);
                     snprintf(buffer, buffer_size, "%.1f %%", perc_of_total_heal);

--- a/GWToolboxdll/Widgets/PartyDamage.h
+++ b/GWToolboxdll/Widgets/PartyDamage.h
@@ -69,7 +69,6 @@ public:
     void Initialize() override;
     void Terminate() override;
 
-    // Draw user interface. Will be called every frame if the element is visible
     void Draw(IDirect3DDevice9* pDevice) override;
 
     void Update(float delta) override;

--- a/GWToolboxdll/Widgets/ServerInfoWidget.cpp
+++ b/GWToolboxdll/Widgets/ServerInfoWidget.cpp
@@ -104,7 +104,6 @@ void ServerInfoWidget::Update(float)
         }
         current_server_info->last_update = time(nullptr);
         server_info_fetcher = std::thread([this] {
-            // Need to check details
             using namespace std::string_literals;
             const std::string url = "https://api.ipgeolocation.io/ipgeo?apiKey="s + IPGEO_API_KEY + "&ip=" + current_server_info->ip;
             int tries = 0;

--- a/GWToolboxdll/Widgets/SkillbarWidget.cpp
+++ b/GWToolboxdll/Widgets/SkillbarWidget.cpp
@@ -26,7 +26,6 @@ namespace {
     GW::UI::FramePosition skillbar_skill_positions[8];
     ImVec2 skill_positions_calculated[8];
 
-    // Overall settings
     enum class Layout {
         Row,
         Rows,
@@ -106,7 +105,6 @@ namespace {
             }
         }
 
-        // Calculate columns/rows
         if (skillbar_skill_positions[0].screen_top == skillbar_skill_positions[7].screen_top) {
             layout = Layout::Row;
         }
@@ -281,13 +279,11 @@ void SkillbarWidget::Draw(IDirect3DDevice9*)
         const ImVec2& top_left = skill_positions_calculated[i];
         const ImVec2 bottom_right = {skill_positions_calculated[i].x + m_skill_width, skill_positions_calculated[i].y + m_skill_height};
 
-        // draw overlay
         if (settings.display_skill_overlay) {
             draw_list->AddRectFilled(top_left, bottom_right, skill.color);
         }
         draw_list->AddRect(top_left, bottom_right, settings.color_border);
 
-        // label
         if (*skill.cooldown) {
             ImGui::PushFont(NULL, draw_list, font_size);
             const ImVec2 label_size = ImGui::CalcTextSize(skill.cooldown);

--- a/GWToolboxdll/Widgets/SkillbarWidget.h
+++ b/GWToolboxdll/Widgets/SkillbarWidget.h
@@ -70,7 +70,6 @@ public:
     void Initialize() override;
     void Terminate() override;
 
-    // Draw user interface. Will be called every frame if the element is visible
     void Draw(IDirect3DDevice9* pDevice) override;
 
     void Update(float delta) override;
@@ -93,7 +92,6 @@ private:
 
     std::array<Skill, 8> m_skills{};
 
-    // Internal utils
     [[nodiscard]] Color UptimeToColor(uint32_t uptime) const;
     static std::vector<Effect> get_effects(GW::Constants::SkillID skillId);
     static Effect get_longest_effect(GW::Constants::SkillID skillId);

--- a/GWToolboxdll/Widgets/TitleTrackerWidget.cpp
+++ b/GWToolboxdll/Widgets/TitleTrackerWidget.cpp
@@ -97,9 +97,7 @@ namespace {
     float GetTitleProgressRatio(GW::Constants::TitleID title_id, GW::Title* title, bool current_tier = false)
     {
         if (!title) return 0.f;
-        // Calculate progress ratio like original
         if (title->is_percentage_based()) {
-            // Percentage-based: min(current_points, 1000) / 1000
             uint32_t capped_points = std::min(title->current_points, 1000u);
             return (float)capped_points / 1000.0f;
         }
@@ -124,7 +122,6 @@ namespace {
 
         if (!title_1 || !title_2) return false;
 
-        // Check for unavailable titles (points_needed_next_rank == -1)
         bool unavailable_1 = (title_1->points_needed_next_rank == 0xFFFFFFFF);
         bool unavailable_2 = (title_2->points_needed_next_rank == 0xFFFFFFFF);
 
@@ -169,7 +166,6 @@ namespace {
         update_progress(frame_id_1, GetTitleProgressRatio(title_id_1, title_1, settings.show_overall_title_progress));
         update_progress(frame_id_2, GetTitleProgressRatio(title_id_2, title_2, settings.show_overall_title_progress));
 
-        // Reuse TitleProgress comparison logic via temporary wrappers
         TitleProgress p1(title_id_1), p2(title_id_2);
         return CompareTitleProgress(&p1, &p2) ? 1 : 0;
     }
@@ -375,12 +371,10 @@ void TitleTrackerWidget::Draw(IDirect3DDevice9*)
         ImVec2 bar_size(available_width, settings.progress_bar_height);
         const auto draw_list = ImGui::GetWindowDrawList();
 
-        // Calculate progress bar colour
         const ImVec4 base_color = ImGui::ColorConvertU32ToFloat4(settings.progress_bar_foreground_color);
         const float lighten_factor = 1.5f; // Adjust to control how much lighter
         ImVec4 light_color(std::min(base_color.x * lighten_factor, 1.0f), std::min(base_color.y * lighten_factor, 1.0f), std::min(base_color.z * lighten_factor, 1.0f), base_color.w);
 
-        // Convert ImVec4 colors to ImU32
         ImU32 color_start = settings.progress_bar_foreground_color;
         ImU32 color_end = ImGui::ColorConvertFloat4ToU32(light_color);
 
@@ -390,7 +384,6 @@ void TitleTrackerWidget::Draw(IDirect3DDevice9*)
                 continue;
             }
             if (p->overlay_label->encoded().empty()) continue;
-            // Get strings from EncString
             const auto& title_text = p->title_label.string();
             auto sub_title_text = p->tier_label.string();
             if (p->current_rank > 0)
@@ -416,10 +409,8 @@ void TitleTrackerWidget::Draw(IDirect3DDevice9*)
 
             ImVec2 bar_pos = ImGui::GetCursorScreenPos();
             ImVec2 bar_pos_max = ImVec2(bar_pos.x + bar_size.x, bar_pos.y + bar_size.y);
-            // Background progress bar
             draw_list->AddRectFilled(bar_pos, bar_pos_max, settings.progress_bar_background_color);
 
-            // Foreground progress bar
             float fill_width = bar_size.x * p->percent;
             draw_list->AddRectFilledMultiColor(bar_pos, ImVec2(bar_pos.x + fill_width, bar_pos.y + bar_size.y), color_start, color_end, color_end, color_start);
 
@@ -429,7 +420,6 @@ void TitleTrackerWidget::Draw(IDirect3DDevice9*)
                 ImVec2 secondary_bar_pos(bar_pos.x, bar_pos_max.y - secondary_height);
                 float secondary_fill_width = bar_size.x * p->secondary_percent;
 
-                // Determine color based on progress thresholds
                 ImU32 secondary_color;
                 if (p->secondary_percent >= 1.0f) {
                     secondary_color = IM_COL32(255, 0, 0, 150); // Red when full
@@ -444,10 +434,8 @@ void TitleTrackerWidget::Draw(IDirect3DDevice9*)
                 draw_list->AddRectFilled(secondary_bar_pos, ImVec2(secondary_bar_pos.x + secondary_fill_width, secondary_bar_pos.y + secondary_height), secondary_color);
             }
 
-            // Border
             draw_list->AddRect(bar_pos, bar_pos_max, progress_bar_border_color);
 
-            // Overlay label
             if (Colors::IsVisible(settings.progress_overlay_label_color)) {
                 ImVec2 overlay_size = ImGui::CalcTextSize(overlay_text.c_str());
                 ImVec2 overlay_pos(bar_pos.x + (bar_size.x - overlay_size.x) * 0.5f, bar_pos.y + (bar_size.y - overlay_size.y) * 0.5f);

--- a/GWToolboxdll/Widgets/VanquishMapOverlayWidget.cpp
+++ b/GWToolboxdll/Widgets/VanquishMapOverlayWidget.cpp
@@ -26,7 +26,6 @@ namespace {
     Color vq_color_blocked = IM_COL32(60, 20, 20, 170);
     Color vq_color_blocked_border = IM_COL32(180, 100, 100, 140);
 
-    // Enemy tracking
     enum class EnemyState { NotApplicable, Alive, Stale };
     struct TrackedEnemy {
         GW::Vec2f pos;
@@ -1068,7 +1067,6 @@ void VanquishMapOverlayWidget::Update(float)
         }
     }
 
-    // Frame rate check for expensive updates
     static clock_t last_check = TIMER_INIT();
     if (!ToolboxUtils::FrameRateCheck(last_check, 30)) return;
 

--- a/GWToolboxdll/Widgets/VanquishWidget.cpp
+++ b/GWToolboxdll/Widgets/VanquishWidget.cpp
@@ -33,7 +33,6 @@ void VanquishWidget::Draw(IDirect3DDevice9*)
         static char foes_count[32] = "";
         snprintf(foes_count, 32, "%lu / %lu", killed, tokill + killed);
 
-        // vanquished
         ImGui::PushFont(FontLoader::GetFont(), static_cast<float>(FontLoader::FontSize::header1));
         ImVec2 cur = ImGui::GetCursorPos();
         ImGui::SetCursorPos(ImVec2(cur.x + 1, cur.y + 1));
@@ -42,7 +41,6 @@ void VanquishWidget::Draw(IDirect3DDevice9*)
         ImGui::Text("Vanquished");
         ImGui::PopFont();
 
-        // count
         ImGui::PushFont(FontLoader::GetFont(), static_cast<float>(FontLoader::FontSize::widget_small));
         cur = ImGui::GetCursorPos();
         ImGui::SetCursorPos(ImVec2(cur.x + 2, cur.y + 2));

--- a/GWToolboxdll/Widgets/WorldMapWidget.cpp
+++ b/GWToolboxdll/Widgets/WorldMapWidget.cpp
@@ -443,10 +443,8 @@ namespace {
         for (auto prop : *props) {
             if (!IsTravelPortal(prop)) continue;
             // TOOD: If found is null or this prop->location is closer than the found one, this wins
-            // Calculate the distance between the current portal and the given location
             float distance = GW::GetDistance(prop->position, game_pos);
 
-            // If found is null or this portal is closer than the currently found one, update found
             if (!found || distance < closest_distance) {
                 found = prop;
                 closest_distance = distance;
@@ -515,7 +513,6 @@ namespace {
         });
     }
 
-    // Helper function to calculate rotated points
     void CalculateRotatedPoints(const ImRect& rect, const ImVec2& center, float rotation_angle, ImVec2 out_points[4])
     {
         ImVec2 points[4] = {
@@ -529,12 +526,10 @@ namespace {
             const float dx = points[i].x - center.x;
             const float dy = points[i].y - center.y;
 
-            // Apply the rotation transformation using rotation_angle
             out_points[i] = {center.x + dx * cos(rotation_angle) - dy * sin(rotation_angle), center.y + dx * sin(rotation_angle) + dy * cos(rotation_angle)};
         }
     }
 
-    // Helper function to calculate UV coordinates for a sprite map
     void CalculateUVCoords(float uv_start_x, float uv_end_x, ImVec2 uv_points[4])
     {
         uv_points[0] = {uv_start_x, 0.0f}; // Top-left
@@ -545,7 +540,6 @@ namespace {
 
 
 
-    // Function to calculate viewport position
     ImVec2 CalculateViewportPos(const GW::Vec2f& marker_world_pos, const ImVec2& top_left)
     {
         return {world_map_proj_scale.x * (marker_world_pos.x - top_left.x) + viewport_offset.x, world_map_proj_scale.y * (marker_world_pos.y - top_left.y) + viewport_offset.y};
@@ -811,7 +805,6 @@ namespace {
             color = QuestModule::GetQuestColor(quest->quest_id);
         }
 
-        // draw_quest_marker
         const auto draw_quest_marker = [&](const GW::Vec2f& quest_marker_pos) {
             const auto viewport_quest_pos = CalculateViewportPos(quest_marker_pos, world_map_context->top_left);
 
@@ -833,11 +826,9 @@ namespace {
             return icon_rect.Contains(ImGui::GetMousePos());
         };
 
-        // draw_quest_arrow
         const auto draw_quest_arrow = [&](const GW::Vec2f& quest_marker_pos) {
             const auto viewport_quest_pos = CalculateViewportPos(quest_marker_pos, world_map_context->top_left);
             const auto viewport_player_pos = CalculateViewportPos(player_world_map_pos, world_map_context->top_left);
-            // Calculate the vector from your position to the quest marker
             const float dx = viewport_quest_pos.x - viewport_player_pos.x;
             const float dy = viewport_quest_pos.y - viewport_player_pos.y;
 
@@ -1317,7 +1308,6 @@ void WorldMapWidget::Draw(IDirect3DDevice9*)
     }
 
     hovered_quest_id = GW::Constants::QuestID::None;
-    // Draw all quest markers on world map if applicable
     if (settings.showing_all_quests) {
         if (const auto quest_log = GW::QuestMgr::GetQuestLog()) {
             for (auto& quest : *quest_log) {

--- a/GWToolboxdll/Windows/AccountInventoryWindow.cpp
+++ b/GWToolboxdll/Windows/AccountInventoryWindow.cpp
@@ -471,7 +471,6 @@ namespace {
     std::wstring GetItemEncDescription(GW::Item* item);
     void ClearMissingItem(const UUID* account, const std::string& character, const GW::Constants::HeroID hero_id, const GW::Constants::Bag bag_id, const uint32_t slot);
 
-    // collective callback hook
     GW::HookEntry OnUIMessage_HookEntry{};
     // main item storage: the account hierarchy, keyed by canonical GUID string.
     std::unordered_map<std::string, Account> accounts{};
@@ -574,10 +573,8 @@ namespace {
     clock_t save_dirty_inventories_timer{};
     bool map_loaded_delayed_trigger = false;
 
-    // config options
     AccountInventoryWindow::Settings settings;
 
-    // input buffers
     inline static const size_t BUFFER_SIZE = 128;
     char name_filter_buf[BUFFER_SIZE]{};
     char location_filter_buf[BUFFER_SIZE]{};
@@ -587,7 +584,6 @@ namespace {
     GUID current_account;
     std::string current_character;
 
-    // member variables
     ImVec4 color_chest_item{};
     ImVec4 color_chest_item_hovered{};
     ImVec4 color_chest_item_active{};
@@ -1614,7 +1610,6 @@ void InventoryScanner::Update()
         } break;
         case InventoryScanner::Stage::NextCharacter: {
             if (reroll_char_queue.empty()) {
-                // Restore original heroes
                 for (auto hero_id : original_player_heroes) {
                     GW::PartyMgr::AddHero(hero_id);
                 }
@@ -1632,7 +1627,6 @@ void InventoryScanner::Update()
             if (!wcseq(GW::AccountMgr::GetCurrentPlayerName(), current_reroll_char.c_str())) break;
             original_heroes = GetPartyHeroIDs();
             queued_hero_ids.clear();
-            // Grab unlocked hero ids
             const auto w = GW::GetWorldContext();
             const auto h = w ? &w->hero_info : nullptr;
             if (h) {
@@ -1769,7 +1763,6 @@ void ItemReroller::Update()
                 InventoryManager::MoveItem((InventoryManager::Item*)GW::Items::GetItemById(loc->item->item_id));
             }
             Cancel();
-            // Done.
         } break;
     }
 }
@@ -2025,7 +2018,6 @@ void AccountInventoryWindow::Draw(IDirect3DDevice9*)
         return;
     }
 
-    // view related settings
     ImGui::Checkbox("Detailed View", &settings.detailed_view);
     ImGui::SameLine();
     if (ImGui::GetContentRegionAvail().x < checkbox_max_width) ImGui::NewLine();

--- a/GWToolboxdll/Windows/AccountInventoryWindow.h
+++ b/GWToolboxdll/Windows/AccountInventoryWindow.h
@@ -26,8 +26,6 @@ public:
         bool hide_unclaimed_items = false;
     };
 
-    // callbacks
-
     void Initialize() override;
     void Terminate() override;
     void Update(float delta) override;

--- a/GWToolboxdll/Windows/ArmoryWindow.cpp
+++ b/GWToolboxdll/Windows/ArmoryWindow.cpp
@@ -1072,12 +1072,10 @@ namespace GWArmory {
                 state = SnapshotState::WaitingForDecode;
             } break;
             case SnapshotState::WaitingForDecode: {
-                // Check if all strings are decoded
                 for (auto& it : pending_decodes) {
                     if (it.second->IsDecoding()) return;
                 }
 
-                // Build JSON output
                 std::vector<armory_snapshot::WeaponEntry> output;
                 output.reserve(pending_decodes.size());
                 for (auto& it : pending_decodes) {
@@ -1091,7 +1089,6 @@ namespace GWArmory {
                     });
                 }
 
-                // Write to file
                 const auto filename = Resources::GetPath("weapon_snapshot.json");
                 std::ofstream file(filename);
                 if (file.is_open()) {
@@ -1103,7 +1100,6 @@ namespace GWArmory {
                     Log::Error("Failed to write weapon snapshot to %s", filename.string().c_str());
                 }
 
-                // Cleanup
                 pending_decodes.clear();
                 pending_items.clear();
                 state = SnapshotState::Idle;

--- a/GWToolboxdll/Windows/BuildsWindow.cpp
+++ b/GWToolboxdll/Windows/BuildsWindow.cpp
@@ -38,7 +38,6 @@ namespace {
     BuildsWindow::Settings settings;
     bool order_by_index = !settings.order_by_name;
 
-    // Preferred skill orders
     bool preferred_skill_orders_visible = false;
 
     GuiUtils::EncString preferred_skill_order_tooltip;
@@ -842,7 +841,6 @@ void BuildsWindow::Draw(IDirect3DDevice9* pDevice)
         ImGui::End();
     }
 
-    // Draw edit windows using the unified DrawEditWindow
     for (size_t i = 0; i < teambuilds.size(); i++) {
         if (!teambuilds[i].edit_open) continue;
         if (!teambuilds[i].DrawEditWindow(i, teambuilds, builds_changed)) {

--- a/GWToolboxdll/Windows/CompletionWindow.h
+++ b/GWToolboxdll/Windows/CompletionWindow.h
@@ -243,7 +243,6 @@ struct CharacterCompletion {
     std::vector<uint32_t> festival_hats{};
 };
 
-// class used to keep a list of hotkeys, capture keyboard event and fire hotkeys as needed
 class CompletionWindow : public ToolboxWindow {
 public:
     static CompletionWindow& Instance()

--- a/GWToolboxdll/Windows/DailyQuestsWindow.cpp
+++ b/GWToolboxdll/Windows/DailyQuestsWindow.cpp
@@ -178,8 +178,6 @@ namespace {
     };
     static_assert(_countof(zaishen_bounty_cycles) == ZAISHEN_BOUNTY_COUNT);
 
-    // These vectors are good to go
-
     std::unordered_map<DailyQuests::NicholasCycleData*, uint16_t> nicholas_item_collected_count;
 
     DailyQuests::NicholasCycleData nicholas_cycles[] = {
@@ -1028,7 +1026,6 @@ namespace {
     {
         static clock_t last_inv_check_sandford = 0;
 
-        // If the map is empty, populate it with unique keys from the cycle array
         if (nicholas_sandford_item_collected_count.empty()) {
             for (auto& item : nicholas_sandford_cycles) {
                 nicholas_sandford_item_collected_count[item.enc_name] = 0;
@@ -1036,7 +1033,6 @@ namespace {
         }
 
         if (!last_inv_check_sandford || TIMER_DIFF(last_inv_check_sandford) > 10000) {
-            // Check inventory for each Nicholas Sandford item
             for (const auto& [enc_name, count] : nicholas_sandford_item_collected_count) {
                 nicholas_sandford_item_collected_count[enc_name] = InventoryManager::CountItemsByName(enc_name.c_str());
             }
@@ -1048,7 +1044,6 @@ namespace {
         return found->second;
     }
     const std::unordered_map<GW::Constants::QuestID, DailyQuests::ZaishenCoinReward> zaishen_coin_rewards = {
-        // ZaishenMission
         {QuestID::ZaishenMission_The_Great_Northern_Wall, {15, 74}},
         {QuestID::ZaishenMission_Fort_Ranik, {15, 74}},
         {QuestID::ZaishenMission_Ruins_of_Surmia, {15, 74}},
@@ -1119,7 +1114,6 @@ namespace {
         {QuestID::ZaishenMission_Minister_Chos_Estate, {15, 74}},
         {QuestID::ZaishenMission_Pogahn_Passage, {30, 150}},
 
-        // ZaishenBounty
         {QuestID::ZaishenBounty_Urgoz, {60, 210}},
         {QuestID::ZaishenBounty_Chung_The_Attuned, {20, 70}},
         {QuestID::ZaishenBounty_Mungri_Magicbox, {20, 70}},
@@ -1148,7 +1142,6 @@ namespace {
         {QuestID::ZaishenBounty_Magmus, {40, 140}},
         {QuestID::ZaishenBounty_Lord_Khobay, {40, 140}},
 
-        // ZaishenVanquish
         {QuestID::ZaishenVanquish_Dejarin_Estate, {150, 150}},
         {QuestID::ZaishenVanquish_Watchtower_Coast, {50, 50}},
         {QuestID::ZaishenVanquish_Arbor_Bay, {250, 250}},
@@ -1438,7 +1431,6 @@ void DailyQuests::Draw(IDirect3DDevice9*)
         if (settings.show_other_searing_dailies) add_pre_cols();
     }
 
-    // Header row
     float offset = 0.0f;
     ImGui::Text("Date");
     ImGui::SameLine(offset += short_text_width);
@@ -1941,7 +1933,6 @@ size_t DailyQuests::NicholasCycleData::GetCollectedQuantity()
 {
     static clock_t last_inv_check = 0;
     if (!last_inv_check || TIMER_DIFF(last_inv_check) > 10000) {
-        // Check inventory
         for (auto& item : nicholas_cycles) {
             nicholas_item_collected_count[&item] = InventoryManager::CountItemsByName(item.enc_name.c_str());
         }

--- a/GWToolboxdll/Windows/DoorMonitorWindow.h
+++ b/GWToolboxdll/Windows/DoorMonitorWindow.h
@@ -40,7 +40,6 @@ public:
                 return;
             }
             if (d->is_open) {
-                // Opening
                 if (!d->first_open) {
                     d->first_open = now;
                 }
@@ -49,7 +48,6 @@ public:
                 }
             }
             else {
-                // Closing
                 if (!d->first_close) {
                     d->first_close = now;
                 }

--- a/GWToolboxdll/Windows/DropTrackerWindow.cpp
+++ b/GWToolboxdll/Windows/DropTrackerWindow.cpp
@@ -126,7 +126,6 @@ namespace {
                 // Use the index as the ID, not the string content
                 ImGui::PushID(group_idx++);
 
-                // Use TreeNodeEx with a simple label
                 bool open = ImGui::TreeNodeEx("##tree", ImGuiTreeNodeFlags_SpanAvailWidth, "%s", key.empty() ? "(Unknown)" : key.c_str());
 
                 ImGui::TableNextColumn();
@@ -246,7 +245,6 @@ namespace {
                         ImGui::TableNextRow();
                         ImGui::TableNextColumn();
 
-                        // Show item details with weapon stats
                         ImGui::TextColored(GW::Items::GetRarityColor(drop->rarity), "%s", drop->GetItemName()->string().c_str());
                         ImGui::TableNextColumn();
                         ImGui::Text("%d", drop->quantity);

--- a/GWToolboxdll/Windows/FriendListWindow.cpp
+++ b/GWToolboxdll/Windows/FriendListWindow.cpp
@@ -92,10 +92,8 @@ namespace {
 
     uint8_t poll_interval_seconds = 10;
 
-    // Mapping of Name > UUID
     std::unordered_map<std::wstring, FriendListWindow::Friend*> uuid_by_name{};
 
-    // Main store of Friend info
     std::unordered_map<std::string, FriendListWindow::Friend*> friends{};
 
     bool show_location = true;
@@ -251,11 +249,9 @@ namespace {
         // This is a player that TB has added to friend list to find out who they're actually playing on.
 
         if (lf->IsOffline()) {
-            // If they're still not online, then show the "Player is not online" error
             ASSERT(WriteError(MessageType::PLAYER_X_NOT_ONLINE, pending_whisper.charname.c_str()));
         }
         else {
-            // If they're online, send the original message...
             ASSERT(lf->current_char);
             is_redirecting_whisper = true;
             GW::Chat::SendChat(lf->current_char->getNameW().c_str(), pending_whisper.message.c_str());
@@ -263,7 +259,6 @@ namespace {
         }
         pending_whisper.reset();
 
-        // ... then remove from GW.
         ASSERT(lf->RemoveGWFriend());
         ASSERT(FriendListWindow::RemoveFriend(lf));
     }
@@ -277,7 +272,6 @@ namespace {
         }
     }
 
-    // Remove from pending whispers when whisper has been sent
     void OnOutgoingWhisperSuccess(GW::HookStatus*, wchar_t*)
     {
         pending_whisper.reset();
@@ -287,7 +281,6 @@ namespace {
     {
         const auto player_name = TextUtils::GetPlayerNameFromEncodedString(message);
         if (const auto friend_ = FriendListWindow::GetFriend(player_name.c_str())) {
-            // If this player is already in my friend list, send the message directly.
             if (!friend_->IsOffline() && friend_->current_char->getNameW() != player_name) {
                 is_redirecting_whisper = true;
                 GW::Chat::SendChat(friend_->current_char->getNameW().c_str(), pending_whisper.message.c_str());
@@ -467,7 +460,6 @@ namespace {
             const auto packet = (GW::UI::UIPacket::kSendChatMessage*)wparam;
             const auto message = packet->message;
             const auto channel = GW::Chat::GetChannel(*message);
-            // If this outgoing whisper was created due to a redirect, or its not a whisper, drop out here.
             if (is_redirecting_whisper || channel != GW::Chat::CHANNEL_WHISPER) {
                 return;
             }
@@ -521,7 +513,6 @@ namespace {
         if (!is_valid_uuid) {
             return nullptr;
         }
-        // Try to get the existing Friend entry via uuid or charname
         FriendListWindow::Friend* lf = FriendListWindow::GetFriend(uuid);
         if (!lf && charname) {
             lf = FriendListWindow::GetFriend(charname);
@@ -552,12 +543,10 @@ namespace {
             uuid_by_name.emplace(lf->GetAliasW(), lf);
         }
         if (lf->current_map_id != map_id) {
-            // Map changed
             lf->current_map_id = map_id;
             lf->current_map_name = Resources::GetMapName(static_cast<GW::Constants::MapID>(map_id));
         }
 
-        // Check and copy charnames, only if player is NOT offline
         if (!charname || status == GW::FriendStatus::Offline) {
             lf->current_char = nullptr;
         }
@@ -700,7 +689,6 @@ bool FriendListWindow::GetIsPlayerIgnored(const std::wstring& player_name)
 
 
 /*  FriendListWindow::Friend    */
-// Get the Guild Wars friend object for this friend (if it exists)
 GW::Friend* FriendListWindow::Friend::GetFriend()
 {
     return GW::FriendListMgr::GetFriend((uint8_t*)&uuid_bytes);
@@ -727,7 +715,6 @@ FriendListWindow::Character* FriendListWindow::Friend::GetCharacter(const wchar_
     return &it->second;
 }
 
-// Get the character belonging to this friend (e.g. to find profession etc)
 FriendListWindow::Character* FriendListWindow::Friend::SetCharacter(const wchar_t* char_name, const uint8_t profession)
 {
     Character* existing = GetCharacter(char_name);
@@ -911,7 +898,6 @@ void FriendListWindow::Terminate()
     ToolboxWindow::Terminate();
     // Try to remove callbacks AGAIN here.
     SignalTerminate();
-    // Free memory for Friends list.
     while (friends.begin() != friends.end()) {
         RemoveFriend(friends.begin()->second);
     }
@@ -999,11 +985,9 @@ void FriendListWindow::Poll()
     while (it != friends.end()) {
         Friend* lf = it->second;
         if (lf->GetFriend()) {
-            // Friend exists in friend list, don't need to mess
             ++it;
             continue;
         }
-        // Removed from in-game friend list, delete from tb friend list.
         ASSERT(RemoveFriend(lf));
         it = friends.begin();
     }
@@ -1338,7 +1322,6 @@ void FriendListWindow::LoadFromFile()
         settings_thread.join();
     }
     settings_thread = std::thread([this] {
-        // clear builds from toolbox
         uuid_by_name.clear();
         while (friends.begin() != friends.end()) {
             RemoveFriend(friends.begin()->second);
@@ -1357,7 +1340,6 @@ void FriendListWindow::LoadFromFile()
                 continue; // Error, alias or uuid empty.
             }
 
-            // Grab char names
             for (const auto& [name, profession] : record.charnames) {
                 lf->SetCharacter(TextUtils::StringToWString(name).c_str(), profession);
             }
@@ -1390,7 +1372,6 @@ void FriendListWindow::SaveToFile()
         if (friends.empty()) {
             return; // Error, should have at least 1 friend
         }
-        // Load the existing records in, and amend the info
         auto records = LoadRecords();
         for (auto it = friends.begin(); it != friends.end(); ++it) {
             Friend& lf = *it->second;

--- a/GWToolboxdll/Windows/GWMarketWindow.cpp
+++ b/GWToolboxdll/Windows/GWMarketWindow.cpp
@@ -55,7 +55,6 @@ namespace {
     constexpr uint32_t COST_PER_CONNECTION_MS = 30 * 1000;
     constexpr uint32_t COST_PER_CONNECTION_MAX_MS = 60 * 1000;
 
-    // Enums for type-safe representations
     enum class Currency : uint32_t { Platinum = 0, Ecto = 1, Zkeys = 2, Arms = 3, Count = 4, All = 0xf };
 
     enum class OrderType : uint8_t { Sell = 0, Buy = 1 };
@@ -193,7 +192,6 @@ namespace {
         return Attribute::None;
     }
 
-    // Data structures
     struct Price {
         Currency type = Currency::Platinum;
         float quantity = 1.f;
@@ -335,7 +333,6 @@ namespace {
     bool show_edit_item_window = false;
     size_t editing_item_index = 0;
 
-    // Edit window - matching item orders
     std::vector<MarketItem> edit_window_matching_orders;
     std::string edit_window_matching_item_name;
     bool edit_window_orders_needs_sort = true;
@@ -447,13 +444,10 @@ namespace {
         int buyOrders = 0;
     };
 
-    // Settings
     GWMarketWindow::Settings settings;
 
-    // WebSocket
     ThreadedWebSocket market_ws;
 
-    // Data
     std::vector<AvailableItem> available_items;
     std::vector<MarketItem> last_items;
     std::vector<MarketItem> current_item_orders;
@@ -461,13 +455,11 @@ namespace {
     std::string pending_search_item;
     std::map<std::string, AvailableItem> favorite_items;
 
-    // UI
     char search_buffer[256] = "";
     enum FilterMode { SHOW_ALL, SHOW_SELL_ONLY, SHOW_BUY_ONLY };
     FilterMode filter_mode = SHOW_ALL;
     float refresh_timer = 0.0f;
 
-    // Socket.IO
     bool socket_io_ready = false;
     clock_t last_ping_time = 0;
     int ping_interval = 25000;
@@ -477,7 +469,6 @@ namespace {
     bool available_items_needs_sort = true;
     bool current_orders_needs_sort = true;
 
-    // Forward declarations
     void SendSocketStarted();
     void SendGetAvailableOrders();
     void SendGetLastItemsByFamily(const std::string& family);
@@ -660,13 +651,11 @@ namespace {
         if (!_orders.empty()) {
             const auto& item_name = _orders[0].name;
 
-            // Update current viewing orders
             if (item_name == current_viewing_item) {
                 current_item_orders = _orders;
                 current_orders_needs_sort = true;
             }
 
-            // Update edit window matching orders
             if (item_name == edit_window_matching_item_name) {
                 edit_window_matching_orders = _orders;
                 edit_window_orders_needs_sort = true;
@@ -739,7 +728,6 @@ namespace {
         SendSocketStarted();
         Refresh();
 
-        // Process any pending search request
         if (!pending_search_item.empty()) {
             SendGetItemOrders(pending_search_item);
             pending_search_item.clear();
@@ -934,7 +922,6 @@ namespace {
     {
         ImGui::Text("Available Listings (%zu)", available_items.size());
         ImGui::Separator();
-        // Sort only when data changes
         if (available_items_needs_sort) {
             std::sort(available_items.begin(), available_items.end(), [](const AvailableItem& a, const AvailableItem& b) {
                 return *a.name < *b.name;
@@ -944,11 +931,9 @@ namespace {
         }
 
         for (const auto& item : available_items) {
-            // Apply filter mode
             if (filter_mode == SHOW_SELL_ONLY && item.sellOrders == 0) continue;
             if (filter_mode == SHOW_BUY_ONLY && item.buyOrders == 0) continue;
 
-            // Apply search filter
             if (search_buffer[0] != '\0') {
                 std::string search_lower = search_buffer;
                 std::string name_lower = *item.name;
@@ -1035,7 +1020,6 @@ namespace {
 
         ImGui::Text("Item: %s", current_viewing_item.c_str());
 
-        // Sort mode dropdown
         ImGui::SameLine();
         ImGui::SetNextItemWidth(150.0f);
         if (ImGui::BeginCombo("##sort_mode", order_sort_mode == OrderSortMode::MostRecent ? "Most Recent" : "Currency")) {
@@ -1066,7 +1050,6 @@ namespace {
 
         ImGui::Separator();
 
-        // Add favorite/unfavorite button
         if (!current_viewing_item.empty()) {
             bool is_favorite = favorite_items.contains(current_viewing_item);
             std::string fav_label = std::format("{} {}", ICON_FA_STAR, is_favorite ? "Unfavorite" : "Favorite");
@@ -1097,10 +1080,8 @@ namespace {
             return;
         }
 
-        // Sort orders only when data changes or sort mode changes
         if (current_orders_needs_sort) {
             if (order_sort_mode == OrderSortMode::Currency) {
-                // Sort by price (cheapest first)
                 std::sort(current_item_orders.begin(), current_item_orders.end(), [](const MarketItem& a, const MarketItem& b) {
                     if (a.prices.empty() || b.prices.empty()) return false;
                     if (a.currency() != b.currency()) return a.currency() < b.currency();
@@ -1108,7 +1089,6 @@ namespace {
                 });
             }
             else {
-                // Sort by most recent
                 std::sort(current_item_orders.begin(), current_item_orders.end(), [](const MarketItem& a, const MarketItem& b) {
                     return a.lastRefresh > b.lastRefresh;
                 });
@@ -1227,9 +1207,7 @@ namespace {
             return;
         }
 
-        // Sort orders only when data changes
         if (edit_window_orders_needs_sort) {
-            // Sort by price (cheapest first)
             std::sort(edit_window_matching_orders.begin(), edit_window_matching_orders.end(), [](const MarketItem& a, const MarketItem& b) {
                 if (a.prices.empty() || b.prices.empty()) return false;
                 if (a.currency() != b.currency()) return a.currency() < b.currency();
@@ -1248,23 +1226,19 @@ namespace {
             ImGui::PushID(&order);
             // const auto top = ImGui::GetCursorPosY();
 
-            // Player name and time
             ImGui::TextUnformatted(order.player.c_str());
             const auto timetext = TextUtils::RelativeTime(order.lastRefresh);
             ImGui::SameLine();
             ImGui::TextDisabled("%s", timetext.c_str());
 
-            // Weapon details
             if (order.has_weapon_details()) {
                 ImGui::TextUnformatted(order.weaponDetails.toString().c_str());
             }
 
-            // Description
             if (!order.description.empty()) {
                 ImGui::TextUnformatted(order.description.c_str());
             }
 
-            // Price info
             ImGui::Text("Wants to %s %d for ", order.orderType == OrderType::Sell ? "sell" : "buy", order.quantity);
 
             ImGui::SameLine(0, 0);
@@ -1280,7 +1254,6 @@ namespace {
                 ImGui::Text("%.2f %s", price.price, GetPriceTypeString(price.type));
             }
 
-            // Price per item
             ImGui::SameLine();
             const auto price_per = order.price_per();
             ImGui::TextDisabled(price_per == static_cast<int>(price_per) ? "(%.0f %s each)" : "(%.1f %s each)", price_per, GetPriceTypeString(price.type));
@@ -1289,7 +1262,6 @@ namespace {
             ImGui::PopID();
         };
 
-        // Show sell orders first
         bool has_sell_orders = false;
         for (const auto& order : edit_window_matching_orders) {
             if (order.orderType == OrderType::Sell && order.valid()) {
@@ -1302,7 +1274,6 @@ namespace {
             }
         }
 
-        // Show buy orders
         bool has_buy_orders = false;
         for (const auto& order : edit_window_matching_orders) {
             if (order.orderType == OrderType::Buy && order.valid()) {
@@ -1329,7 +1300,6 @@ namespace {
 
 
 
-    // Temporary values for editing shop items
     struct EditingShopItem {
         char name_buffer[256] = {0};
         char description_buffer[512] = {0};
@@ -1367,14 +1337,11 @@ namespace {
     {
         ImGui::PushID(static_cast<int>(index));
 
-        // Item name
         ImGui::TextUnformatted(item.name.c_str());
 
-        // Quantity
         ImGui::SameLine(250);
         ImGui::Text("x%d", item.quantity);
 
-        // Price
         ImGui::SameLine(350);
         if (!item.prices.empty()) {
             const auto& price = item.prices[0];
@@ -1385,7 +1352,6 @@ namespace {
             ImGui::Text("%.0f %s", price.price, GetPriceTypeString(price.type));
         }
 
-        // Edit button
         ImGui::SameLine(ImGui::GetContentRegionAvail().x - 50);
         if (ImGui::SmallButton("Edit")) {
             editing_item_index = index;
@@ -1402,7 +1368,6 @@ namespace {
 
         ImGui::SetNextWindowSize(ImVec2(600, 400), ImGuiCond_FirstUseEver);
         if (ImGui::Begin("My Shop", &show_my_shop_window, ImGuiWindowFlags_NoCollapse)) {
-            // Shop status
             if (!my_shop.uuid.empty() && my_shop.is_certified(GetCurrentPlayerName())) {
                 ImGui::TextColored(ImVec4(0.0f, 1.0f, 0.0f, 1.0f), "Shop Status: Verified");
             }
@@ -1416,14 +1381,12 @@ namespace {
 
             ImGui::Separator();
 
-            // Shop items list
             if (my_shop.items.empty()) {
                 ImGui::TextDisabled("No items in shop");
             }
             else {
                 ImGui::BeginChild("ShopItems", ImVec2(0, -30), true);
 
-                // Header
                 ImGui::Text("Item Name");
                 ImGui::SameLine(250);
                 ImGui::Text("Quantity");
@@ -1431,7 +1394,6 @@ namespace {
                 ImGui::Text("Price");
                 ImGui::Separator();
 
-                // Items
                 for (size_t i = 0; i < my_shop.items.size(); i++) {
                     DrawShopItem(my_shop.items[i], i);
                 }
@@ -1439,7 +1401,6 @@ namespace {
                 ImGui::EndChild();
             }
 
-            // Footer
             ImGui::Separator();
             if (ImGui::Button("Add Item", ImVec2(120, 0))) {
                 editing_item.Reset();
@@ -1463,56 +1424,44 @@ namespace {
 
         ImGui::SetNextWindowSize(ImVec2(900, 500), ImGuiCond_FirstUseEver);
         if (ImGui::Begin(window_title, &show_edit_item_window, ImGuiWindowFlags_NoCollapse)) {
-            // Check if item name changed and search for matching items
             static char last_search_name[256] = {0};
             if (strcmp(editing_item.name_buffer, last_search_name) != 0 && strlen(editing_item.name_buffer) > 0) {
-                // Item name changed, search for matching item
                 strncpy(last_search_name, editing_item.name_buffer, sizeof(last_search_name) - 1);
 
-                // Find matching item in available_items
                 const auto found = std::ranges::find_if(available_items.begin(), available_items.end(), [](const AvailableItem& item) {
                     return *item.name == last_search_name;
                 });
 
                 if (found != available_items.end()) {
-                    // Found a match, request order info
                     edit_window_matching_item_name = *found->name;
                     edit_window_matching_orders.clear();
                     edit_window_orders_needs_sort = true;
                     SendGetItemOrders(edit_window_matching_item_name);
                 }
                 else {
-                    // No match found
                     edit_window_matching_item_name.clear();
                     edit_window_matching_orders.clear();
                 }
             }
 
-            // Calculate column widths
             const float available_width = ImGui::GetContentRegionAvail().x;
             const float available_height = ImGui::GetContentRegionAvail().y - 40.f; // Leave space for buttons
             const float left_column_width = available_width * 0.5f - ImGui::GetStyle().ItemSpacing.x * 0.5f;
             const float right_column_width = available_width * 0.5f - ImGui::GetStyle().ItemSpacing.x * 0.5f;
 
-            // Left column - Edit form
             ImGui::BeginChild("EditForm", ImVec2(left_column_width, available_height), true);
 
-            // Item name
             ImGui::InputText("Item Name", editing_item.name_buffer, sizeof(editing_item.name_buffer));
 
-            // Description
             ImGui::InputTextMultiline("Description", editing_item.description_buffer, sizeof(editing_item.description_buffer), ImVec2(-1, 80));
 
 
-            // Quantity
             ImGui::InputFloat("Quantity", &editing_item.price.quantity, 1.f, 10.f, "%.0f");
             if (editing_item.price.quantity < 0.f) editing_item.price.quantity = 0.f;
 
-            // Price type
             const char* price_types[] = {"Platinum", "Ecto", "Zkeys", "Arms"};
             ImGui::Combo("Currency", (int*)&editing_item.price.type, price_types, IM_ARRAYSIZE(price_types));
 
-            // Price amount
             ImGui::InputFloat("Price Per", &editing_item.price.price, 1.f, 5.f, "%.0f");
             if (editing_item.price.price < 0) editing_item.price.price = 0;
 
@@ -1526,30 +1475,24 @@ namespace {
 
             ImGui::Separator();
 
-            // Action buttons
             if (ImGui::Button("Save", ImVec2(120, 0))) {
                 if (editing_item_index < my_shop.items.size()) {
-                    // Editing existing item
                     auto& item = my_shop.items[editing_item_index];
 
                     item = editing_item.item;
                     item.prices = {editing_item.price};
 
-                    // Update item
                     item.name = editing_item.name_buffer;
                     if (*editing_item.description_buffer) {
                         item.description = editing_item.description_buffer;
                     }
 
-                    // Update price
                 }
                 else {
-                    // Adding new item
                     auto item = editing_item.item;
                     item = editing_item.item;
                     item.prices = {editing_item.price};
 
-                    // Update item
                     item.name = editing_item.name_buffer;
                     if (*editing_item.description_buffer) {
                         item.description = editing_item.description_buffer;
@@ -1562,7 +1505,6 @@ namespace {
                     my_shop.items.push_back(item);
                 }
 
-                // Send update to server
                 SaveShop(my_shop, true);
 
                 editing_item.Reset();
@@ -1581,7 +1523,6 @@ namespace {
                 show_edit_item_window = false;
             }
 
-            // Only show Remove button when editing existing items
             if (!is_new_item) {
                 ImGui::SameLine();
                 if (ImGui::Button("Remove Item", ImVec2(120, 0))) {
@@ -1892,7 +1833,6 @@ void GWMarketWindow::DrawSettingsInternal()
 
 void GWMarketWindow::Draw(IDirect3DDevice9*)
 {
-// Draw shop windows
 #if (GWMARKET_SELLING_ENABLED)
     DrawMyShopWindow();
     DrawEditItemWindow();
@@ -1938,24 +1878,20 @@ void GWMarketWindow::Draw(IDirect3DDevice9*)
         ImGui::InputText("Search", search_buffer, sizeof(search_buffer));
         ImGui::Separator();
 
-        // Calculate available width and height for the two-column layout
         const float available_width = ImGui::GetContentRegionAvail().x;
         const float available_height = ImGui::GetContentRegionAvail().y - 32.f;
         const float left_column_width = available_width * 0.5f - ImGui::GetStyle().ItemSpacing.x * 0.5f;
         const float right_column_width = available_width * 0.5f - ImGui::GetStyle().ItemSpacing.x * 0.5f;
 
-        // Left column split: 65% for item list, 35% for favorites
         const float item_list_height = available_height * 0.7f - ImGui::GetStyle().ItemSpacing.y * 0.5f;
         const float favorites_height = available_height * 0.3f - ImGui::GetStyle().ItemSpacing.y * 0.5f;
 
-        // Left column - Item List (top 65%)
         ImGui::BeginChild("ItemList", ImVec2(left_column_width, item_list_height), true);
         DrawItemList();
         ImGui::EndChild();
 
         const auto favourites_cursor_pos = ImGui::GetCursorPos();
 
-        // Right column - Item Details (full height)
         ImGui::SameLine();
         ImGui::BeginChild("ItemDetails", ImVec2(right_column_width, available_height), true);
         DrawItemDetails();
@@ -1963,7 +1899,6 @@ void GWMarketWindow::Draw(IDirect3DDevice9*)
 
         ImGui::SetCursorPos(favourites_cursor_pos);
 
-        // Left column - Favorites List (bottom 35%)
         ImGui::BeginChild("FavoritesList", ImVec2(left_column_width, favorites_height), true);
         ImGui::Text("Favorites");
         ImGui::Separator();

--- a/GWToolboxdll/Windows/HeroBuildsWindow.cpp
+++ b/GWToolboxdll/Windows/HeroBuildsWindow.cpp
@@ -304,7 +304,6 @@ void HeroBuildsWindow::Draw(IDirect3DDevice9*)
             const float btn_width = 60.0f * ImGui::FontScale();
             const float& item_spacing = ImGui::GetStyle().ItemInnerSpacing.x;
 
-            // Collect filtered builds, preserving order
             std::vector<TeamBuild*> filtered;
             for (TeamBuild& tbuild : teambuilds) {
                 if (settings.filter_by_profession && player_profession != GW::Constants::Profession::None) {
@@ -323,7 +322,6 @@ void HeroBuildsWindow::Draw(IDirect3DDevice9*)
 
             bool vector_invalidated = false;
 
-            // Group builds by name
             std::unordered_map<std::string, std::vector<TeamBuild*>> by_group;
             for (TeamBuild* tbuild : filtered) {
                 by_group[std::string(tbuild->group)].push_back(tbuild);
@@ -477,7 +475,6 @@ void HeroBuildsWindow::Draw(IDirect3DDevice9*)
         ImGui::End();
     }
 
-    // Draw edit windows for each open teambuild using unified DrawEditWindow
     for (size_t i = 0; i < teambuilds.size(); i++) {
         if (!teambuilds[i].edit_open) continue;
         if (!teambuilds[i].DrawEditWindow(i, teambuilds, builds_changed)) {

--- a/GWToolboxdll/Windows/HeroBuildsWindow.h
+++ b/GWToolboxdll/Windows/HeroBuildsWindow.h
@@ -97,7 +97,6 @@ private:
 
     // Encode a teambuild into a Daybreak party loadout base64 string (header=15, type=1, version=1).
     static std::string EncodeTeambuildToDaybreak(const TeamBuild& tbuild);
-    // Decode a Daybreak party loadout base64 string into a teambuild.
     static bool DecodeTeambuildFromDaybreak(const std::string& code, TeamBuild& out);
 
     bool builds_changed = false;

--- a/GWToolboxdll/Windows/Hotkeys/HotkeyEquipItem.cpp
+++ b/GWToolboxdll/Windows/Hotkeys/HotkeyEquipItem.cpp
@@ -168,7 +168,6 @@ bool HotkeyEquipItem::DrawSettings()
         }
         if (ImGui::BeginPopupModal("Choose Item to Equip", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
             if (need_to_fetch_bag_items) {
-                // Free available_items ptrs
                 for (auto& it : available_items) {
                     for (auto atts : it.second) {
                         delete atts;
@@ -351,7 +350,6 @@ void HotkeyEquipItem::Execute()
     const GW::Skillbar* s = GW::SkillbarMgr::GetPlayerSkillbar();
     if (p->GetIsKnockedDown() || (s && s->cast_array.size())) {
         ongoing = true;
-        // Player knocked down or casting; wait.
         return;
     }
     if (p->skill) {

--- a/GWToolboxdll/Windows/Hotkeys/HotkeyGWKey.cpp
+++ b/GWToolboxdll/Windows/Hotkeys/HotkeyGWKey.cpp
@@ -29,7 +29,6 @@ namespace {
         if (waiting) {
             return false;
         }
-        // Reorder
         std::ranges::sort(HotkeyGWKey::control_labels, [](const ControlLabelPair& lhs, const ControlLabelPair& rhs) {
             return lhs.second->string().compare(rhs.second->string()) < 0;
             });

--- a/GWToolboxdll/Windows/Hotkeys/HotkeyGroup.cpp
+++ b/GWToolboxdll/Windows/Hotkeys/HotkeyGroup.cpp
@@ -93,7 +93,6 @@ int HotkeyGroup::Description(char* buf, size_t bufsz)
 bool HotkeyGroup::DrawSettings()
 {
     bool hotkey_changed = false;
-    // Draw child hotkeys
     ImGui::Spacing();
     ImGui::TextDisabled("Group hotkeys:");
     ImGui::Separator();

--- a/GWToolboxdll/Windows/Hotkeys/HotkeyGroup.h
+++ b/GWToolboxdll/Windows/Hotkeys/HotkeyGroup.h
@@ -21,7 +21,6 @@ public:
     void Execute() override {};
     void Toggle() override;
 
-    // Overrides the outer draw to render the group header + its children
     bool DrawSettings() override;
 
     int Description(char* buf, size_t bufsz) override;

--- a/GWToolboxdll/Windows/Hotkeys/HotkeySendChat.h
+++ b/GWToolboxdll/Windows/Hotkeys/HotkeySendChat.h
@@ -2,8 +2,6 @@
 
 #include <Windows/Hotkeys/TBHotkey.h>
 
-// hotkey to send a message in chat
-// can be used for anything that uses SendChat
 class HotkeySendChat : public TBHotkey {
     char message[139]{};
     char channel = '/';

--- a/GWToolboxdll/Windows/Hotkeys/HotkeyToggle.h
+++ b/GWToolboxdll/Windows/Hotkeys/HotkeyToggle.h
@@ -4,7 +4,6 @@
 
 #include <Windows/Hotkeys/TBHotkey.h>
 
-// hotkey to toggle a toolbox function
 class HotkeyToggle : public TBHotkey {
     enum ToggleTarget {
         Clicker,

--- a/GWToolboxdll/Windows/Hotkeys/TBHotkey.cpp
+++ b/GWToolboxdll/Windows/Hotkeys/TBHotkey.cpp
@@ -35,7 +35,6 @@
 #include <Windows/Hotkeys/HotkeyUseItem.h>
 
 unsigned int TBHotkey::cur_ui_id = 0;
-// add these:
 std::vector<TBHotkey*> TBHotkey::all_hotkeys;
 std::vector<TBHotkey*> TBHotkey::top_level_hotkeys;
 std::unordered_map<std::string, HotkeyGroup*> TBHotkey::hotkey_groups;
@@ -814,7 +813,6 @@ bool TBHotkey::SetGroup(HotkeyGroup* to_set)
             ancestor = ancestor->group;
         }
     }
-    // Remove from old scope
     if (group) {
         auto& v = group->hotkeys;
         v.erase(std::remove(v.begin(), v.end(), this), v.end());
@@ -823,7 +821,6 @@ bool TBHotkey::SetGroup(HotkeyGroup* to_set)
         top_level_hotkeys.erase(std::remove(top_level_hotkeys.begin(), top_level_hotkeys.end(), this), top_level_hotkeys.end());
     }
     group = to_set;
-    // Add to new scope
     if (to_set) {
         to_set->hotkeys.push_back(this);
     }
@@ -845,7 +842,6 @@ void TBHotkey::SortHotkeys()
         return hk->sort_order;
     };
 
-    // Sort top_level_hotkeys and each group's children by sort_order
     std::function<void(std::vector<TBHotkey*>&)> sort_and_normalise = [&](std::vector<TBHotkey*>& vec) {
         std::ranges::sort(vec, [](const TBHotkey* a, const TBHotkey* b) {
             return a->sort_order < b->sort_order;
@@ -860,7 +856,6 @@ void TBHotkey::SortHotkeys()
 
     sort_and_normalise(top_level_hotkeys);
 
-    // Rebuild all_hotkeys in the correct flattened order
     auto size_before = all_hotkeys.size();
     all_hotkeys.clear();
     std::function<void(std::vector<TBHotkey*>&)> flatten = [&](std::vector<TBHotkey*>& vec) {

--- a/GWToolboxdll/Windows/Hotkeys/TBHotkey.h
+++ b/GWToolboxdll/Windows/Hotkeys/TBHotkey.h
@@ -17,8 +17,6 @@ namespace GW {
     enum class HeroBehavior : uint32_t;
 }
 
-// abstract class Toolbox Hotkey
-// has the key code and pressed status
 class TBHotkey {
 public:
     enum Op {

--- a/GWToolboxdll/Windows/HotkeysWindow.cpp
+++ b/GWToolboxdll/Windows/HotkeysWindow.cpp
@@ -167,7 +167,6 @@ namespace {
         }
     }
 
-    // Repopulates applicable_hotkeys based on current character/map context.
     // Used because its not necessary to check these vars on every keystroke, only when they change
     bool CheckSetValidHotkeys()
     {
@@ -208,7 +207,6 @@ namespace {
             return false;
         }
         bool is_in_controller_mode = GW::UI::IsInControllerMode();
-        // Check if the hotkey or any ancestor group has the trigger flag set.
         auto inherited_trigger = [&mt](const TBHotkey* hk) -> bool {
             for (const TBHotkey* cur = hk; cur; cur = cur->group) {
                 if (cur->trigger_on_explorable && mt == GW::Constants::InstanceType::Explorable) return true;
@@ -263,7 +261,6 @@ namespace {
         keysHeld.reset(); // Clear previous key states
         BYTE keyState[256];
 
-        // Get the current keyboard state
         if (GetKeyboardState(keyState)) {
             for (uint32_t vkey = 0; vkey < 256; ++vkey) {
                 // Check if the high-order bit is set (key is pressed)
@@ -299,7 +296,6 @@ namespace {
             hotkey_popup_first_draw = false;
         }
 
-        // Record any new key presses
         keys_selected |= wndproc_keys_held;
 
         std::string keys_held_buf = ModKeyName(keys_selected);
@@ -600,17 +596,10 @@ bool HotkeysWindow::WndProc(const UINT Message, const WPARAM wParam, LPARAM)
         for (TBHotkey* hk : valid_hotkeys) {
             if (is_key_up) hk->pressed = false;
 
-            // A hotkey is considered "matching" if:
-            // - It hasn't already been triggered (`hk->pressed == false`)
-            // - It should trigger on key-up (if we're processing a key-up event)
-            // - All its required keys are currently held (`hk->key_combo & wndproc_keys_held == hk->key_combo`)
-            // - The key that was just pressed/released is part of this hotkey (`hk->key_combo.test(keyData)`)
             if (check_trigger(hk, is_key_up, keyData, is_in_controller_mode)) {
-                // Count how many keys (modifiers + main key) are required for this hotkey
                 size_t modifier_count = hk->key_combo.count();
                 matching_hotkeys.push_back(hk);
 
-                // Track the highest number of required keys (most specific hotkey)
                 max_modifier_count = std::max(max_modifier_count, modifier_count);
             }
         }
@@ -622,7 +611,6 @@ bool HotkeysWindow::WndProc(const UINT Message, const WPARAM wParam, LPARAM)
             if (hk->key_combo.count() == max_modifier_count) {
                 PushPendingHotkey(hk);
 
-                // If this hotkey is set to block Guild Wars input, mark it as triggered
                 if (!is_key_up && hk->block_gw) {
                     triggered = true;
                 }

--- a/GWToolboxdll/Windows/InfoWindow.cpp
+++ b/GWToolboxdll/Windows/InfoWindow.cpp
@@ -967,7 +967,6 @@ namespace {
                 // GW::GetCharContext()->player_flags ^= 0x8;
             });
         }
-        // DownloadStringFiles
         if (ImGui::Button("DownloadStringFiles")) {
             Resources::EnqueueWorkerTask([]() {
                 Log::Info("Downloading strings...");

--- a/GWToolboxdll/Windows/InventorySorting.cpp
+++ b/GWToolboxdll/Windows/InventorySorting.cpp
@@ -24,7 +24,6 @@
 
 
 namespace {
-// Macro to wait for a game thread task to complete with timeout and cancellation checks
 #define WAIT_FOR_GAME_THREAD_TASK(task_done_flag, timeout_ms, error_message)               \
     for (size_t i = 0; i < (timeout_ms) && !(task_done_flag) && !pending_cancel; i += 5) { \
         Sleep(5);                                                                          \
@@ -42,7 +41,6 @@ namespace {
         return false;                                                                      \
     }
 
-    // Helper function to check if map is ready
     bool IsMapReady()
     {
         return GW::Map::GetInstanceType() != GW::Constants::InstanceType::Loading && !GW::Map::GetIsObserving() && GW::MemoryMgr::GetGWWindowHandle() == GetActiveWindow();
@@ -53,13 +51,11 @@ namespace {
     const ImVec4 ItemPurple = ImColor(187, 137, 237).Value;
     const ImVec4 ItemGold = ImColor(255, 204, 86).Value;
 
-    // State variables
     bool show_sort_popup = false;
     bool is_sorting = false;
     bool pending_cancel = false;
     size_t items_sorted_count = 0;
 
-    // Chat command hook entries
     GW::HookEntry sort_inventory_cmd_entry;
     GW::HookEntry sort_storage_cmd_entry;
 
@@ -67,7 +63,6 @@ namespace {
     bool pending_sortinventory_confirm = false;
     bool pending_sortstorage_confirm = false;
 
-    // Sort order configuration
     std::vector<GW::Constants::ItemType> sort_order;
     InventorySorting::Settings settings;
 
@@ -102,10 +97,6 @@ namespace {
         return (static_cast<uint32_t>(priority_by_type & 0xFF) << 24) | secondary;
     }
 
-    /**
-     * Compares two items for sorting purposes.
-     * Returns true if item_a should come before item_b.
-     */
     bool ShouldItemComeFirst(GW::Item* item_a, GW::Item* item_b)
     {
         if (!item_a || !item_b) return false;
@@ -126,14 +117,8 @@ namespace {
         pending_sortstorage_confirm = true;
     }
 
-    /**
-     * Draws the inventory sorting progress popup with cancel button.
-     */
     void DrawSortInventoryPopup();
 
-    /**
-     * Resets the sort order to default values.
-     */
     void ResetSortOrder()
     {
         sort_order = {GW::Constants::ItemType::Salvage,    GW::Constants::ItemType::Materials_Zcoins,
@@ -158,7 +143,6 @@ namespace {
 
         if (ImGui::BeginPopupModal("Sort Inventory", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
             if (!is_sorting) {
-                // Sorting has completed, close the popup
                 ImGui::CloseCurrentPopup();
                 ImGui::EndPopup();
                 return;
@@ -189,7 +173,6 @@ namespace {
         }
     }
 
-    // Helper: iterate over all slots in a bag range
     template <typename Fn>
     void ForEachItemInBags(GW::Constants::Bag start, GW::Constants::Bag end, Fn&& fn)
     {
@@ -215,7 +198,6 @@ namespace {
         ItemId,   // expected_value is item_id
     };
 
-    // Helper: wait until all slot expectations are met
     bool WaitForExpectations(const std::vector<SlotExpectation>& expectations, ExpectationMode mode, uint32_t timeout_ms)
     {
         for (size_t t = 0; t < timeout_ms && !pending_cancel; t += 50) {
@@ -312,7 +294,6 @@ void InventorySorting::LoadSettings(SettingsDoc& doc, ToolboxIni* legacy)
         }
     }
 
-    // If loading failed or no custom order, use default
     if (sort_order.empty()) {
         ResetSortOrder();
     }
@@ -379,7 +360,6 @@ void InventorySorting::DrawSettingsInternal()
 {
     ImGui::PushID("inventory_sorting_settings");
 
-    // Character inventory sorting
     {
         bool sort_char_inv = false;
         if (ImGui::ConfirmButton("Sort Character Inventory!", &sort_char_inv)) {
@@ -413,7 +393,6 @@ void InventorySorting::DrawSettingsInternal()
         ImGui::TextDisabled("Drag items to reorder priority (top = higher priority)");
         ImGui::Spacing();
 
-        // Drag and drop reordering for sort order
         for (size_t i = 0; i < sort_order.size(); i++) {
             const auto type = sort_order[i];
             const char* type_name = GW::Items::GetItemTypeName(type);
@@ -421,18 +400,15 @@ void InventorySorting::DrawSettingsInternal()
             ImGui::PushID(static_cast<int>(i));
             ImGui::Selectable(type_name, false, ImGuiSelectableFlags_None);
 
-            // Drag and drop source
             if (ImGui::BeginDragDropSource(ImGuiDragDropFlags_None)) {
                 ImGui::SetDragDropPayload("SORT_ORDER_ITEM", &i, sizeof(i));
                 ImGui::TextUnformatted(type_name);
                 ImGui::EndDragDropSource();
             }
 
-            // Drag and drop target
             if (ImGui::BeginDragDropTarget()) {
                 if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("SORT_ORDER_ITEM")) {
                     const size_t payload_i = *static_cast<const size_t*>(payload->Data);
-                    // Swap items
                     if (payload_i != i && payload_i < sort_order.size()) {
                         std::swap(sort_order[payload_i], sort_order[i]);
                     }

--- a/GWToolboxdll/Windows/ObjectiveTimerWindow.cpp
+++ b/GWToolboxdll/Windows/ObjectiveTimerWindow.cpp
@@ -943,7 +943,6 @@ void ObjectiveTimerWindow::Draw(IDirect3DDevice9*)
     if (loading) {
         return;
     }
-    // Main objective timer window
     if (visible && !loading) {
         ImGui::SetNextWindowCenter(ImGuiCond_FirstUseEver);
         ImGui::SetNextWindowSize(ImVec2(300, 0), ImGuiCond_FirstUseEver);
@@ -968,7 +967,6 @@ void ObjectiveTimerWindow::Draw(IDirect3DDevice9*)
         ImGui::End();
     }
 
-    // Breakout objective set for current run
     if (settings.show_current_run_window && current_objective_set) {
         ImGui::SetNextWindowCenter(ImGuiCond_FirstUseEver);
         ImGui::SetNextWindowSize(ImVec2(300, 0), ImGuiCond_FirstUseEver);
@@ -1043,7 +1041,6 @@ void ObjectiveTimerWindow::DrawSettingsInternal()
             EnableWebsocketServer(false);
             EnableWebsocketServer(enable_websocket_server);
         }
-        // Display websocket server status
         ImGui::Text("LiveSplit Server status: %s", websocket_app && websocket_server ? "Running" : "Stopped");
         if (websocket_app && websocket_server) {
             ImGui::SameLine();
@@ -1112,7 +1109,6 @@ void ObjectiveTimerWindow::LoadRuns()
         }
         FindClose(hFind);
 
-        // Output the list of names found
         for (auto it = obj_timer_files.rbegin(); it != obj_timer_files.rend() && instance.objective_sets.size() < max_objectives_in_memory; ++it) {
             try {
                 std::ifstream file;

--- a/GWToolboxdll/Windows/ObserverExportWindow.cpp
+++ b/GWToolboxdll/Windows/ObserverExportWindow.cpp
@@ -23,7 +23,6 @@ void ObserverExportWindow::Initialize()
     SettingsRegistry::Register(this, settings);
 }
 
-// Convert to JSON (Version 0.1)
 glz::generic ObserverExportWindow::ToJSON_V_0_1()
 {
     glz::generic json;
@@ -52,14 +51,12 @@ glz::generic ObserverExportWindow::ToJSON_V_0_1()
     json["skills"] = glz::generic::array_t{};
 
     for (const uint32_t party_id : party_ids) {
-        // parties
         const ObserverModule::ObservableParty* party = observer_module.GetObservablePartyById(party_id);
         if (!party) {
             json["parties"].get_array().push_back(glz::generic{nullptr});
             continue;
         }
         json["parties"].get_array().push_back([&] {
-            // parties -> party
             glz::generic json_party;
             json_party["party_id"] = party->party_id;
             json_party["stats"] = shared_stats_to_json(party->stats);
@@ -75,7 +72,6 @@ glz::generic ObserverExportWindow::ToJSON_V_0_1()
                 json_party["health_snapshots"].get_array().push_back(snapshot_json);
             }
 
-            // Shrine captures (captured shrines by this party)
             json_party["shrine_captures"] = glz::generic::array_t{};
             for (const auto& shrine_capture : party->shrine_captures) {
                 glz::generic shrine_json;
@@ -83,7 +79,6 @@ glz::generic ObserverExportWindow::ToJSON_V_0_1()
                 json_party["shrine_captures"].get_array().push_back(shrine_json);
             }
 
-            // Tower captures (captured towers/flags by this party)
             json_party["tower_captures"] = glz::generic::array_t{};
             for (const auto& tower_capture : party->tower_captures) {
                 glz::generic tower_json;
@@ -93,14 +88,12 @@ glz::generic ObserverExportWindow::ToJSON_V_0_1()
 
             json_party["members"] = glz::generic::array_t{};
             for (const uint32_t agent_id : party->agent_ids) {
-                // parties -> party -> agents
                 ObserverModule::ObservableAgent* agent = observer_module.GetObservableAgentById(agent_id);
                 if (!agent) {
                     json_party["members"].get_array().push_back(glz::generic{nullptr});
                     continue;
                 }
                 json_party["members"].get_array().push_back([&] {
-                    // parties -> party -> agents -> agent
                     glz::generic json_agent;
                     json_agent["display_name"] = agent->DisplayName();
                     json_agent["raw_name"] = agent->RawName();
@@ -113,7 +106,6 @@ glz::generic ObserverExportWindow::ToJSON_V_0_1()
                     json_agent["profession"] = agent->profession;
                     json_agent["stats"] = shared_stats_to_json(agent->stats);
 
-                    // Death events (all deaths for this agent)
                     json_agent["death_events"] = glz::generic::array_t{};
                     for (const auto& death : agent->death_events) {
                         glz::generic death_json;
@@ -126,14 +118,12 @@ glz::generic ObserverExportWindow::ToJSON_V_0_1()
                         json_agent["death_events"].get_array().push_back(death_json);
                     }
 
-                    // Resurrection events (all resurrections for this agent)
                     json_agent["resurrection_events"] = glz::generic::array_t{};
                     for (const auto& rez : agent->resurrection_events) {
                         glz::generic rez_json;
                         rez_json["timestamp_ms"] = rez.timestamp_ms;
                         rez_json["resurrector_agent_id"] = rez.resurrector_agent_id;
 
-                        // Add resurrection type
                         const char* res_type_str = "unknown";
                         switch (rez.resurrection_type) {
                             case ObserverModule::ResurrectionType::Skill: res_type_str = "skill"; break;
@@ -146,14 +136,12 @@ glz::generic ObserverExportWindow::ToJSON_V_0_1()
                     }
 
                     for (const auto skill_id : agent->stats.skill_ids_used) {
-                        // parties -> party -> agents -> agent -> skills
                         ObserverModule::ObservableSkill* skill = ObserverModule::Instance().GetObservableSkillById(skill_id);
                         if (!skill) {
                             json["skills"].get_array().push_back(glz::generic{nullptr});
                             continue;
                         }
                         json["skills"].get_array().push_back([&] {
-                            // parties -> party -> agents -> agent -> skills -> skill
                             glz::generic json_skill;
                             json_skill["name"] = skill->Name();
                             return json_skill;
@@ -170,7 +158,6 @@ glz::generic ObserverExportWindow::ToJSON_V_0_1()
     return json;
 }
 
-// Convert to JSON (Version 1.0)
 glz::generic ObserverExportWindow::ToJSON_V_1_0()
 {
     glz::generic json;
@@ -190,7 +177,6 @@ glz::generic ObserverExportWindow::ToJSON_V_1_0()
     json["match_date"] = settings.match_date;
     json["mat_round"] = settings.mat_round;
 
-    // Use the map from when the match started (if available), otherwise fall back to current map
     ObserverModule::ObservableMap* map = om.match_start_map ? om.match_start_map : om.GetMap();
     
     json["map"] = glz::generic{nullptr};
@@ -288,7 +274,6 @@ glz::generic ObserverExportWindow::ToJSON_V_1_0()
         json["guilds"]["by_id"][guild_id_s]["cape_trim"] = guild->cape_trim;
     }
 
-    // skills
     json["skills"]["ids"] = skill_ids;
     json["skills"]["by_id"] = glz::generic::object_t{};
     for (auto skill_id : skill_ids) {
@@ -339,7 +324,6 @@ glz::generic ObserverExportWindow::ToJSON_V_1_0()
         json["skills"]["by_id"][skill_id_s]["icon_file_id"] = skill->gw_skill.icon_file_id;
     }
 
-    // parties
     json["parties"]["ids"] = party_ids;
     json["parties"]["by_id"] = glz::generic::object_t{};
     for (uint32_t party_id : party_ids) {
@@ -366,7 +350,6 @@ glz::generic ObserverExportWindow::ToJSON_V_1_0()
         json["parties"]["by_id"][party_id_s]["rating"] = party->rating;
         json["parties"]["by_id"][party_id_s]["stats"] = shared_stats_to_json(party->stats);
         
-        // Morale boost events (with timestamps)
         json["parties"]["by_id"][party_id_s]["morale_boosts"] = glz::generic::array_t{};
         for (const auto& morale_boost : party->morale_boosts) {
             glz::generic morale_json;
@@ -374,7 +357,6 @@ glz::generic ObserverExportWindow::ToJSON_V_1_0()
             json["parties"]["by_id"][party_id_s]["morale_boosts"].get_array().push_back(morale_json);
         }
         
-        // Shrine capture events (with timestamps)
         json["parties"]["by_id"][party_id_s]["shrine_captures"] = glz::generic::array_t{};
         for (const auto& shrine_capture : party->shrine_captures) {
             glz::generic shrine_json;
@@ -382,7 +364,6 @@ glz::generic ObserverExportWindow::ToJSON_V_1_0()
             json["parties"]["by_id"][party_id_s]["shrine_captures"].get_array().push_back(shrine_json);
         }
         
-        // Tower capture events (with timestamps)
         json["parties"]["by_id"][party_id_s]["tower_captures"] = glz::generic::array_t{};
         for (const auto& tower_capture : party->tower_captures) {
             glz::generic tower_json;
@@ -402,7 +383,6 @@ glz::generic ObserverExportWindow::ToJSON_V_1_0()
         }
     }
 
-    // agents
     json["agents"]["ids"] = agent_ids;
     json["agents"]["by_id"] = glz::generic::object_t{};
     for (uint32_t agent_id : agent_ids) {
@@ -427,7 +407,6 @@ glz::generic ObserverExportWindow::ToJSON_V_1_0()
 
         // attacks
 
-        // attacks dealt (by agent)
         for (auto& [target_id, action] : agent->stats.attacks_dealt_to_agents) {
             std::string target_id_s = std::to_string(target_id);
             if (!action) {
@@ -437,7 +416,6 @@ glz::generic ObserverExportWindow::ToJSON_V_1_0()
             json["agents"]["by_id"][agent_id_s]["stats"]["attacks_dealt_to_agents"][target_id_s] = action_to_json(*action);
         }
 
-        // attacks received (by agent)
         for (auto& [caster_id, action] : agent->stats.attacks_received_from_agents) {
             std::string caster_id_s = std::to_string(caster_id);
             if (!action) {
@@ -449,7 +427,6 @@ glz::generic ObserverExportWindow::ToJSON_V_1_0()
 
         // skills
 
-        // skills used
         json["agents"]["by_id"][agent_id_s]["stats"]["skill_ids_used"] = agent->stats.skill_ids_used;
         for (auto skill_id : agent->stats.skill_ids_used) {
             std::string skill_id_s = std::to_string(std::to_underlying(skill_id));
@@ -462,7 +439,6 @@ glz::generic ObserverExportWindow::ToJSON_V_1_0()
             json["agents"]["by_id"][agent_id_s]["stats"]["skills_used"][skill_id_s]["skill_id"] = it_skill->second->skill_id;
         }
 
-        // skills received
         json["agents"]["by_id"][agent_id_s]["stats"]["skill_ids_received"] = agent->stats.skill_ids_received;
         for (auto skill_id : agent->stats.skill_ids_received) {
             std::string skill_id_s = std::to_string(std::to_underlying(skill_id));
@@ -475,7 +451,6 @@ glz::generic ObserverExportWindow::ToJSON_V_1_0()
             json["agents"]["by_id"][agent_id_s]["stats"]["skills_received"][skill_id_s]["skill_id"] = it_skill->second->skill_id;
         }
 
-        // skills used (by agent)
         for (auto& [target_id, agent_skill_ids] : agent->stats.skill_ids_used_on_agents) {
             std::string target_id_s = std::to_string(target_id);
             auto it_target = agent->stats.skills_used_on_agents.find(target_id);
@@ -494,7 +469,6 @@ glz::generic ObserverExportWindow::ToJSON_V_1_0()
             }
         }
 
-        // skills received (by agent)
         for (auto& [caster_id, agent_skill_ids] : agent->stats.skill_ids_received_from_agents) {
             std::string caster_id_s = std::to_string(caster_id);
             auto it_target = agent->stats.skills_received_from_agents.find(caster_id);
@@ -513,43 +487,36 @@ glz::generic ObserverExportWindow::ToJSON_V_1_0()
             }
         }
 
-        // damage dealt (by agent)
         for (auto& [target_id, damage] : agent->stats.damage_dealt_to_agents) {
             std::string target_id_s = std::to_string(target_id);
             json["agents"]["by_id"][agent_id_s]["stats"]["damage_dealt_to_agents"][target_id_s] = damage;
         }
 
-        // damage received (by agent)
         for (auto& [caster_id, damage] : agent->stats.damage_received_from_agents) {
             std::string caster_id_s = std::to_string(caster_id);
             json["agents"]["by_id"][agent_id_s]["stats"]["damage_received_from_agents"][caster_id_s] = damage;
         }
 
-        // healing dealt (by agent)
         for (auto& [target_id, healing] : agent->stats.healing_dealt_to_agents) {
             std::string target_id_s = std::to_string(target_id);
             json["agents"]["by_id"][agent_id_s]["stats"]["healing_dealt_to_agents"][target_id_s] = healing;
         }
 
-        // healing received (by agent)
         for (auto& [caster_id, healing] : agent->stats.healing_received_from_agents) {
             std::string caster_id_s = std::to_string(caster_id);
             json["agents"]["by_id"][agent_id_s]["stats"]["healing_received_from_agents"][caster_id_s] = healing;
         }
 
-        // damage by skill
         for (auto& [skill_id, damage] : agent->stats.damage_by_skill) {
             std::string skill_id_s = std::to_string(std::to_underlying(skill_id));
             json["agents"]["by_id"][agent_id_s]["stats"]["damage_by_skill"][skill_id_s] = damage;
         }
 
-        // healing by skill
         for (auto& [skill_id, healing] : agent->stats.healing_by_skill) {
             std::string skill_id_s = std::to_string(std::to_underlying(skill_id));
             json["agents"]["by_id"][agent_id_s]["stats"]["healing_by_skill"][skill_id_s] = healing;
         }
 
-        // damage by skill to agents
         for (auto& [target_id, skill_damage_map] : agent->stats.damage_by_skill_to_agents) {
             std::string target_id_s = std::to_string(target_id);
             for (auto& [skill_id, damage] : skill_damage_map) {
@@ -558,7 +525,6 @@ glz::generic ObserverExportWindow::ToJSON_V_1_0()
             }
         }
 
-        // damage from skill from agents
         for (auto& [caster_id, skill_damage_map] : agent->stats.damage_from_skill_from_agents) {
             std::string caster_id_s = std::to_string(caster_id);
             for (auto& [skill_id, damage] : skill_damage_map) {
@@ -567,7 +533,6 @@ glz::generic ObserverExportWindow::ToJSON_V_1_0()
             }
         }
 
-        // healing by skill to agents
         for (auto& [target_id, skill_healing_map] : agent->stats.healing_by_skill_to_agents) {
             std::string target_id_s = std::to_string(target_id);
             for (auto& [skill_id, healing] : skill_healing_map) {
@@ -576,7 +541,6 @@ glz::generic ObserverExportWindow::ToJSON_V_1_0()
             }
         }
 
-        // healing from skill from agents
         for (auto& [caster_id, skill_healing_map] : agent->stats.healing_from_skill_from_agents) {
             std::string caster_id_s = std::to_string(caster_id);
             for (auto& [skill_id, healing] : skill_healing_map) {
@@ -585,7 +549,6 @@ glz::generic ObserverExportWindow::ToJSON_V_1_0()
             }
         }
 
-        // Death events (all deaths for this agent)
         json["agents"]["by_id"][agent_id_s]["death_events"] = glz::generic::array_t{};
         for (const auto& death : agent->death_events) {
             glz::generic death_json;
@@ -598,14 +561,12 @@ glz::generic ObserverExportWindow::ToJSON_V_1_0()
             json["agents"]["by_id"][agent_id_s]["death_events"].get_array().push_back(death_json);
         }
         
-        // Resurrection events (all resurrections for this agent)
         json["agents"]["by_id"][agent_id_s]["resurrection_events"] = glz::generic::array_t{};
         for (const auto& rez : agent->resurrection_events) {
             glz::generic rez_json;
             rez_json["timestamp_ms"] = rez.timestamp_ms;
             rez_json["resurrector_agent_id"] = rez.resurrector_agent_id;
             
-            // Add resurrection type
             const char* res_type_str = "unknown";
             switch (rez.resurrection_type) {
                 case ObserverModule::ResurrectionType::Skill: res_type_str = "skill"; break;
@@ -630,24 +591,20 @@ std::string ObserverExportWindow::PadLeft(std::string input, const uint8_t count
 }
 
 
-// Export to GWRank.com
 void ObserverExportWindow::ExportToGWRank()
 {
     ObserverModule& observer_module = ObserverModule::Instance();
     
-    // Check if match is finished
     if (!observer_module.match_finished) {
         GW::Chat::WriteChat(GW::Chat::Channel::CHANNEL_GWCA1, L"<c=#FF0000>Match is not finished yet. Cannot export to GWRank.com.</c>");
         return;
     }
     
-    // Check if API key is configured
     if (settings.gwrank_api_key.empty()) {
         GW::Chat::WriteChat(GW::Chat::Channel::CHANNEL_GWCA1, L"<c=#FF0000>API key not configured. Please set it in the Observer Export settings.</c>");
         return;
     }
     
-    // Generate JSON v1.0
     glz::generic json = ToJSON_V_1_0();
     json["verson"] = "1.0";
     std::string json_str = glz::write<glz::opts{.prettify = true}>(json).value_or(std::string{});
@@ -699,7 +656,6 @@ void ObserverExportWindow::ExportToGWRank()
 }
 
 
-// Export as JSON
 void ObserverExportWindow::ExportToJSON(Version version)
 {
     glz::generic json;
@@ -723,7 +679,6 @@ void ObserverExportWindow::ExportToJSON(Version version)
             std::string name = glz::write_json(json["name"]).value_or(std::string{});
             // remove quotation marks (come in from json.dump())
             std::erase(name, '"');
-            // replace spaces with _
             std::ranges::transform(name, name.begin(), [](const unsigned char c) {
                 return static_cast<unsigned char>(c == ' ' ? '_' : c);
             });
@@ -752,7 +707,6 @@ void ObserverExportWindow::ExportToJSON(Version version)
     size_t max_len = _countof(file_location_wc) - 1;
 
     for (wchar_t i : message) {
-        // Break on the end of the message
         if (!i) {
             break;
         }
@@ -772,7 +726,6 @@ void ObserverExportWindow::ExportToJSON(Version version)
 }
 
 
-// Draw the window
 void ObserverExportWindow::Draw(IDirect3DDevice9*)
 {
     if (!visible) {
@@ -787,11 +740,9 @@ void ObserverExportWindow::Draw(IDirect3DDevice9*)
     ImGui::Text("Match Information");
     ImGui::Spacing();
     
-    // Match Type dropdown
     const char* match_types[] = { "AT A", "AT B", "AT C", "MAT", "Ladder", "Scrim" };
     static int current_match_type = -1;
     
-    // Find current selection index based on stored match_type
     if (current_match_type == -1 && !settings.match_type.empty()) {
         for (int i = 0; i < 6; i++) {
             if (settings.match_type == match_types[i]) {
@@ -815,12 +766,10 @@ void ObserverExportWindow::Draw(IDirect3DDevice9*)
         ImGui::EndCombo();
     }
     
-    // MAT Round dropdown (only shown if MAT is selected)
     if (current_match_type == 3) { // MAT is at index 3
         const char* mat_rounds[] = { "Qualification Stage", "Playoff", "Quarterfinals", "Semi-finals", "Finals" };
         static int current_mat_round = -1;
         
-        // Find current selection index based on stored mat_round
         if (current_mat_round == -1 && !settings.mat_round.empty()) {
             for (int i = 0; i < 5; i++) {
                 if (settings.mat_round == mat_rounds[i]) {
@@ -845,7 +794,6 @@ void ObserverExportWindow::Draw(IDirect3DDevice9*)
         }
     }
     
-    // Match Date input
     char date_buf[64];
     strncpy_s(date_buf, settings.match_date.c_str(), 63);
     if (ImGui::InputText("Match Date", date_buf, 64)) {
@@ -897,7 +845,6 @@ void ObserverExportWindow::Draw(IDirect3DDevice9*)
     ImGui::End();
 }
 
-// Load settings
 void ObserverExportWindow::LoadSettings(SettingsDoc& doc, ToolboxIni* legacy)
 {
     ToolboxWindow::LoadSettings(doc, legacy);
@@ -907,7 +854,6 @@ void ObserverExportWindow::LoadSettings(SettingsDoc& doc, ToolboxIni* legacy)
         settings.gwrank_endpoint = "https://gwrank.com/api/v1/matches";
     }
 
-    // Prefill match_date with current date if empty
     if (settings.match_date.empty()) {
         const auto time = TextUtils::Time::GetCurrentSystemTime();
         settings.match_date = std::format("{:04}-{:02}-{:02}", time.year, time.month, time.day);
@@ -920,7 +866,6 @@ void ObserverExportWindow::SaveSettings(SettingsDoc& doc)
     doc.SetStruct(Name(), settings);
 }
 
-// Draw settings
 void ObserverExportWindow::DrawSettingsInternal()
 {
     ImGui::TextUnformatted("GWRank.com API Integration");

--- a/GWToolboxdll/Windows/ObserverPartyWindow.cpp
+++ b/GWToolboxdll/Windows/ObserverPartyWindow.cpp
@@ -30,7 +30,6 @@ void ObserverPartyWindow::SaveSettings(SettingsDoc& doc)
 }
 
 
-// Draw stats headers for the parties
 void ObserverPartyWindow::DrawHeaders(const size_t party_count) const
 {
     float offset = 0;
@@ -41,137 +40,114 @@ void ObserverPartyWindow::DrawHeaders(const size_t party_count) const
     }
 
     for (size_t i = 0; i < party_count; i += 1) {
-        // [profession:short]
         if (settings.show_profession) {
             ImGui::Text(ObserverLabel::Profession);
             ImGui::SameLine(offset += text_short);
         }
 
-        // [name:long]
         ImGui::Text(ObserverLabel::Name);
         ImGui::SameLine(offset += text_long);
 
-        // [guild-tag:short]
         if (settings.show_player_guild_tag) {
             ImGui::Text(ObserverLabel::PlayerGuildTag);
             ImGui::SameLine(offset += text_short);
         }
 
-        // [guild-rating:tiny]
         if (settings.show_player_guild_rating) {
             ImGui::Text(ObserverLabel::PlayerGuildRating);
             ImGui::SameLine(offset += text_tiny);
         }
 
-        // [guild-rank]
         if (settings.show_player_guild_rank) {
             ImGui::Text(ObserverLabel::PlayerGuildRank);
             ImGui::SameLine(offset += text_tiny);
         }
 
-        // [kills:tiny]
         if (settings.show_kills) {
             ImGui::Text(ObserverLabel::Kills);
             ImGui::SameLine(offset += text_tiny);
         }
 
-        // [deaths:tiny]
         if (settings.show_deaths) {
             ImGui::Text(ObserverLabel::Deaths);
             ImGui::SameLine(offset += text_tiny);
         }
 
-        // [kdr:tiny]
         if (settings.show_kdr) {
             ImGui::Text(ObserverLabel::KDR);
             ImGui::SameLine(offset += text_tiny);
         }
 
-        // [cancels:tiny]
         if (settings.show_cancels) {
             ImGui::Text(ObserverLabel::Cancels);
             ImGui::SameLine(offset += text_tiny);
         }
 
-        // [rupts:tiny]
         if (settings.show_interrupts) {
             ImGui::Text(ObserverLabel::Interrupts);
             ImGui::SameLine(offset += text_tiny);
         }
 
-        // [kds:tiny]
         if (settings.show_knockdowns) {
             ImGui::Text(ObserverLabel::Knockdowns);
             ImGui::SameLine(offset += text_tiny);
         }
 
-        // [-atk:tiny]
         if (settings.show_dealt_party_attacks) {
             ImGui::Text(ObserverLabel::AttacksReceivedFromOtherParties);
             ImGui::SameLine(offset += text_tiny);
         }
 
-        // [+atk:tiny]
         if (settings.show_received_party_attacks) {
             ImGui::Text(ObserverLabel::AttacksDealtToOtherParties);
             ImGui::SameLine(offset += text_tiny);
         }
 
-        // [-Crt:tiny]
         if (settings.show_received_party_crits) {
             ImGui::Text(ObserverLabel::CritsReceivedFromOtherParties);
             ImGui::SameLine(offset += text_tiny);
         }
 
-        // [+crit:tiny]
         if (settings.show_dealt_party_crits) {
             ImGui::Text(ObserverLabel::CritsDealToOtherParties);
             ImGui::SameLine(offset += text_tiny);
         }
 
-        // [-skl:tiny]
         if (settings.show_received_party_skills) {
             ImGui::Text(ObserverLabel::SkillsReceivedFromOtherParties);
             ImGui::SameLine(offset += text_tiny);
         }
 
-        // [+skl:tiny]
         if (settings.show_dealt_party_skills) {
             ImGui::Text(ObserverLabel::SkillsUsedOnOtherParties);
             ImGui::SameLine(offset += text_tiny);
         }
 
-        // [+skl:tiny]
         if (settings.show_skills_used) {
             ImGui::Text(ObserverLabel::SkillsUsed);
             ImGui::SameLine(offset += text_tiny);
         }
 
-        // [dmg+:short]
         if (settings.show_damage_dealt) {
             ImGui::Text("Dmg+");
             ImGui::SameLine(offset += text_short);
         }
 
-        // [dmg-:short]
         if (settings.show_damage_received) {
             ImGui::Text("Dmg-");
             ImGui::SameLine(offset += text_short);
         }
 
-        // [heal+:short]
         if (settings.show_healing_dealt) {
             ImGui::Text("Heal+");
             ImGui::SameLine(offset += text_short);
         }
 
-        // [heal-:short]
         if (settings.show_healing_received) {
             ImGui::Text("Heal-");
             ImGui::SameLine(offset += text_short);
         }
 
-        // [max hp:tiny]
         if (settings.show_max_hp) {
             ImGui::Text("MaxHP");
             ImGui::SameLine(offset += text_tiny);
@@ -180,7 +156,6 @@ void ObserverPartyWindow::DrawHeaders(const size_t party_count) const
 }
 
 
-// Draw a blank
 void ObserverPartyWindow::DrawBlankPartyMember(float& offset) const
 {
     uint16_t tinys = 0;
@@ -257,23 +232,19 @@ void ObserverPartyWindow::DrawBlankPartyMember(float& offset) const
 }
 
 
-// Draw a Party Member
 void ObserverPartyWindow::DrawPartyMember(float& offset, ObserverModule::ObservableAgent& agent, const ObserverModule::ObservableGuild* guild,
                                           const bool odd, const bool, const bool) const
 {
     auto& Text = odd ? ImGui::TextDisabled : ImGui::Text;
 
-    // [profession:short]
     if (settings.show_profession) {
         Text(agent.profession.c_str());
         ImGui::SameLine(offset += text_short);
     }
 
-    // [name:long]
     Text(agent.DisplayName().c_str());
     ImGui::SameLine(offset += text_long);
 
-    // [guild-tag:short]
     if (settings.show_player_guild_tag) {
         if (guild) {
             ImGui::Text(guild->wrapped_tag.c_str());
@@ -284,7 +255,6 @@ void ObserverPartyWindow::DrawPartyMember(float& offset, ObserverModule::Observa
         ImGui::SameLine(offset += text_short);
     }
 
-    // [guild-rating:tiny]
     if (settings.show_player_guild_rating) {
         if (guild) {
             ImGui::Text(std::to_string(guild->rating).c_str());
@@ -295,7 +265,6 @@ void ObserverPartyWindow::DrawPartyMember(float& offset, ObserverModule::Observa
         ImGui::SameLine(offset += text_tiny);
     }
 
-    // [guild-rank]
     if (settings.show_player_guild_rank) {
         if (guild) {
             ImGui::Text(std::to_string(guild->rank).c_str());
@@ -306,109 +275,91 @@ void ObserverPartyWindow::DrawPartyMember(float& offset, ObserverModule::Observa
         ImGui::SameLine(offset += text_tiny);
     }
 
-    // [kills:tiny]
     if (settings.show_kills) {
         Text(std::to_string(agent.stats.kills).c_str());
         ImGui::SameLine(offset += text_tiny);
     }
 
-    // [deaths:tiny]
     if (settings.show_deaths) {
         Text(std::to_string(agent.stats.deaths).c_str());
         ImGui::SameLine(offset += text_tiny);
     }
 
-    // [kdr:tiny]
     if (settings.show_kdr) {
         Text(agent.stats.kdr_str.c_str());
         ImGui::SameLine(offset += text_tiny);
     }
 
-    // [cancels:tiny]
     if (settings.show_cancels) {
         Text(std::to_string(agent.stats.cancelled_skills_count).c_str());
         ImGui::SameLine(offset += text_tiny);
     }
 
-    // [rupts:tiny]
     if (settings.show_interrupts) {
         Text(std::to_string(agent.stats.interrupted_skills_count).c_str());
         ImGui::SameLine(offset += text_tiny);
     }
 
-    // [kds:tiny]
     if (settings.show_knockdowns) {
         Text(std::to_string(agent.stats.knocked_down_count).c_str());
         ImGui::SameLine(offset += text_tiny);
     }
 
-    // [-atk:tiny]
     if (settings.show_received_party_attacks) {
         Text(std::to_string(agent.stats.total_attacks_received_from_other_parties.finished).c_str());
         ImGui::SameLine(offset += text_tiny);
     }
 
-    // [+atk:tiny]
     if (settings.show_dealt_party_attacks) {
         Text(std::to_string(agent.stats.total_attacks_dealt_to_other_parties.finished).c_str());
         ImGui::SameLine(offset += text_tiny);
     }
 
-    // [-Crt:tiny]
     if (settings.show_received_party_crits) {
         Text(std::to_string(agent.stats.total_party_crits_received).c_str());
         ImGui::SameLine(offset += text_tiny);
     }
 
-    // [+crit:tiny]
     if (settings.show_dealt_party_crits) {
         Text(std::to_string(agent.stats.total_party_crits_dealt).c_str());
         ImGui::SameLine(offset += text_tiny);
     }
 
-    // [-skl:tiny]
     if (settings.show_received_party_skills) {
         Text(std::to_string(agent.stats.total_skills_received_from_other_parties.finished).c_str());
         ImGui::SameLine(offset += text_tiny);
     }
 
-    // [+skl:tiny]
     if (settings.show_dealt_party_skills) {
         Text(std::to_string(agent.stats.total_skills_used_on_other_parties.finished).c_str());
         ImGui::SameLine(offset += text_tiny);
     }
 
-    // [+skl:tiny]
     if (settings.show_skills_used) {
         Text(std::to_string(agent.stats.total_skills_used.finished).c_str());
         ImGui::SameLine(offset += text_tiny);
     }
 
-    // [dmg+:short]
     if (settings.show_damage_dealt) {
         Text(std::to_string(agent.stats.total_damage_dealt).c_str());
         ImGui::SameLine(offset += text_short);
     }
 
-    // [dmg-:short]
     if (settings.show_damage_received) {
         Text(std::to_string(agent.stats.total_damage_received).c_str());
         ImGui::SameLine(offset += text_short);
     }
 
-    // [heal+:short]
     if (settings.show_healing_dealt) {
         Text(std::to_string(agent.stats.total_healing_dealt).c_str());
         ImGui::SameLine(offset += text_short);
     }
 
-    // [heal-:short]
     if (settings.show_healing_received) {
         Text(std::to_string(agent.stats.total_healing_received).c_str());
         ImGui::SameLine(offset += text_short);
     }
 
-    // [max hp:tiny]
     if (settings.show_max_hp) {
         uint32_t max_hp = ObserverModule::Instance().GetCachedMaxHP(agent.agent_id);
         if (max_hp > 0) {
@@ -421,141 +372,117 @@ void ObserverPartyWindow::DrawPartyMember(float& offset, ObserverModule::Observa
 }
 
 
-// Draw a Party row
 void ObserverPartyWindow::DrawParty(float& offset, const ObserverModule::ObservableParty& party) const
 {
-    // [name:long]
     ImGui::Text(party.display_name.c_str());
     ImGui::SameLine(offset += text_long);
 
-    // [profession:tiny]
     if (settings.show_profession) {
         ImGui::Text("");
         ImGui::SameLine(offset += text_short);
     }
 
-    // [guild-tag:short]
     if (settings.show_player_guild_tag) {
         // tag is in display_name
         // this makes it not hideable
         ImGui::SameLine(offset += text_short);
     }
 
-    // [guild-rating:tiny]
     if (settings.show_player_guild_rating) {
         ImGui::Text(std::to_string(party.rating).c_str());
         ImGui::SameLine(offset += text_tiny);
     }
 
-    // [guild-rank]
     if (settings.show_player_guild_rank) {
         ImGui::Text(std::to_string(party.rank).c_str());
         ImGui::SameLine(offset += text_tiny);
     }
 
-    // [kills:tiny]
     if (settings.show_kills) {
         ImGui::Text(std::to_string(party.stats.kills).c_str());
         ImGui::SameLine(offset += text_tiny);
     }
 
-    // [deaths:tiny]
     if (settings.show_deaths) {
         ImGui::Text(std::to_string(party.stats.deaths).c_str());
         ImGui::SameLine(offset += text_tiny);
     }
 
-    // [kdr:tiny]
     if (settings.show_kdr) {
         ImGui::Text(party.stats.kdr_str.c_str());
         ImGui::SameLine(offset += text_tiny);
     }
 
-    // [cancels:tiny]
     if (settings.show_cancels) {
         ImGui::Text(std::to_string(party.stats.cancelled_skills_count).c_str());
         ImGui::SameLine(offset += text_tiny);
     }
 
-    // [rupts:tiny]
     if (settings.show_interrupts) {
         ImGui::Text(std::to_string(party.stats.interrupted_skills_count).c_str());
         ImGui::SameLine(offset += text_tiny);
     }
 
-    // [kds:tiny]
     if (settings.show_knockdowns) {
         ImGui::Text(std::to_string(party.stats.knocked_down_count).c_str());
         ImGui::SameLine(offset += text_tiny);
     }
 
-    // [-atk:tiny]
     if (settings.show_received_party_attacks) {
         ImGui::Text(std::to_string(party.stats.total_attacks_received_from_other_parties.finished).c_str());
         ImGui::SameLine(offset += text_tiny);
     }
 
-    // [+atk:tiny]
     if (settings.show_dealt_party_attacks) {
         ImGui::Text(std::to_string(party.stats.total_attacks_dealt_to_other_parties.finished).c_str());
         ImGui::SameLine(offset += text_tiny);
     }
 
-    // [-Crt:tiny]
     if (settings.show_received_party_crits) {
         ImGui::Text(std::to_string(party.stats.total_party_crits_received).c_str());
         ImGui::SameLine(offset += text_tiny);
     }
 
-    // [+crit:tiny]
     if (settings.show_received_party_crits) {
         ImGui::Text(std::to_string(party.stats.total_party_crits_dealt).c_str());
         ImGui::SameLine(offset += text_tiny);
     }
 
-    // [-skl:tiny]
     if (settings.show_received_party_skills) {
         ImGui::Text(std::to_string(party.stats.total_skills_received_from_other_parties.finished).c_str());
         ImGui::SameLine(offset += text_tiny);
     }
 
-    // [+skl:tiny]
     if (settings.show_dealt_party_skills) {
         ImGui::Text(std::to_string(party.stats.total_skills_used_on_other_parties.finished).c_str());
         ImGui::SameLine(offset += text_tiny);
     }
 
-    // [+skl:tiny]
     if (settings.show_skills_used) {
         ImGui::Text(std::to_string(party.stats.total_skills_used.finished).c_str());
         ImGui::SameLine(offset += text_tiny);
     }
 
-    // [dmg+:short]
     if (settings.show_damage_dealt) {
         ImGui::Text(std::to_string(party.stats.total_damage_dealt).c_str());
         ImGui::SameLine(offset += text_short);
     }
 
-    // [dmg-:short]
     if (settings.show_damage_received) {
         ImGui::Text(std::to_string(party.stats.total_damage_received).c_str());
         ImGui::SameLine(offset += text_short);
     }
 
-    // [heal+:short]
     if (settings.show_healing_dealt) {
         ImGui::Text(std::to_string(party.stats.total_healing_dealt).c_str());
         ImGui::SameLine(offset += text_short);
     }
 
-    // [heal-:short]
     if (settings.show_healing_received) {
         ImGui::Text(std::to_string(party.stats.total_healing_received).c_str());
         ImGui::SameLine(offset += text_short);
     }
 
-    // [max hp:tiny]
     if (settings.show_max_hp) {
         ImGui::Text("");
         ImGui::SameLine(offset += text_tiny);
@@ -563,7 +490,6 @@ void ObserverPartyWindow::DrawParty(float& offset, const ObserverModule::Observa
 }
 
 
-// Draw everything
 void ObserverPartyWindow::Draw(IDirect3DDevice9*)
 {
     if (!visible) {
@@ -611,7 +537,6 @@ void ObserverPartyWindow::Draw(IDirect3DDevice9*)
     // ImGui::Text(""); // new line
     // ImGui::Separator();
 
-    // iterate through each party member
     for (auto party_member_index = -1; party_member_index < static_cast<int>(max_party_size); party_member_index += 1) {
         // `party_member_offset == -1` is the party info
         // `party_member_offset == 0` is player 1
@@ -629,12 +554,9 @@ void ObserverPartyWindow::Draw(IDirect3DDevice9*)
         }
         // else if (party_member_index > 0) ImGui::Separator();
 
-        // line offset
         float offset = 0;
 
-        // iterate through each party
         for (auto party_index = 0u; party_index < party_count; party_index += 1) {
-            // party member #
             if (settings.show_player_number && party_index == 0) {
                 // print #1. <player> for players, not the party
                 if (party_member_index != -1) {
@@ -651,28 +573,23 @@ void ObserverPartyWindow::Draw(IDirect3DDevice9*)
                 return;
             }
 
-            // draw party total
             if (party_member_index == -1) {
                 DrawParty(offset, *party);
                 continue;
             }
 
             if (party_member_index >= static_cast<int>(party->agent_ids.size())) {
-                // overflowed party size
-                // fill blank...
                 DrawBlankPartyMember(offset);
                 continue;
             }
 
             const uint32_t party_member_id = party->agent_ids[party_member_index];
 
-            // no party_member
             if (party_member_id == NO_AGENT) {
                 DrawBlankPartyMember(offset);
                 continue;
             }
 
-            // party_member not found
             ObserverModule::ObservableAgent* party_member =
                 observer_module.GetObservableAgentById(party_member_id);
             if (!party_member) {
@@ -680,7 +597,6 @@ void ObserverPartyWindow::Draw(IDirect3DDevice9*)
                 continue;
             }
 
-            // party member found!
             const ObserverModule::ObservableGuild* guild = observer_module.GetObservableGuildById(party_member->guild_id);
             DrawPartyMember(offset, *party_member, guild, party_member_index % 2, false, false);
         }
@@ -690,7 +606,6 @@ void ObserverPartyWindow::Draw(IDirect3DDevice9*)
 }
 
 
-// Draw settings
 void ObserverPartyWindow::DrawSettingsInternal()
 {
     ImGui::Text("Make sure the Observer Module is enabled.");

--- a/GWToolboxdll/Windows/ObserverPlayerWindow.cpp
+++ b/GWToolboxdll/Windows/ObserverPlayerWindow.cpp
@@ -32,7 +32,6 @@ void ObserverPlayerWindow::SaveSettings(SettingsDoc& doc)
 }
 
 
-// Get the agent we're currently tracking
 uint32_t ObserverPlayerWindow::GetTracking()
 {
     if (!ObserverModule::Instance().IsActive()) {
@@ -55,7 +54,6 @@ uint32_t ObserverPlayerWindow::GetTracking()
     return living->agent_id;
 }
 
-// Get the agent we're comparing to
 uint32_t ObserverPlayerWindow::GetComparison()
 {
     if (!ObserverModule::Instance().IsActive()) {
@@ -78,43 +76,36 @@ uint32_t ObserverPlayerWindow::GetComparison()
     return living->agent_id;
 }
 
-// Draw the headers for player skills
 void ObserverPlayerWindow::DrawHeaders() const
 {
     float offset = 0;
     ImGui::Text("Name");
     float offset_d = text_long;
-    // attempted
     if (settings.show_attempts) {
         ImGui::SameLine(offset += offset_d);
         ImGui::Text(ObserverLabel::Attempts);
         offset_d = text_tiny;
     }
-    // cancelled
     if (settings.show_cancels) {
         ImGui::SameLine(offset += offset_d);
         ImGui::Text(ObserverLabel::Cancels);
         offset_d = text_tiny;
     }
-    // interrupted
     if (settings.show_interrupts) {
         ImGui::SameLine(offset += offset_d);
         ImGui::Text(ObserverLabel::Interrupts);
         offset_d = text_tiny;
     }
-    // finished
     if (settings.show_finishes) {
         ImGui::SameLine(offset += offset_d);
         ImGui::Text(ObserverLabel::Finishes);
         offset_d = text_tiny;
     }
-    // integrity
     if (settings.show_integrity) {
         ImGui::SameLine(offset += offset_d);
         ImGui::Text(ObserverLabel::Integrity);
         offset_d = text_tiny;
     }
-    // damage
     if (settings.show_damage) {
         ImGui::SameLine(offset += offset_d);
         ImGui::Text("Damage");
@@ -126,44 +117,37 @@ void ObserverPlayerWindow::DrawAction(const std::string& name, const ObserverMod
     float offset = 0;
     ImGui::Text(name.c_str());
     float offset_d = text_long;
-    // attempted
     if (settings.show_attempts) {
         ImGui::SameLine(offset += offset_d);
         ImGui::Text(std::to_string(action->started).c_str());
         offset_d = text_tiny;
     }
-    // cancelled
     if (settings.show_cancels) {
         ImGui::SameLine(offset += offset_d);
         ImGui::Text(std::to_string(action->stopped).c_str());
         offset_d = text_tiny;
     }
-    // interrupted
     if (settings.show_interrupts) {
         ImGui::SameLine(offset += offset_d);
         ImGui::Text(std::to_string(action->interrupted).c_str());
         offset_d = text_tiny;
     }
-    // finished
     if (settings.show_finishes) {
         ImGui::SameLine(offset += offset_d);
         ImGui::Text(std::to_string(action->finished).c_str());
         offset_d = text_tiny;
     }
-    // integrity
     if (settings.show_integrity) {
         ImGui::SameLine(offset += offset_d);
         ImGui::Text(std::to_string(action->integrity).c_str());
         offset_d = text_tiny;
     }
-    // damage
     if (settings.show_damage) {
         ImGui::SameLine(offset += offset_d);
         ImGui::Text(std::to_string(action->total_damage).c_str());
     }
 }
 
-// Draw the skills of a player
 void ObserverPlayerWindow::DrawSkills(const std::unordered_map<GW::Constants::SkillID, ObserverModule::ObservedSkill*>& skills,
                                       const std::vector<GW::Constants::SkillID>& skill_ids) const
 {
@@ -183,7 +167,6 @@ void ObserverPlayerWindow::DrawSkills(const std::unordered_map<GW::Constants::Sk
 }
 
 
-// Draw the window
 void ObserverPlayerWindow::Draw(IDirect3DDevice9*)
 {
     if (!visible) {
@@ -207,12 +190,10 @@ void ObserverPlayerWindow::Draw(IDirect3DDevice9*)
     if (tracking) {
         ImGui::Text(tracking->DisplayName().c_str());
 
-        // Display health and energy information if available
         const GW::Agent* agent = GW::Agents::GetAgentByID(tracking_agent_id);
         if (agent) {
             const GW::AgentLiving* living = agent->GetAsAgentLiving();
             if (living) {
-                // Get max HP (from cache or direct if observed)
                 uint32_t max_hp = om.GetCachedMaxHP(tracking_agent_id);
                 
                 // Calculate current HP from percentage
@@ -236,7 +217,6 @@ void ObserverPlayerWindow::Draw(IDirect3DDevice9*)
         text_short = 80.0f * global;
         text_tiny = 40.0f * global;
 
-        // Display total damage dealt and received
         if (settings.show_damage_details) {
             ImGui::Separator();
             ImGui::Text("Damage & Healing Summary:");
@@ -245,20 +225,16 @@ void ObserverPlayerWindow::Draw(IDirect3DDevice9*)
             ImGui::Text(("Total Healing Dealt: "s + std::to_string(tracking->stats.total_healing_dealt)).c_str());
             ImGui::Text(("Total Healing Received: "s + std::to_string(tracking->stats.total_healing_received)).c_str());
             
-            // Create separate tables for allies and opponents
             if (!tracking->stats.damage_dealt_to_agents.empty() || 
                 !tracking->stats.damage_received_from_agents.empty() ||
                 !tracking->stats.healing_dealt_to_agents.empty() ||
                 !tracking->stats.healing_received_from_agents.empty()) {
                 
-                // Collect and separate agents into allies and opponents
                 std::set<uint32_t> ally_agent_ids;
                 std::set<uint32_t> opponent_agent_ids;
                 
-                // Get tracking agent's party
                 uint32_t tracking_party_id = tracking->party_id;
                 
-                // Collect all unique agent IDs and categorize them
                 std::set<uint32_t> all_agent_ids;
                 for (const auto& [agent_id, _] : tracking->stats.damage_dealt_to_agents) {
                     all_agent_ids.insert(agent_id);
@@ -273,7 +249,6 @@ void ObserverPlayerWindow::Draw(IDirect3DDevice9*)
                     all_agent_ids.insert(agent_id);
                 }
                 
-                // Categorize agents
                 for (const auto& agent_id : all_agent_ids) {
                     ObserverModule::ObservableAgent* categorized_agent = om.GetObservableAgentById(agent_id);
                     if (!categorized_agent) continue;
@@ -285,7 +260,6 @@ void ObserverPlayerWindow::Draw(IDirect3DDevice9*)
                     }
                 }
                 
-                // Draw Allies table (healing only)
                 if (!ally_agent_ids.empty()) {
                     ImGui::Text("");
                     ImGui::Text("Allies:");
@@ -306,7 +280,6 @@ void ObserverPlayerWindow::Draw(IDirect3DDevice9*)
                         ImGui::Text(ally_agent->DisplayName().c_str());
                         ImGui::SameLine(offset += text_long);
                         
-                        // Healing dealt
                         const auto it_heal_dealt = tracking->stats.healing_dealt_to_agents.find(agent_id);
                         if (it_heal_dealt != tracking->stats.healing_dealt_to_agents.end()) {
                             ImGui::Text(std::to_string(it_heal_dealt->second).c_str());
@@ -315,7 +288,6 @@ void ObserverPlayerWindow::Draw(IDirect3DDevice9*)
                         }
                         ImGui::SameLine(offset += text_short);
                         
-                        // Healing received
                         const auto it_heal_recv = tracking->stats.healing_received_from_agents.find(agent_id);
                         if (it_heal_recv != tracking->stats.healing_received_from_agents.end()) {
                             ImGui::Text(std::to_string(it_heal_recv->second).c_str());
@@ -325,7 +297,6 @@ void ObserverPlayerWindow::Draw(IDirect3DDevice9*)
                     }
                 }
                 
-                // Draw Opponents table (damage only)
                 if (!opponent_agent_ids.empty()) {
                     ImGui::Text("");
                     ImGui::Text("Opponents:");
@@ -346,7 +317,6 @@ void ObserverPlayerWindow::Draw(IDirect3DDevice9*)
                         ImGui::Text(opponent_agent->DisplayName().c_str());
                         ImGui::SameLine(offset += text_long);
                         
-                        // Damage dealt
                         const auto it_dmg_dealt = tracking->stats.damage_dealt_to_agents.find(agent_id);
                         if (it_dmg_dealt != tracking->stats.damage_dealt_to_agents.end()) {
                             ImGui::Text(std::to_string(it_dmg_dealt->second).c_str());
@@ -355,7 +325,6 @@ void ObserverPlayerWindow::Draw(IDirect3DDevice9*)
                         }
                         ImGui::SameLine(offset += text_short);
                         
-                        // Damage received
                         const auto it_dmg_recv = tracking->stats.damage_received_from_agents.find(agent_id);
                         if (it_dmg_recv != tracking->stats.damage_received_from_agents.end()) {
                             ImGui::Text(std::to_string(it_dmg_recv->second).c_str());
@@ -368,7 +337,6 @@ void ObserverPlayerWindow::Draw(IDirect3DDevice9*)
         }
 
         if (settings.show_tracking) {
-            // skills
             ImGui::Separator();
             ImGui::Text("Skills:");
             DrawHeaders();
@@ -377,7 +345,6 @@ void ObserverPlayerWindow::Draw(IDirect3DDevice9*)
         }
 
         if (settings.show_comparison && compared && !(!settings.show_skills_used_on_self && tracking && compared->agent_id == tracking->agent_id)) {
-            // skills
             ImGui::Text(""); // new line
             ImGui::Text(("Skills used on: "s + compared->DisplayName()).c_str());
             DrawHeaders();
@@ -389,7 +356,6 @@ void ObserverPlayerWindow::Draw(IDirect3DDevice9*)
                 DrawSkills(it_used_on_agent_skills->second, it_used_on_agent_skill_ids->second);
             }
 
-            // Display damage and healing for this specific player
             if (settings.show_damage_details) {
                 ImGui::Text("");
                 ImGui::Text(("Stats with "s + compared->DisplayName()).c_str());
@@ -404,7 +370,6 @@ void ObserverPlayerWindow::Draw(IDirect3DDevice9*)
     ImGui::End();
 }
 
-// Draw settings
 void ObserverPlayerWindow::DrawSettingsInternal()
 {
     ImGui::Text("Make sure the Observer Module is enabled.");

--- a/GWToolboxdll/Windows/ObserverTargetWindow.cpp
+++ b/GWToolboxdll/Windows/ObserverTargetWindow.cpp
@@ -12,7 +12,6 @@ void ObserverTargetWindow::Prepare()
         return;
     }
 
-    // prepare the current tracking and compared agents
     // keep tracking up-to-date with the current desired target
     const GW::Agent* tracking_agent = GW::Agents::GetTarget();
     const GW::AgentLiving* tracking_living = nullptr;
@@ -40,13 +39,11 @@ void ObserverTargetWindow::Prepare()
     previously_tracked_agent_id = next_tracked_id;
 }
 
-// Get the agent we're currently tracking
 uint32_t ObserverTargetWindow::GetTracking()
 {
     return previously_tracked_agent_id;
 }
 
-// Get the agent we're comparing to
 uint32_t ObserverTargetWindow::GetComparison()
 {
     return previously_compared_agent_id;

--- a/GWToolboxdll/Windows/PacketLoggerWindow.cpp
+++ b/GWToolboxdll/Windows/PacketLoggerWindow.cpp
@@ -692,7 +692,6 @@ void PacketLoggerWindow::SaveMessageLog() const
     const auto filename = Resources::GetPath(L"message_log.csv");
     std::wofstream my_file(filename);
 
-    // Send column names to the stream
     for (const auto& it : message_log) {
         if (!it.second || !it.second->length()) {
             continue;
@@ -702,7 +701,6 @@ void PacketLoggerWindow::SaveMessageLog() const
         my_file << it.second->c_str();
         my_file << "\n";
     }
-    // Close the file
     my_file.close();
 }
 

--- a/GWToolboxdll/Windows/PartySearchWindow.cpp
+++ b/GWToolboxdll/Windows/PartySearchWindow.cpp
@@ -275,7 +275,6 @@ void PartySearchWindow::Initialize()
             }
         }
     });
-    // local messages
     GW::StoC::RegisterPostPacketCallback(&OnMessageLocal_Entry, GAME_SMSG_PARTY_SEARCH_REMOVE, OnRegionPartyUpdated);
     GW::StoC::RegisterPostPacketCallback(&OnMessageLocal_Entry, GAME_SMSG_PARTY_SEARCH_SIZE, OnRegionPartyUpdated);
     GW::StoC::RegisterPostPacketCallback(&OnMessageLocal_Entry, GAME_SMSG_PARTY_SEARCH_ADVERTISEMENT, OnRegionPartyUpdated);
@@ -546,14 +545,12 @@ void PartySearchWindow::fetch()
     }
 
     ws_window->dispatch([this](const std::string& data) {
-        // Add to message feed
         Message msg;
         if (!parse_json_message(data, &msg)) {
             return; // Not valid message object
         }
         messages.add(msg);
 
-        // Check alerts
         // do not display trade chat while in kamadan AE district 1
         const bool print_message = settings.print_game_chat && IsLfpAlert(msg.message);
 
@@ -698,7 +695,6 @@ void PartySearchWindow::Draw(IDirect3DDevice9*)
 
             if (ImGui::Button(label, ImVec2(playernamewidth, 0))) {
                 std::wstring leader_name = TextUtils::StringToWString(party->player_name);
-                // open whisper to player
                 GW::GameThread::Enqueue([leader_name] {
                     SendUIMessage(GW::UI::UIMessage::kOpenWhisper, (wchar_t*)leader_name.data(), nullptr);
                 });

--- a/GWToolboxdll/Windows/PartyStatisticsWindow.cpp
+++ b/GWToolboxdll/Windows/PartyStatisticsWindow.cpp
@@ -374,7 +374,6 @@ namespace {
         }
         ASSERT(player_party_member);
 
-        // Add player skills
         for (const GW::SkillbarSkill& skill : my_skillbar->skills) {
             set_member_skill(player_party_member, skill.skill_id);
         }
@@ -407,14 +406,11 @@ namespace {
             return;
         }
 
-        /* all skills for self player */
         if (static_cast<size_t>(-1) == player_idx) {
             WritePlayerStatisticsAllSkills(player_party_member);
-            /* single skill for some player */
         }
         else if (std::numeric_limits<uint32_t>::max() != skill_idx) {
             WritePlayerStatisticsSingleSkill(GetPartyMemberByPartyIdx(player_idx), skill_idx);
-            /* all skills for some player */
         }
         else {
             WritePlayerStatisticsAllSkills(GetPartyMemberByPartyIdx(player_idx));

--- a/GWToolboxdll/Windows/Pathfinding/MathUtility.cpp
+++ b/GWToolboxdll/Windows/Pathfinding/MathUtility.cpp
@@ -58,8 +58,6 @@ namespace MathUtil {
         return false;
     }
 
-    // The main function that returns true if line segment 'p1q1'
-    // and 'p2q2' intersect.
     bool Intersect(const GW::Vec2f& p1, const GW::Vec2f& q1, const GW::Vec2f& p2, const GW::Vec2f& q2) {
         constexpr float eps = 0.001f;
         float denom = (q2.y - p2.y) * (q1.x - p1.x) - (q2.x - p2.x) * (q1.y - p1.y);

--- a/GWToolboxdll/Windows/Pathfinding/MathUtility.h
+++ b/GWToolboxdll/Windows/Pathfinding/MathUtility.h
@@ -18,8 +18,6 @@ namespace MathUtil {
     // point q lies on line segment 'pr'
     bool onSegment(const GW::Vec2f &p, const GW::Vec2f &q, const GW::Vec2f &r);
 
-    // The main function that returns true if line segment 'p1q1'
-    // and 'p2q2' intersect.
     bool Intersect(const GW::Vec2f &p1, const GW::Vec2f &q1, const GW::Vec2f &p2, const GW::Vec2f &q2);
 
     bool between(float x, float min, float max);

--- a/GWToolboxdll/Windows/Pathfinding/PathfindingWindow.cpp
+++ b/GWToolboxdll/Windows/Pathfinding/PathfindingWindow.cpp
@@ -642,7 +642,6 @@ namespace {
         DeferRemoveLines(hover_highlight_lines);
     }
 
-    // Check if a portal position on a map has any connection
     bool IsPortalConnected(GW::Constants::MapID map_id, const GW::Vec2f& pos, float threshold_sq = 500.f * 500.f)
     {
         for (const auto& c : portal_connections.GetAll()) {
@@ -678,7 +677,6 @@ namespace {
         };
 
         for (const auto& [hash, info] : cached_map_info) {
-            // Filter by continent
             const auto area = GW::Map::GetMapInfo(info.map_id);
             if (area && area->continent != cur_continent) continue;
 
@@ -723,7 +721,6 @@ namespace {
             GW::GamePos br = {info.bounds_max.x, info.bounds_max.y, 0};
             GW::GamePos bl = {info.bounds_min.x, info.bounds_max.y, 0};
 
-            // Convert to current map coords for display
             tl = ToCurrentMapCoords(tl, info.map_id);
             tr = ToCurrentMapCoords(tr, info.map_id);
             br = ToCurrentMapCoords(br, info.map_id);
@@ -834,7 +831,6 @@ namespace {
         }
     }
 
-    // Convert path points from source map coords to current map coords via world map
     bool IsOutpostMap(GW::Constants::MapID map_id); // forward decl
 
     // "Don't draw a line here" sentinel in flat full_path arrays; inserted between segments around underground (no_draw) maps.
@@ -956,7 +952,6 @@ namespace {
         return from != astar->m_path.points().at(0) || to != astar->m_path.points().at(astar->m_path.points().size() - 1);
     }
 
-    // Find a cached MilePath for a given MapID
     Pathing::MilePath* GetMilepathForMap(GW::Constants::MapID map_id)
     {
         // Look up by file_hash so shared-hash maps (e.g. 107/135 with hash 0xC77A)
@@ -1107,11 +1102,9 @@ namespace {
             if (fwd_match || rev_match) {
                 PATH_LOG_INFO("[GetAdj]   conn from=%d to=%d ftype=%d ttype=%d oneway=%d fwd=%d rev=%d", (int)conn.from_map, (int)conn.to_map, (int)conn.from_type, (int)conn.to_type, conn.IsOneWay() ? 1 : 0, fwd_match ? 1 : 0, rev_match ? 1 : 0);
             }
-            // Forward: conn.from matches current → conn.to is neighbor
             if (fwd_match && conn.to_map != map_id && !contains(conn.to_map)) {
                 result.push_back(conn.to_map);
             }
-            // Reverse: only for bidirectional connections
             if (rev_match && conn.from_map != map_id && !contains(conn.from_map)) {
                 result.push_back(conn.from_map);
             }
@@ -1222,7 +1215,6 @@ namespace {
         auto it = portal_props_cache.find(fh);
         if (it != portal_props_cache.end()) return it->second;
 
-        // Check if already in cached_map_info (from full DAT load)
         for (const auto& [hash, info] : cached_map_info) {
             if (info.map_id == map_id && !info.portal_props.empty()) {
                 portal_props_cache[fh] = info.portal_props;
@@ -1261,7 +1253,6 @@ namespace {
         ArenaNetFileParser::ArenaNetFile game_asset;
         if (!game_asset.readFromDat(fid, 1)) return;
 
-        // Get bounds from Map_Info chunk
 #pragma pack(push, 1)
         struct MapInfoChunk : ArenaNetFileParser::Chunk {
             uint32_t signature;
@@ -1272,7 +1263,6 @@ namespace {
         const auto map_info_chunk = (MapInfoChunk*)game_asset.FindChunk(ArenaNetFileParser::ChunkType::Map_Info);
         if (!map_info_chunk) return;
 
-        // Parse portal props
         std::vector<Pathing::PortalProp> props;
         Pathing::LoadPortalPropsFromDAT(fid, props);
 
@@ -1722,9 +1712,7 @@ namespace {
         for (const auto& pa : info_a->portal_props) {
             GW::Vec2f wm_pa;
             if (!WorldMapWidget::GamePosToWorldMap({pa.pos.x, pa.pos.y, 0}, wm_pa, map_a)) continue;
-            // Only consider portals near the overlap region
             if (!overlap.Contains({wm_pa.x, wm_pa.y})) continue;
-            // Outpost filter: portal must be near the outpost icon if map_a is an outpost
             if (IsPortalTooFarFromOutpost(map_a, wm_pa)) continue;
 
             for (const auto& pb : info_b->portal_props) {
@@ -1789,7 +1777,6 @@ namespace {
             }
         }
 
-        // Score and pick the best candidate
         if (!candidates.empty()) {
             if (start_game || goal_game) {
                 // Score by actual AStar cost; penalize failures heavily (an unreachable portal must not beat a reachable one).
@@ -1976,7 +1963,6 @@ namespace {
                 auto map_id = route_copy[seg];
                 GW::GamePos seg_from, seg_to;
 
-                // Determine segment start
                 if (seg == 0) {
                     seg_from = start_copy;
                 }
@@ -1990,11 +1976,9 @@ namespace {
                     }
                     seg_from = this_entry;
                     portal_draws.push_back({prev_exit, this_entry, route_copy[seg - 1], map_id});
-                    // Update last_portal_wm to the entry portal's world map position
                     WorldMapWidget::GamePosToWorldMap(this_entry, last_portal_wm, map_id);
                 }
 
-                // Determine segment end
                 if (seg == route_copy.size() - 1) {
                     seg_to = goal_copy;
                 }
@@ -2008,7 +1992,6 @@ namespace {
                         return;
                     }
                     seg_to = this_exit;
-                    // Update chain hint to exit portal position
                     WorldMapWidget::GamePosToWorldMap(this_exit, last_portal_wm, map_id);
                 }
 
@@ -2042,7 +2025,6 @@ namespace {
                     full_path.push_back({PATH_BREAK_VALUE, PATH_BREAK_VALUE, 0});
                 }
 
-                // Convert segment to current map coords and append
                 auto converted = ConvertPathToCurrentMap(seg_path, map_id);
                 full_path.insert(full_path.end(), converted.begin(), converted.end());
             }
@@ -2328,7 +2310,6 @@ namespace {
         ClearPathLines();
         delete astar;
         astar = nullptr;
-        // Use path_from_map if both are on the same map, otherwise current map
         auto target_map = GW::Map::GetMapID();
         if (path_from_map != GW::Constants::MapID::None && path_from_map == path_to_map) target_map = path_from_map;
         const auto map_id = target_map;
@@ -2347,7 +2328,6 @@ namespace {
                 PATH_LOG_ERROR("No milepath for map %d", (int)map_id);
                 return;
             }
-            // Wait for vis graph to finish building
             if (!milepath->ready()) {
                 PATH_LOG_INFO("Waiting for map %d vis graph...", (int)map_id);
                 while (!milepath->ready() && !pending_terminate) {
@@ -2373,7 +2353,6 @@ namespace {
                 return;
             }
             astar = tmpAstar;
-            // Draw path on main thread
             const auto points = astar->m_path.points(); // copy
             Resources::EnqueueMainTask([points, map_id] {
                 DrawPathAsLines(points, map_id);

--- a/GWToolboxdll/Windows/Pathfinding/PathfindingWindow.h
+++ b/GWToolboxdll/Windows/Pathfinding/PathfindingWindow.h
@@ -66,7 +66,6 @@ public:
     // True while one or more cross-map/world-map route computations are running on a worker thread. Lock-free;
     // safe to poll every frame (the world map shows a "calculating" indicator while true).
     static bool IsCalculatingPath();
-    // False if still calculating current map
     static clock_t CalculatePath(const GW::GamePos& from, const GW::GamePos& to, CalculatedCallback callback, void* args = nullptr);
 
     static void SetFrom(const GW::GamePos& pos);

--- a/GWToolboxdll/Windows/Pathfinding/PathingMapDataLoader.cpp
+++ b/GWToolboxdll/Windows/Pathfinding/PathingMapDataLoader.cpp
@@ -2,7 +2,6 @@
 
 #include "PathingMapDataLoader.h"
 
-// Include actual GW headers
 #include <GWCA/Context/MapContext.h>
 #include <GWCA/GameContainers/Array.h>
 #include <GWCA/GameEntities/Pathing.h>
@@ -147,11 +146,9 @@ namespace Pathing {
             AllocatePlaneBuffer(dst, src.trapezoid_count, src.portal_count, src.portal_trapezoids_count,
                                src.x_node_count, src.y_node_count, src.sink_node_count);
 
-            // Copy trapezoids
             if (src.trapezoids && src.trapezoid_count > 0) {
                 memcpy(dst.trapezoids, src.trapezoids, sizeof(GW::PathingTrapezoid) * src.trapezoid_count);
 
-                // Clear adjacent pointers and build id map
                 for (uint32_t i = 0; i < src.trapezoid_count; ++i) {
                     dst.trapezoids[i].adjacent[0] = nullptr;
                     dst.trapezoids[i].adjacent[1] = nullptr;
@@ -162,11 +159,9 @@ namespace Pathing {
                 }
             }
 
-            // Copy portals
             if (src.portals && src.portal_count > 0) {
                 memcpy(dst.portals, src.portals, sizeof(GW::Portal) * src.portal_count);
 
-                // Clear pair and trapezoids pointers, build old->new map
                 for (uint32_t i = 0; i < src.portal_count; ++i) {
                     dst.portals[i].pair = nullptr;
                     dst.portals[i].trapezoids = nullptr;
@@ -186,7 +181,6 @@ namespace Pathing {
                 memcpy(dst.sink_nodes, src.sink_nodes, sizeof(GW::SinkNode) * src.sink_node_count);
             }
 
-            // Build old->new node pointer map for this plane
             for (uint32_t i = 0; i < src.x_node_count; ++i) {
                 oldNodeToNew[reinterpret_cast<GW::Node*>(&src.x_nodes[i])] = reinterpret_cast<GW::Node*>(&dst.x_nodes[i]);
             }
@@ -224,7 +218,6 @@ namespace Pathing {
                 uint32_t pt_offset = 0;
 
                 for (uint32_t i = 0; i < src.portal_count; ++i) {
-                    // Fix pair pointer
                     if (src.portals[i].pair) {
                         auto it = oldToNew.find(src.portals[i].pair);
                         if (it != oldToNew.end()) {
@@ -281,7 +274,6 @@ namespace Pathing {
                 }
             }
 
-            // Remap root_node
             dst.root_node = remap_node(src.root_node);
         }
 
@@ -316,7 +308,6 @@ namespace Pathing {
         AllocatePlaneBuffer(dst, trap_count, portal_count, portal_trap_count,
                            x_count, y_count, sink_count);
 
-        // Fill trapezoids
         for (uint32_t i = 0; i < trap_count; ++i) {
             const auto& pt = parsed.trapezoids[i];
             GW::PathingTrapezoid& dt = dst.trapezoids[i];
@@ -389,7 +380,6 @@ namespace Pathing {
             }
         };
 
-        // Fill XNodes
         for (uint32_t i = 0; i < x_count; ++i) {
             const auto& src = parsed.x_nodes[i];
             GW::XNode& xn = dst.x_nodes[i];
@@ -406,7 +396,6 @@ namespace Pathing {
             xn.right = resolve_node(src.right_idx);
         }
 
-        // Fill YNodes
         for (uint32_t i = 0; i < y_count; ++i) {
             const auto& src = parsed.y_nodes[i];
             GW::YNode& yn = dst.y_nodes[i];
@@ -417,7 +406,6 @@ namespace Pathing {
             yn.below = resolve_node(src.below_idx);
         }
 
-        // Fill SinkNodes
         for (uint32_t i = 0; i < sink_count; ++i) {
             const auto& src = parsed.sink_nodes[i];
             GW::SinkNode& sn = dst.sink_nodes[i];
@@ -547,7 +535,6 @@ namespace Pathing {
         if (!detail::read_u32(chunk_data, 4, chunk_size, version)) return false;
         if (!detail::read_u32(chunk_data, 8, chunk_size, sequence)) return false;
 
-        // Verify signature
         if (signature != 0xEEFE704C) return false;
 
         size_t off = 12;
@@ -568,7 +555,6 @@ namespace Pathing {
         if (!detail::read_u32(chunk_data, off, chunk_size, plane_count)) return false;
         off += 4;
 
-        // Sanity check
         if (plane_count > 256) return false;
 
         // Parse into intermediate format first
@@ -598,7 +584,6 @@ namespace Pathing {
             if (!ConvertParsedPlaneToCopied(parsed_planes[i], result.planes[i], plane_trap_id_start[i])) {
                 return false;
             }
-            // Set portal_plane for each portal
             for (uint32_t j = 0; j < result.planes[i].portal_count; ++j) {
                 result.planes[i].portals[j].portal_plane = static_cast<uint16_t>(i);
             }
@@ -636,7 +621,6 @@ namespace Pathing {
 
         out->map_file_id = map_file_id;
 
-        // Parse portal props
         ParsePortalProps(game_asset, out->portal_props);
         out->total_props_parsed = 0; // not tracked in shared helper
         out->total_prop_filenames = 0;

--- a/GWToolboxdll/Windows/Pathfinding/PortalConnections.h
+++ b/GWToolboxdll/Windows/Pathfinding/PortalConnections.h
@@ -74,10 +74,8 @@ namespace Pathing {
         const std::vector<PortalConnection>& GetAll() const { return connections; }
         size_t Count() const { return connections.size(); }
 
-        // Get all connections involving a specific map
         std::vector<const PortalConnection*> GetConnectionsForMap(GW::Constants::MapID map) const;
 
-        // Get connections between two specific maps
         std::vector<const PortalConnection*> GetConnectionsBetween(
             GW::Constants::MapID a, GW::Constants::MapID b) const;
 
@@ -89,7 +87,6 @@ namespace Pathing {
         // Check if any connection exists between two maps (ignoring positions)
         bool HasConnection(GW::Constants::MapID from, GW::Constants::MapID to) const;
 
-        // Cost multiplier for a connection type
         static float GetCostMultiplier(ConnectionType type);
 
     private:

--- a/GWToolboxdll/Windows/Pcons.cpp
+++ b/GWToolboxdll/Windows/Pcons.cpp
@@ -182,19 +182,16 @@ void Pcon::Terminate()
 void Pcon::Update(int delay)
 {
     if (mapid != GW::Map::GetMapID() || maptype != GW::Map::GetInstanceType()) {
-        // Map changed; reset vars
         mapid = GW::Map::GetMapID();
         maptype = GW::Map::GetInstanceType();
         SetPlayerName();
         ResetCounts();
         Refill(refill_if_below_threshold && IsEnabled() && PconsWindow::Instance().GetEnabled());
     }
-    // Refill pcons if needed.
     UpdateRefill();
     if (maptype == GW::Constants::InstanceType::Loading || GW::Map::GetIsObserving()) {
         return;
     }
-    // Check pcon count in inventory
     if (!pcon_quantity_checked) {
         const auto qty = CheckInventory();
         if (qty < 0) {
@@ -272,7 +269,6 @@ void Pcon::AfterUsed(const bool used, const int qty)
         if (used) {
             timer = TIMER_INIT();
             if (quantity == 0) {
-                // if we just used the last one
                 mapid = GW::Map::GetMapID();
                 maptype = GW::Map::GetInstanceType();
                 Log::Warning("Just used the last %s", chat.c_str());
@@ -299,7 +295,6 @@ void Pcon::AfterUsed(const bool used, const int qty)
 
 bool Pcon::FindVacantStackOrSlotInInventory(const GW::Item* likeItem, GW::Item* result)
 {
-    // Scan bags, find an incomplete stack, or otherwise an empty slot.
     GW::Bag** bags = GW::Items::GetBagArray();
     if (bags == nullptr) {
         return false;
@@ -322,7 +317,6 @@ bool Pcon::FindVacantStackOrSlotInInventory(const GW::Item* likeItem, GW::Item* 
             const size_t slotIndex = i - 1;
             GW::Item* item = items[slotIndex];
             if (!item || item == nullptr) {
-                // Reserve this slot for later
                 if (!emptyBag && ReserveSlotForMove(bag->index, slotIndex)) {
                     emptySlotIdx = slotIndex;
                     emptyBag = bag;

--- a/GWToolboxdll/Windows/Pcons.h
+++ b/GWToolboxdll/Windows/Pcons.h
@@ -55,7 +55,6 @@ protected:
     static bool UnreserveSlotForMove(size_t bagId, size_t slot); // Unlock slot.
     // Prevents more than 1 pcon from trying to add to the same slot at the same time.
     static bool ReserveSlotForMove(size_t bagId, size_t slot);
-    // Checks whether another pcon has reserved this slot.
     static bool IsSlotReservedForMove(size_t bagId, size_t slot);
 
     static bool IsControllingCurrentChar();

--- a/GWToolboxdll/Windows/PconsWindow.cpp
+++ b/GWToolboxdll/Windows/PconsWindow.cpp
@@ -56,7 +56,6 @@ namespace {
     bool elite_area_disable_triggered = false; // Already triggered in this run?
     clock_t elite_area_check_timer = 0;
 
-    // Map of which objectives to check per map_id
     std::vector<DWORD> objectives_complete = {};
     const std::map<MapID, std::vector<DWORD>>
     objectives_to_complete_by_map_id = {
@@ -674,14 +673,12 @@ void PconsWindow::MapChanged()
         previous_instance_type = instance_type;
     }
     instance_type = GW::Map::GetInstanceType();
-    // If we've just come from an explorable area then disable pcons.
     if (settings.disable_pcons_on_map_change && previous_instance_type == InstanceType::Explorable) {
         SetEnabled(false);
     }
 
     player = nullptr;
     elite_area_disable_triggered = false;
-    // Find out which objectives we need to complete for this map.
     const auto map_objectives_it = objectives_to_complete_by_map_id.find(map_id);
     if (map_objectives_it != objectives_to_complete_by_map_id.end()) {
         objectives_complete.clear();
@@ -690,7 +687,6 @@ void PconsWindow::MapChanged()
     else {
         current_objectives_to_check.clear();
     }
-    // Find out if we need to check for boss range for this map.
     const auto map_location_it = final_room_location_by_map_id.find(map_id);
     if (map_location_it != final_room_location_by_map_id.end()) {
         current_final_room_location = map_location_it->second;
@@ -783,7 +779,6 @@ void PconsWindow::DrawLunarsAndAlcoholSettings()
 
 void PconsWindow::CheckBossRangeAutoDisable()
 {
-    // Trigger Elite area auto disable if applicable
     if (!enabled || elite_area_disable_triggered || instance_type != InstanceType::Explorable) {
         return; // Pcons disabled, auto disable already triggered, or not in explorable area.
     }

--- a/GWToolboxdll/Windows/PerformanceWindow.cpp
+++ b/GWToolboxdll/Windows/PerformanceWindow.cpp
@@ -13,7 +13,6 @@
 namespace {
     PerformanceWindow::Settings settings;
 
-    // QPC helper
     uint64_t QpcToMicroseconds(LONGLONG ticks)
     {
         static LARGE_INTEGER freq = [] { LARGE_INTEGER f; QueryPerformanceFrequency(&f); return f; }();
@@ -171,7 +170,6 @@ namespace {
     {
         if (settings.stream_to_csv) StreamSnapshotToCsv(tick);
 
-        // Store current 1s snapshot into ring buffer
         hist_frame[hist_index] = acc_frame;
         hist_tb_update[hist_index] = acc_tb_update;
         hist_tb_draw[hist_index] = acc_tb_draw;
@@ -179,7 +177,6 @@ namespace {
         hist_modules[hist_index] = acc_modules;
         hist_index = (hist_index + 1) % WINDOW_SECONDS;
 
-        // Merge all snapshots in the ring buffer
         displayed_frame = {};
         displayed_tb_update = {};
         displayed_tb_draw = {};
@@ -200,7 +197,6 @@ namespace {
             }
         }
 
-        // Reset accumulators for next 1s window
         acc_frame = {};
         acc_tb_update = {};
         acc_tb_draw = {};
@@ -283,7 +279,6 @@ void PerformanceWindow::Draw(IDirect3DDevice9* device)
     }
     HookPresent(device);
 
-    // Frame period tracking
     static LARGE_INTEGER prev_frame_qpc = {};
     {
         LARGE_INTEGER now;
@@ -295,7 +290,6 @@ void PerformanceWindow::Draw(IDirect3DDevice9* device)
         prev_frame_qpc = now;
     }
 
-    // Accumulate per-module times
     uint64_t total_update_us = 0, total_draw_us = 0;
 
     for (const auto* m : GWToolbox::GetAllModules()) {
@@ -316,7 +310,6 @@ void PerformanceWindow::Draw(IDirect3DDevice9* device)
     if (total_draw_us > 0) acc_tb_draw.Record(total_draw_us);
     if (present_time_us > 0) acc_present.Record(present_time_us);
 
-    // Flush every 1s
     const DWORD now = GetTickCount();
     if (window_start_tick == 0) window_start_tick = now;
     if (now - window_start_tick >= 1000) {

--- a/GWToolboxdll/Windows/RerollWindow.cpp
+++ b/GWToolboxdll/Windows/RerollWindow.cpp
@@ -255,7 +255,6 @@ namespace {
 
             ImGui::PushID(static_cast<int>(i));
 
-            // Collect available chars for this profession for the combo.
             std::vector<const wchar_t*> candidates;
             if (available_chars_ptr && available_chars_ptr->valid()) {
                 for (const auto& c : *available_chars_ptr) {
@@ -273,7 +272,6 @@ namespace {
 
             ImGui::SetNextItemWidth(dropdown_w);
             if (ImGui::BeginCombo("##pref", preview)) {
-                // "(any)" option
                 if (ImGui::Selectable("(any)", pref.empty())) {
                     pref.clear();
                 }
@@ -394,7 +392,6 @@ namespace {
             return false;
         }
 
-        // Check the configured preferred character first.
         const auto account_it = preferred_chars_per_account.find(GetCurrentAccountUuidStr());
         if (account_it != preferred_chars_per_account.end()) {
             const auto pref_it = account_it->second.find(static_cast<uint32_t>(profession));
@@ -406,7 +403,6 @@ namespace {
             }
         }
 
-        // Fall back to the first non-excluded available character with the matching profession.
         for (const auto& available_char : *available_characters) {
             if (IsExcludedFromReroll(available_char.player_name)) {
                 continue;

--- a/GWToolboxdll/Windows/SkillListingWindow.cpp
+++ b/GWToolboxdll/Windows/SkillListingWindow.cpp
@@ -111,7 +111,6 @@ void SkillListingWindow::ExportToJSON() const
     constexpr size_t max_len = _countof(file_location_wc) - 1;
 
     for (size_t i = 0; i < message.length(); i++) {
-        // Break on the end of the message
         if (!message[i]) {
             break;
         }

--- a/GWToolboxdll/Windows/TradeWindow.cpp
+++ b/GWToolboxdll/Windows/TradeWindow.cpp
@@ -346,7 +346,6 @@ void TradeWindow::fetch()
         // Fill searched_words for the on-the-fly search in ::fetch
         searched_words = TextUtils::ParsePatterns<char>(search_buffer);
 
-        // Send request
         const tradechat_api::SearchRequest request{.query = pending_query_string};
         pending_query_sent = clock();
         ws_window->send(glz::write_json(request).value_or(std::string{}));
@@ -394,7 +393,6 @@ void TradeWindow::fetch()
             print_search_results = false;
             return;
         }
-        // Add to message feed
         Message msg;
         const tradechat_api::RawMessage raw{.s = res.s, .m = res.m, .t = res.t};
         if (!fill_message(raw, &msg)) {
@@ -416,7 +414,6 @@ void TradeWindow::fetch()
             messages.add(msg);
         }
 
-        // Check alerts
         // do not display trade chat while in kamadan AE district 1 or Pre-Searing Ascalon AE district 1
         bool print_message = ((settings.is_kamadan_chat && settings.print_game_chat && !GetInKamadanAE1()) || (!settings.is_kamadan_chat && settings.print_game_chat_asc && !GetInAscalonAE1())) && IsTradeAlert(msg.message);
 
@@ -611,7 +608,6 @@ void TradeWindow::Draw(IDirect3DDevice9*)
                 ImGui::SameLine(playername_left);
             }
             if (ImGui::Button(msg.name.c_str(), ImVec2(playernamewidth, 0))) {
-                // open whisper to player
                 GW::GameThread::Enqueue([&msg] {
                     std::wstring name_ws = TextUtils::StringToWString(msg.name);
                     SendUIMessage(GW::UI::UIMessage::kOpenWhisper, name_ws.data());

--- a/GWToolboxdll/Windows/TravelWindow.cpp
+++ b/GWToolboxdll/Windows/TravelWindow.cpp
@@ -88,7 +88,6 @@ namespace {
             }
             if (enc_name->IsDecoding())
                 return nullptr;
-            // Sanitise for searching my removing punctuation etc
             const auto sanitised = SanitiseForSearch(enc_name->wstring());
             name = new char[sanitised.length() + 1];
             strcpy(name, sanitised.c_str());
@@ -336,7 +335,6 @@ namespace {
             }
         }
 
-        // Helper function
         auto FindMatchingMap = [](const char* compare, const char* const* map_names, const GW::Constants::MapID* map_ids, const size_t map_count) -> GW::Constants::MapID {
             const char* bestMatchMapName = nullptr;
             auto bestMatchMapID = GW::Constants::MapID::None;
@@ -363,7 +361,6 @@ namespace {
             }
             return bestMatchMapID;
         };
-        // Helper function
         auto FindMatchingMapVec = [](const char* compare, std::vector<SearchableArea*>& maps) -> GW::Constants::MapID {
             const char* bestMatchMapName = nullptr;
             auto bestMatchMapID = GW::Constants::MapID::None;
@@ -430,7 +427,6 @@ namespace {
 
     void CHAT_CMD_FUNC(CmdTP)
     {
-        // zero argument error
         if (argc == 1) {
             Log::Error("[Error] Please provide an argument");
             return;
@@ -445,7 +441,6 @@ namespace {
             pending_map_travel.map_id = GW::Constants::MapID::None;
             return;
         }
-        // Guild hall
         if (argOutpost == L"gh") {
             if (IsInGH()) {
                 GW::GuildMgr::LeaveGH();
@@ -1191,13 +1186,11 @@ void TravelWindow::DrawSettingsInternal()
 
             ImGui::TableNextRow();
 
-            // Alias key
             ImGui::TableSetColumnIndex(0);
             ImGui::SetNextItemWidth(-1);
             if (ImGui::InputText("##alias", entry.alias, 32))
                 aliases_changed = true;
 
-            // Map combo
             ImGui::TableSetColumnIndex(1);
             ImGui::SetNextItemWidth(-1);
             auto map_idx = OutpostIDToIndex(entry.map_id);
@@ -1206,7 +1199,6 @@ void TravelWindow::DrawSettingsInternal()
                 aliases_changed = true;
             }
 
-            // District combo
             ImGui::TableSetColumnIndex(2);
             ImGui::SetNextItemWidth(-1);
             auto dist_idx = DistrictToAliasIndex(entry.district);
@@ -1215,7 +1207,6 @@ void TravelWindow::DrawSettingsInternal()
                 aliases_changed = true;
             }
 
-            // District number
             ImGui::TableSetColumnIndex(3);
             ImGui::SetNextItemWidth(-1);
             auto dist_num = static_cast<int>(entry.district_number);
@@ -1224,7 +1215,6 @@ void TravelWindow::DrawSettingsInternal()
                 aliases_changed = true;
             }
 
-            // Delete button
             ImGui::TableSetColumnIndex(4);
             if (ImGui::ButtonWithHint(ICON_FA_TRASH, "Delete alias", ImVec2(btn_w, 0))) {
                 user_aliases.erase(user_aliases.begin() + i);

--- a/GWToolboxdll/mp3.h
+++ b/GWToolboxdll/mp3.h
@@ -1,6 +1,5 @@
 #pragma once
 
-// Windows Header Files:
 #include <windows.h>
 #include <strmif.h>
 #include <control.h>
@@ -29,25 +28,14 @@ public:
     // -10000 is lowest volume and 0 is highest volume
     long GetVolume() const;
 
-    // Returns the duration in 1/10 millionth of a second,
-    // meaning 10,000,000 == 1 second
-    // You have to divide the result by 10,000,000
-    // to get the duration in seconds.
+    // Duration in units of 100ns (10,000,000 == 1 second).
     __int64 GetDuration() const;
 
-    // Returns the current playing position
-    // in 1/10 millionth of a second,
-    // meaning 10,000,000 == 1 second
-    // You have to divide the result by 10,000,000
-    // to get the duration in seconds.
+    // Playing position in units of 100ns (10,000,000 == 1 second).
     __int64 GetCurrentPosition() const;
 
-    // Seek to position with pCurrent and pStop
-    // bAbsolutePositioning specifies absolute or relative positioning.
-    // If pCurrent and pStop have the same value, the player will seek to the position
-    // and stop playing. Note: Even if pCurrent and pStop have the same value,
-    // avoid putting the same pointer into both of them, meaning put different
-    // pointers with the same dereferenced value.
+    // Equal pCurrent/pStop values seek then stop playing; they must still be two
+    // distinct pointers.
     bool SetPositions(__int64* pCurrent, __int64* pStop, bool bAbsolutePositioning) const;
 
 private:
@@ -57,6 +45,5 @@ private:
     IBasicAudio* piba;
     IMediaSeeking* pims;
     bool ready;
-    // Duration of the MP3.
     __int64 duration;
 };

--- a/RestClient/HttpClient.cpp
+++ b/RestClient/HttpClient.cpp
@@ -403,8 +403,7 @@ bool HttpRequest::Perform()
         LeaveCriticalSection(cs);
     }
 
-    // Security relaxation: WinHTTP/Schannel verifies certs by default. Disable
-    // checks when the caller has opted out.
+    // WinHTTP/Schannel verifies certs by default; relax only where the caller opted out.
     if (!m_VerifyPeer || !m_VerifyHost) {
         DWORD secFlags = 0;
         if (!m_VerifyPeer) {
@@ -419,7 +418,6 @@ bool HttpRequest::Perform()
                          &secFlags, sizeof(secFlags));
     }
 
-    // Redirect policy
     {
         DWORD policy = m_FollowLocation
                            ? WINHTTP_OPTION_REDIRECT_POLICY_ALWAYS
@@ -433,7 +431,6 @@ bool HttpRequest::Perform()
                          &limit, sizeof(limit));
     }
 
-    // Custom request headers
     if (!m_HeadersBlock.empty()) {
         WinHttpAddRequestHeaders(
             hRequest,
@@ -474,7 +471,6 @@ bool HttpRequest::Perform()
         return false;
     }
 
-    // Status code
     {
         DWORD status_code = 0;
         DWORD size = sizeof(status_code);
@@ -486,7 +482,6 @@ bool HttpRequest::Perform()
         m_StatusCode = static_cast<int>(status_code);
     }
 
-    // Raw response headers
     {
         DWORD bytes = 0;
         WinHttpQueryHeaders(
@@ -513,7 +508,6 @@ bool HttpRequest::Perform()
         }
     }
 
-    // Body (skip when caller opted out)
     if (!m_NoBody) {
         char buf[8192];
         for (;;) {

--- a/RestClient/RestClient.cpp
+++ b/RestClient/RestClient.cpp
@@ -74,7 +74,6 @@ void AsyncRestClient::ExecuteAsync()
     m_Event.Reset();
     m_ThreadHandle = CreateThread(nullptr, 0, &AsyncRestClient::ThreadProc, this, 0, nullptr);
     if (!m_ThreadHandle) {
-        // Failed to spawn a worker; treat as immediately errored.
         m_Status = ResponseStatus::Error;
         m_Event.SetDone();
     }

--- a/RestClient/RestClient.h
+++ b/RestClient/RestClient.h
@@ -49,13 +49,8 @@ public:
     // so "IsCompleted" will return false.
     void Clear();
 
-    // The setters from HttpRequest are not thread-safe and must not be
-    // touched while a request is in flight. "Wait", "IsPending" and "Abort"
-    // are thread-safe.
-    //
-    // You need to guarantee that between a call to "ExecuteAsync" until
-    // "IsPending" returns false (or "Wait" returns true) or until "Abort"
-    // is called the options are not changed.
+    // "Wait", "IsPending" and "Abort" are thread-safe; the inherited setters are not
+    // and must not be touched between "ExecuteAsync" and the request finishing.
     void Wait() const;
     bool Wait(uint32_t TimeoutMs) const;
 

--- a/plugins/Base/PluginUtils.cpp
+++ b/plugins/Base/PluginUtils.cpp
@@ -297,7 +297,6 @@ namespace PluginUtils {
         return out;
     }
 
-    // Convert a wide Unicode string to an UTF8 string
     std::string WStringToString(const std::wstring& s)
     {
         // @Cleanup: ASSERT used incorrectly here; value passed could be from anywhere!
@@ -351,7 +350,6 @@ namespace PluginUtils {
     std::wstring RemoveDiacritics(const std::wstring& s)
     {
         if (diacritics_charmap.empty()) {
-            // Build static diacritics map if not already done so
             for (size_t i = 0; i < _countof(diacritics); i++) {
                 for (size_t j = 1; diacritics[i][j]; j++) {
                     diacritics_charmap[diacritics[i][j]] = diacritics[i][0];
@@ -369,7 +367,6 @@ namespace PluginUtils {
         return out;
     }
 
-    // Convert an UTF8 string to a wide Unicode String
     std::wstring StringToWString(const std::string& str)
     {
         // @Cleanup: ASSERT used incorrectly here; value passed could be from anywhere!

--- a/plugins/Base/ToolboxPlugin.h
+++ b/plugins/Base/ToolboxPlugin.h
@@ -68,13 +68,11 @@ public:
     // Pre-JSON settings file (<folder>/<Name>.ini), only read as a legacy fallback - never written.
     [[nodiscard]] virtual std::filesystem::path GetLegacySettingFile(const wchar_t* folder) const;
 
-    // Initialize module
     virtual void Initialize(ImGuiContext* ctx, ImGuiAllocFns allocator_fns, HMODULE toolbox_dll);
 
     // Send termination signal to module, make sure Terminate can be called.
     virtual void SignalTerminate() {}
 
-    // Can we terminate this module?
     virtual bool CanTerminate() { return true; }
 
     // Terminate module. Release any resources used. Make sure to revert all callbacks

--- a/plugins/Base/ToolboxUIPlugin.cpp
+++ b/plugins/Base/ToolboxUIPlugin.cpp
@@ -32,15 +32,12 @@ namespace {
         }
         const std::wstring arg2 = PluginUtils::ToLower(argv[2]);
         if (arg2 == L"hide") {
-            // /tb PluginName hide
             *instance->GetVisiblePtr() = false;
         }
         else if (arg2 == L"show") {
-            // /tb PluginName hide
             *instance->GetVisiblePtr() = true;
         }
         else if (arg2 == L"toggle") {
-            // /tb PluginName hide
             *instance->GetVisiblePtr() = !*instance->GetVisiblePtr();
         }
         if (arg1 != pluginname) {


### PR DESCRIPTION
Applies the new `AGENTS.md` rule #1 across all 482 first-party `.cpp`/`.h` files (`Dependencies/` excluded), split across 30 parallel passes.

**What was removed**
- Standalone comments that only restate the adjacent code (`// Constructor`, `// Draw the window`, `// Loop through agents`, ImGui/WinHTTP call narration, function-name echoes).
- Several stale or copy-pasted comments that described the wrong function/branch.
- A handful of rambling why-comments shortened to 1-2 lines with the substance kept.

**What was deliberately left alone**
- Inline (trailing) comments — untouched byte-for-byte.
- License/file headers, `// ===`/`// ---` banners, TODO/FIXME/`@Cleanup` notes, commented-out code, lint/ReSharper directives.
- Reverse-engineering notes (scan patterns, struct offsets, packet layouts), threading/lifetime contracts, units, and game-client quirks.
- Vendored files (`sha1.cpp`, `imgui_impl_*`, `resource.h`) to avoid diverging from upstream.

**Verification**
149 files changed, 44 insertions / 1408 deletions. Every changed line was checked to be a comment line — the diff contains zero code changes. Block-comment markers were checked for balance (the two pre-existing imbalances in `ArmoryWindow.cpp` and `ObjectiveTimerWindow.cpp` are a `*/` inside a `//` comment and a `"/*"` string literal, both unchanged from `dev`).

Not compiled here — this environment is Linux, and the project builds with MSVC on Windows. Worth letting CI confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)