### PR TITLE
Refresh only the agent whose allegiance changed

### DIFF
--- a/GWToolboxdll/Modules/GameSettings.cpp
+++ b/GWToolboxdll/Modules/GameSettings.cpp
@@ -439,18 +439,10 @@ namespace {
         GW::Hook::LeaveHook();
     }
 
-    using SetGlobalNameTagVisibility_pt = void(__cdecl*)(uint32_t flags);
-    SetGlobalNameTagVisibility_pt SetGlobalNameTagVisibility_Func = nullptr;
-    uint32_t* GlobalNameTagVisibilityFlags = nullptr;
-
     // Refresh agent name tags when allegiance changes ( https://github.com/gwdevhub/GWToolboxpp/issues/781 )
-    void OnAgentAllegianceChanged(GW::HookStatus*, GW::Packet::StoC::AgentUpdateAllegiance*)
+    void OnAgentAllegianceChanged(GW::HookStatus*, const GW::Packet::StoC::AgentUpdateAllegiance* packet)
     {
-        // Backup the current name tag flag state, then "flash" nametags to update.
-        const uint32_t prev_flags = *GlobalNameTagVisibilityFlags;
-        SetGlobalNameTagVisibility_Func(0);
-        SetGlobalNameTagVisibility_Func(prev_flags);
-        ASSERT(*GlobalNameTagVisibilityFlags == prev_flags);
+        GW::Agents::RefreshAgentNameTag(GW::Agents::GetAgentByID(packet->agent_id));
     }
 
     uint32_t current_party_target_id = 0;
@@ -1534,27 +1526,12 @@ void GameSettings::Initialize()
 
     Log::Log("[GameSettings] SetFrameSkillDescription_Func = %p\n", SetFrameSkillDescription_Func);
 
-    // See OnAgentAllegianceChanged
-    address = GW::Scanner::Find("\x81\xce\xa0\x06\x00\x00", "xxxxxx");
-    if (address) address = GW::Scanner::FunctionFromNearCall(GW::Scanner::FindInRange("\xe8", "x", 0, address, address + 0xff));
-    DEBUG_ASSERT(address);
-    if (address) {
-        SetGlobalNameTagVisibility_Func = (SetGlobalNameTagVisibility_pt)address;
-        if (GW::Scanner::IsValidPtr(*(uintptr_t*)(address + 0xa)))
-            GlobalNameTagVisibilityFlags = *(uint32_t**)(address + 0xa);
-        else if (GW::Scanner::IsValidPtr(*(uintptr_t*)(address + 0xb)))
-            GlobalNameTagVisibilityFlags = *(uint32_t**)(address + 0xb);
-        GW::StoC::RegisterPostPacketCallback<GW::Packet::StoC::AgentUpdateAllegiance>(&PartyDefeated_Entry, &OnAgentAllegianceChanged);
-    }
-    Log::Log("[GameSettings] SetGlobalNameTagVisibility_Func = %p", (void*)SetGlobalNameTagVisibility_Func);
-    Log::Log("[GameSettings] GlobalNameTagVisibilityFlags = %p", static_cast<void*>(GlobalNameTagVisibilityFlags));
+    GW::StoC::RegisterPostPacketCallback<GW::Packet::StoC::AgentUpdateAllegiance>(&PartyDefeated_Entry, &OnAgentAllegianceChanged);
 
 #ifdef _DEBUG
     ASSERT(SkillList_UICallback_Func);
     ASSERT(remove_skill_warmup_duration_patch.IsValid());
     ASSERT(SetFrameSkillDescription_Func);
-    ASSERT(SetGlobalNameTagVisibility_Func);
-    ASSERT(GlobalNameTagVisibilityFlags);
     ASSERT(OnSkillTomeWindow_UIMessage_Func);
 #endif
 

--- a/GWToolboxdll/Utils/ToolboxUtils.cpp
+++ b/GWToolboxdll/Utils/ToolboxUtils.cpp
@@ -48,10 +48,6 @@ namespace {
 
     GW::Array<GW::AvailableCharacterInfo>* available_chars_ptr = nullptr;
 
-    // AvAgent.cpp; __thiscall modelled as __fastcall. `force` skips the "did visibility change" guard.
-    typedef void(__fastcall* RefreshNameTag_pt)(GW::Agent* agent, void* edx, uint32_t old_flags, uint32_t new_flags, uint32_t force);
-    RefreshNameTag_pt RefreshNameTag_Func = nullptr;
-
     constexpr uint32_t bogus_area_info_flags = 0x5000000; // e.g. "wrong" Augury Rock is map 119, no NPCs.
     constexpr uint32_t debug_area_info_flag = 0x80000000;
 


### PR DESCRIPTION
Follow-up to #2475 and the GWCA update, closing out the #gwtoolbox thread on refreshing a targeted agent's name tag.

### The allegiance patch

`OnAgentAllegianceChanged` (for #781) flashed the global name tag filter off and back on:

```cpp
const uint32_t prev_flags = *GlobalNameTagVisibilityFlags;
SetGlobalNameTagVisibility_Func(0);
SetGlobalNameTagVisibility_Func(prev_flags);
```

Two problems with that:

1. **It rebuilds every name tag in the instance** to update one agent.
2. **It never refreshes the agent that usually matters.** That call toggles bit `0x400` on every agent, but visibility is `!(f & 0x200) && (f & 0x598)` — and `0x598` includes `NameTagFlags_EvaluatedTarget` (`0x80`). For the current target, visibility is unchanged before and after, so the client's guard rejects it and **no UI message is emitted at all** for that agent. Flag an enemy that you're targeting and its tag keeps the old colour until you retarget.

`GW::Agents::RefreshAgentNameTag` doesn't go through the flags at all — it re-reads the name and colours from the agent and sends `kSetAgentNameTagAttribs` directly — so it works on the target. The packet already carries `agent_id`:

```cpp
void OnAgentAllegianceChanged(GW::HookStatus*, const GW::Packet::StoC::AgentUpdateAllegiance* packet)
{
    GW::Agents::RefreshAgentNameTag(GW::Agents::GetAgentByID(packet->agent_id));
}
```

Null agent is fine — GWCA's implementation opens with `if (!agent || !agent->vtable) return false;`.

That removes the `\x81\xce\xa0\x06\x00\x00` signature, `SetGlobalNameTagVisibility_Func`, `GlobalNameTagVisibilityFlags`, their logging and their two debug asserts. Nothing else referenced them.

### Also

`ToolboxUtils.cpp` still had the `RefreshNameTag_pt` typedef and `RefreshNameTag_Func` global orphaned by the GWCA update — the function that used them is gone. Removed.

### Not verified in-game

The behavioural claim above is derived from the client's visibility logic, not observed. Worth confirming by targeting an enemy and flagging its allegiance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)