### PR TITLE
perf(in-game rendering): index navmesh point-location, throttle path re-anchor

### DIFF
--- a/GWToolboxdll/Widgets/Minimap/GameWorldRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/GameWorldRenderer.cpp
@@ -352,7 +352,7 @@ namespace {
         }
 
         void* mem_loc = nullptr;
-        res = poly.vb->Lock(0, vertices.size() * sizeof(D3DVertex), &mem_loc, D3DLOCK_DISCARD);
+        res = poly.vb->Lock(0, vertices.size() * sizeof(D3DVertex), &mem_loc, 0);
         if (res != S_OK || !mem_loc) {
             poly.vb->Release();
             poly.vb = nullptr;
@@ -427,8 +427,14 @@ void GameWorldRenderer::GenericPolyRenderable::Draw(IDirect3DDevice9* device)
         return;
 
     if (from_player_pos && vertices.size() > 1) {
-        if (const auto player = GW::Agents::GetControlledCharacter()) {
-            // Re-anchor the leading line to the player's live position each frame and drape on the navmesh-walkable
+        // Re-anchoring drapes every vertex, so gate it on the player having actually moved: at 288 gw/s that still refreshes ~20x a second, and standing still costs nothing.
+        constexpr float reanchor_move_threshold = 15.f;
+        const auto player = GW::Agents::GetControlledCharacter();
+        if (player && (!anchored || std::abs(player->pos.x - anchor_x) + std::abs(player->pos.y - anchor_y) >= reanchor_move_threshold)) {
+            anchor_x = player->pos.x;
+            anchor_y = player->pos.y;
+            anchored = true;
+            // Re-anchor the leading line to the player's live position and drape on the navmesh-walkable
             // plane at each sample, seeded from player->z (reliable even when the reported plane reads 0). This rides
             // the surface the player actually walks (up a monument/ramp between hops) instead of the ground beneath.
             const float ex = vertices.back().x, ey = vertices.back().y;
@@ -456,7 +462,8 @@ void GameWorldRenderer::GenericPolyRenderable::Draw(IDirect3DDevice9* device)
             }
 
             void* mem_loc = nullptr;
-            auto res = vb->Lock(0, vertices.size() * sizeof(D3DVertex), &mem_loc, D3DLOCK_DISCARD);
+            // flags=0, not D3DLOCK_DISCARD: DISCARD needs D3DUSAGE_DYNAMIC but this is MANAGED, so it's ignored and the lock serialises against the GPU.
+            auto res = vb->Lock(0, vertices.size() * sizeof(D3DVertex), &mem_loc, 0);
             if (res == S_OK) {
                 memcpy(mem_loc, vertices.data(), vertices.size() * sizeof(D3DVertex));
                 vb->Unlock();

--- a/GWToolboxdll/Widgets/Minimap/GameWorldRenderer.h
+++ b/GWToolboxdll/Widgets/Minimap/GameWorldRenderer.h
@@ -32,6 +32,9 @@ public:
             , from_player_pos(other.from_player_pos)
             , use_dotted_effect(other.use_dotted_effect)
             , vertices_processed(other.vertices_processed)
+            , anchor_x(other.anchor_x)
+            , anchor_y(other.anchor_y)
+            , anchored(other.anchored)
             , vb(other.vb)
         {
             other.vb = nullptr;
@@ -59,6 +62,9 @@ public:
             vertices_processed = other.vertices_processed;
             from_player_pos = other.from_player_pos;
             use_dotted_effect = other.use_dotted_effect;
+            anchor_x = other.anchor_x;
+            anchor_y = other.anchor_y;
+            anchored = other.anchored;
 
             return *this;
         }
@@ -72,6 +78,10 @@ public:
         bool from_player_pos = false;
         bool use_dotted_effect = false;
         unsigned int vertices_processed = 0u;
+        // Player position this from_player_pos line was last re-anchored to; gates the per-vertex re-drape.
+        float anchor_x = 0.f;
+        float anchor_y = 0.f;
+        bool anchored = false;
         IDirect3DVertexBuffer9* vb = nullptr;
     };
 

--- a/GWToolboxdll/Windows/Pathfinding/NavMesh.cpp
+++ b/GWToolboxdll/Windows/Pathfinding/NavMesh.cpp
@@ -80,6 +80,70 @@ namespace Pathing {
         m_poly_trap.clear();
         m_ground_poly_count = 0;
         m_plane_count = 0;
+        m_row_min_y = 0.f;
+        m_row_inv_h = 0.f;
+        m_row_count = 0;
+        m_row_start.clear();
+        m_row_items.clear();
+        m_tall_items.clear();
+    }
+
+    void NavMesh::BuildDrapeIndex(const float min_y, const float max_y)
+    {
+        m_row_inv_h = 0.f;
+        m_row_count = 0;
+        m_row_start.clear();
+        m_row_items.clear();
+        m_tall_items.clear();
+
+        const float span = max_y - min_y;
+        if (m_ground_poly_count == 0 || !(span > 0.f)) return;
+
+        constexpr uint32_t kTrapsPerRow = 8;
+        constexpr uint32_t kMaxRowsPerTrap = 32; // past this a trapezoid goes to m_tall_items, so degenerate data can't grow the index to n*rows
+        m_row_count = std::clamp(m_ground_poly_count / kTrapsPerRow, 64u, 4096u);
+        m_row_min_y = min_y;
+        const float inv_h = static_cast<float>(m_row_count) / span;
+
+        const auto row_of = [&](const float y) -> uint32_t {
+            const float r = (y - min_y) * inv_h;
+            if (r <= 0.f) return 0;
+            const auto ri = static_cast<uint32_t>(r);
+            return ri >= m_row_count ? m_row_count - 1 : ri;
+        };
+
+        m_row_start.assign(m_row_count + 1, 0);
+        std::vector<uint8_t> is_tall(m_ground_poly_count, 0);
+        size_t total = 0;
+        for (uint32_t i = 0; i < m_ground_poly_count; ++i) {
+            const GW::PathingTrapezoid* t = m_poly_trap[i];
+            if (!t) { is_tall[i] = 1; continue; } // no bounds to bucket on, so keep it visible to every query
+            const uint32_t lo = row_of(std::min(t->YB, t->YT));
+            const uint32_t hi = row_of(std::max(t->YB, t->YT));
+            if (hi - lo + 1 > kMaxRowsPerTrap) {
+                is_tall[i] = 1;
+                continue;
+            }
+            for (uint32_t r = lo; r <= hi; ++r) m_row_start[r + 1]++;
+            total += hi - lo + 1;
+        }
+
+        for (uint32_t r = 0; r < m_row_count; ++r) m_row_start[r + 1] += m_row_start[r];
+
+        m_row_items.resize(total);
+        std::vector<uint32_t> cursor(m_row_start.begin(), m_row_start.end() - 1);
+        for (uint32_t i = 0; i < m_ground_poly_count; ++i) {
+            if (is_tall[i]) {
+                m_tall_items.push_back(i);
+                continue;
+            }
+            const GW::PathingTrapezoid* t = m_poly_trap[i];
+            const uint32_t lo = row_of(std::min(t->YB, t->YT));
+            const uint32_t hi = row_of(std::max(t->YB, t->YT));
+            for (uint32_t r = lo; r <= hi; ++r) m_row_items[cursor[r]++] = i;
+        }
+
+        m_row_inv_h = inv_h; // published last: non-zero is what marks the index usable
     }
 
     int NavMesh::PlaneIndex(uint32_t zplane) const
@@ -134,6 +198,7 @@ namespace Pathing {
         }
 
         minx -= 16.f; miny -= 16.f; maxx += 16.f; maxy += 16.f;
+        BuildDrapeIndex(miny, maxy);
         m_cs = std::max(1.0f, std::max(maxx - minx, maxy - miny) / 60000.0f); // keep quantised verts in uint16 range
         const float yrange = (float)(m_plane_count + 1) * kPlaneSeparation;
         m_ch = std::max(1.0f, yrange / 60000.0f);
@@ -615,27 +680,39 @@ namespace Pathing {
     float NavMesh::DrapeHeightAt(float x, float y, float prev_z) const
     {
         if (!m_navmesh || m_poly_trap.empty()) return FLT_MAX;
-        // Point-locate directly against the source trapezoids (cheap: a Y-band reject skips almost everything).
         // Among every plane whose walkable trapezoid contains (x,y), return the QueryAltitude surface closest to
         // prev_z. So over a monument the only containing plane is the monument's -> the path rides it; under a
         // bridge the floor plane contains it -> the path stays on the floor.
         float best = FLT_MAX, best_d = FLT_MAX;
-        for (uint32_t i = 0; i < m_ground_poly_count; ++i) {
+
+        const auto consider = [&](const uint32_t i) {
             const GW::PathingTrapezoid* t = m_poly_trap[i];
-            if (!t) continue;
+            if (!t) return;
             const float lo = std::min(t->YB, t->YT), hi = std::max(t->YB, t->YT);
-            if (y < lo || y > hi) continue; // cheap Y-band reject
+            if (y < lo || y > hi) return; // cheap Y-band reject
             const float denom = t->YT - t->YB;
             const float u = std::fabs(denom) > 1e-4f ? (y - t->YB) / denom : 0.f;
             const float lx = t->XBL + (t->XTL - t->XBL) * u;
             const float rx = t->XBR + (t->XTR - t->XBR) * u;
-            if (x < std::min(lx, rx) || x > std::max(lx, rx)) continue; // outside the trapezoid in X at this Y
+            if (x < std::min(lx, rx) || x > std::max(lx, rx)) return; // outside the trapezoid in X at this Y
             const int plane = m_poly_plane[i];
             const float z = TerrainDrape::QueryAltAt(x, y, static_cast<uint32_t>(plane)); // surface of THIS walkable plane at (x,y)
-            if (z == 0.f) continue;                       // out of this plane's data
+            if (z == 0.f) return;                         // out of this plane's data
             const float d = std::fabs(z - prev_z);
             if (d < best_d) { best_d = d; best = z; } // continuity: nearest walkable surface to where we already are
+        };
+
+        if (m_row_inv_h <= 0.f) { // no index: exhaustive scan
+            for (uint32_t i = 0; i < m_ground_poly_count; ++i) consider(i);
+            return best;
         }
+
+        const float rf = (y - m_row_min_y) * m_row_inv_h;
+        if (rf >= 0.f && rf < static_cast<float>(m_row_count)) {
+            const auto row = static_cast<uint32_t>(rf);
+            for (uint32_t k = m_row_start[row]; k < m_row_start[row + 1]; ++k) consider(m_row_items[k]);
+        }
+        for (const uint32_t i : m_tall_items) consider(i);
         return best;
     }
 

--- a/GWToolboxdll/Windows/Pathfinding/NavMesh.h
+++ b/GWToolboxdll/Windows/Pathfinding/NavMesh.h
@@ -43,6 +43,8 @@ namespace Pathing {
         void DestroyMesh();
         int PlaneIndex(uint32_t zplane) const; // GW query zplane -> plane index (ground sentinel -> 0)
         float PlaneY(int plane) const;
+        // Bucket ground trapezoids into Y rows so DrapeHeightAt point-locates in O(few), not O(all ~10k-32k).
+        void BuildDrapeIndex(float min_y, float max_y);
 
         dtNavMesh* m_navmesh = nullptr;
 
@@ -53,6 +55,15 @@ namespace Pathing {
 
         std::vector<uint16_t> m_poly_plane; // ground poly index -> plane index
         std::vector<const GW::PathingTrapezoid*> m_poly_trap; // ground poly index -> source trapezoid (point-location for DrapeHeightAt)
+
+        // === Y-row point-location index (DrapeHeightAt) ===
+        // 1D rows suffice: GW trapezoids are thin horizontal bands, so a query touches exactly one row.
+        float                 m_row_min_y = 0.f;
+        float                 m_row_inv_h = 0.f;  // rows per unit Y; 0 => not built, fall back to the full scan
+        uint32_t              m_row_count = 0;
+        std::vector<uint32_t> m_row_start;        // CSR offsets into m_row_items, size m_row_count + 1
+        std::vector<uint32_t> m_row_items;
+        std::vector<uint32_t> m_tall_items;       // spans too many rows to bucket; always scanned
     };
 
 } // namespace Pathing


### PR DESCRIPTION
Enabling **In-game rendering** tanks FPS. The weather module goes through the *same* `GameWorldCompositor` split, `FlushCommandQueue`, `CreateStateBlock(D3DSBT_ALL)` and `SetupPipeline`, and heavy rain is fine — so the shared compositor machinery is not the problem and the cost is in `GameWorldRenderer`'s own per-frame work.

## Cause

`GameWorldRenderer::GenericPolyRenderable::Draw` re-anchors the `from_player_pos` path line **every frame, unbudgeted, on the render thread**, calling `NavMesh::DrapeHeightAt` per vertex.

`DrapeHeightAt` was a linear scan over every ground trapezoid in the map (`kMaxGroundPolys = 0x8000`), with a `GW::Map::QueryAltitude` call for each containing trapezoid. The line is sampled every 50gw, so a long leading hop means millions of iterations per frame. Weather has no equivalent: it throttles its whole rebuild to 30Hz and draws instanced.

This fires whenever a quest path with `draw_on_terrain` is live — `QuestModule.cpp` sets `from_player_pos` on the first in-game segment.

## Changes

- **Y-row point-location index.** Ground trapezoids are bucketed into Y rows (CSR layout) once per navmesh build. GW trapezoids are thin horizontal bands, so 1D rows are enough — a query touches exactly one row. Trapezoids spanning more than 32 rows go to a small always-scanned overflow list, so degenerate data can't grow the index to `n × rows`. The exhaustive scan remains as a fallback when the index isn't built.
- **Re-anchor throttle.** The per-vertex re-drape only runs once the player has moved ≥15gw. At run speed (288 gw/s) that still refreshes ~20×/sec; standing still costs nothing.
- **Lock flags.** `D3DLOCK_DISCARD` → `0` on both `D3DPOOL_MANAGED` vertex buffer locks. `DISCARD` requires `D3DUSAGE_DYNAMIC`, so on a managed buffer it was ignored and the lock serialised against the GPU. The navmesh batch VB already avoids this for the same reason.

## Verification

The index logic was extracted into a standalone harness and diffed against the brute-force scan over **80,000 queries** across four trapezoid layouts (200–20,000 traps, inverted `YB > YT`, out-of-bounds queries, and map-spanning traps exercising the overflow list):

```
scenario 0: n=200    rows=64    tall=0     avg candidates/query = 3.9  (brute 200)   ->  51x
scenario 1: n=5000   rows=625   tall=0     avg candidates/query = 27.2 (brute 5000)  -> 184x
scenario 2: n=20000  rows=2500  tall=0     avg candidates/query = 84.6 (brute 20000) -> 236x
scenario 3: n=3000   rows=375   tall=60    avg candidates/query = 85.1 (brute 3000)  ->  35x

OK: 80000 queries, indexed result set identical to exhaustive scan.
overall candidate reduction: 140x
```

⚠️ **Not built or run on Windows** — no MSVC toolchain in the authoring environment. The algorithm is verified; the compile and the in-game FPS delta are not. Please confirm both before merging.

## Notes for review

- `PathfindingWindow::GetResidentNavMesh()` is read from the render thread while the navmesh may be rebuilt elsewhere. That race predates this PR, but `DestroyMesh` now clears more state, widening the window slightly.
- If FPS is still short after this, next suspects are draw-call count (one `DrawPrimitive` per renderable) and `SyncAllMarkers` firing more often than expected — `QuestModule.cpp` triggers it on every path recalc.
- The hitch log only reports compositor callbacks over 60ms (`GameWorldCompositor.cpp`), so a steady per-frame drain like this never showed up in it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)