### PR TITLE
refactor(in-game rendering): share one pruned multi-plane altitude query

### DIFF
--- a/GWToolboxdll/Modules/RiverModule.cpp
+++ b/GWToolboxdll/Modules/RiverModule.cpp
@@ -38,7 +38,7 @@ namespace {
     using namespace lava_river_module;
 
     constexpr float kSampleSpacing = 50.f;            // resample a river centerline every ~50 gu (follow slopes)
-    constexpr float kAltUnknown = 1e30f;              // sentinel: no terrain data at this (x,y)
+    constexpr float kAltUnknown = TerrainDrape::kNoAltitude; // sentinel: no terrain data at this (x,y)
     constexpr size_t kMaxVertices = 1500000;          // safety cap on total surface geometry per map (raise cell_size if hit)
 
     // Settings (persisted scalars via SettingsRegistry; rivers persisted separately as JSON).
@@ -144,34 +144,6 @@ namespace {
     // Authoring state (not persisted): which river of the current map "Add point" appends to.
     int active_river = -1;
 
-    // Highest static surface at (x,y) over all planes (GW up is -z, so highest = min altitude), or sentinel.
-    float HighestSurfaceZ(const float x, const float y, const uint32_t n_planes)
-    {
-        float best = kAltUnknown;
-        for (uint32_t zp = 0; zp < n_planes; ++zp) {
-            const float a = TerrainDrape::QueryAltAt(x, y, zp);
-            if (a != 0.f && (best == kAltUnknown || a < best)) best = a;
-        }
-        return best;
-    }
-
-    // Surface altitude at (x,y) closest to `prev` (so a draped ribbon follows the walked surface across
-    // ramps/bridges instead of snapping to the ground beneath), or sentinel if no plane has data.
-    float ClosestSurfaceZ(const float x, const float y, const uint32_t n_planes, const float prev)
-    {
-        float best = kAltUnknown, best_d = kAltUnknown;
-        for (uint32_t zp = 0; zp < n_planes; ++zp) {
-            const float a = TerrainDrape::QueryAltAt(x, y, zp);
-            if (a == 0.f) continue;
-            const float d = std::fabs(a - prev);
-            if (best == kAltUnknown || d < best_d) {
-                best_d = d;
-                best = a;
-            }
-        }
-        return best;
-    }
-
     // Build a draped, textured ribbon for one river and append it to the given vertex bucket.
     void BuildRiverMesh(const LavaRiver& river, const uint32_t n_planes, std::vector<LavaVertex>& out)
     {
@@ -204,7 +176,7 @@ namespace {
         xs.reserve(dense.size());
 
         float arc = 0.f;
-        float prevz = HighestSurfaceZ(dense[0].x, dense[0].y, n_planes);
+        float prevz = TerrainDrape::HighestZ(dense[0].x, dense[0].y, n_planes);
         if (prevz == kAltUnknown) prevz = 0.f;
 
         for (size_t i = 0; i < dense.size(); ++i) {
@@ -229,11 +201,11 @@ namespace {
             const float lx = dense[i].x + px * half, ly = dense[i].y + py * half;
             const float rx = dense[i].x - px * half, ry = dense[i].y - py * half;
 
-            float lz = ClosestSurfaceZ(lx, ly, n_planes, prevz);
+            float lz = TerrainDrape::ClosestZ(lx, ly, n_planes, prevz);
             if (lz == kAltUnknown) lz = prevz;
-            float rz = ClosestSurfaceZ(rx, ry, n_planes, prevz);
+            float rz = TerrainDrape::ClosestZ(rx, ry, n_planes, prevz);
             if (rz == kAltUnknown) rz = prevz;
-            const float cz = ClosestSurfaceZ(dense[i].x, dense[i].y, n_planes, prevz);
+            const float cz = TerrainDrape::ClosestZ(dense[i].x, dense[i].y, n_planes, prevz);
             if (cz != kAltUnknown) prevz = cz;
 
             xs.push_back({lx, ly, lz - z_lift, rx, ry, rz - z_lift, arc / tile});

--- a/GWToolboxdll/Utils/TerrainDrape.cpp
+++ b/GWToolboxdll/Utils/TerrainDrape.cpp
@@ -110,6 +110,16 @@ namespace {
         }
         return false;
     }
+
+    // Plane 0 is exempt from pruning: the terrain heightfield has data outside every walkable trapezoid and draping wants it there.
+    // Containment is strict while QueryAltitude searches within its radius, so samples in the narrow band just outside a plane's edge fall through to the next surface.
+    float PrunedPlaneZ(const GW::PathingMapArray* pm, const uint32_t zp, const float x, const float y)
+    {
+        if (zp != 0 && pm) { // no pathing map to prune with -> let QueryAltitude answer, as the unpruned loops did
+            if (zp >= pm->size() || !PlaneContains((*pm)[zp], x, y)) return 0.f;
+        }
+        return TerrainDrape::QueryAltAt(x, y, zp);
+    }
 }
 
 float TerrainDrape::NativeTerrainZ(const float x, const float y)
@@ -153,6 +163,44 @@ float TerrainDrape::QueryAltAt(const float x, const float y, const uint32_t zpla
     return GW::Map::QueryAltitude(&p);
 }
 
+float TerrainDrape::HighestZ(const float x, const float y, const uint32_t n_planes)
+{
+    const GW::PathingMapArray* pm = GW::Map::GetPathingMap();
+    float best = kNoAltitude;
+    for (uint32_t zp = 0; zp < n_planes; ++zp) {
+        const float a = PrunedPlaneZ(pm, zp, x, y);
+        if (a != 0.f && (best == kNoAltitude || a < best)) best = a;
+    }
+    return best;
+}
+
+float TerrainDrape::HighestZOnPlanes(const float x, const float y, const std::span<const uint32_t> planes)
+{
+    const GW::PathingMapArray* pm = GW::Map::GetPathingMap();
+    float best = kNoAltitude;
+    for (const uint32_t zp : planes) {
+        const float a = PrunedPlaneZ(pm, zp, x, y);
+        if (a != 0.f && (best == kNoAltitude || a < best)) best = a;
+    }
+    return best;
+}
+
+float TerrainDrape::ClosestZ(const float x, const float y, const uint32_t n_planes, const float ref)
+{
+    const GW::PathingMapArray* pm = GW::Map::GetPathingMap();
+    float best = kNoAltitude, best_d = FLT_MAX;
+    for (uint32_t zp = 0; zp < n_planes; ++zp) {
+        const float a = PrunedPlaneZ(pm, zp, x, y);
+        if (a == 0.f) continue;
+        const float d = std::fabs(a - ref);
+        if (d < best_d) {
+            best_d = d;
+            best = a;
+        }
+    }
+    return best;
+}
+
 float TerrainDrape::DrapeZ(const float x, const float y, const uint32_t zplane, const uint32_t n_planes, const float ref)
 {
     float best = ref, best_d = FLT_MAX;
@@ -176,8 +224,7 @@ float TerrainDrape::DrapeZ(const float x, const float y, const uint32_t zplane, 
     if (pm) {
         const auto planes = std::min<uint32_t>(n_planes, static_cast<uint32_t>(pm->size()));
         for (uint32_t zp = 1; zp < planes; ++zp) {
-            if (!PlaneContains((*pm)[zp], x, y)) continue;
-            const float a = QueryAltAt(x, y, zp);
+            const float a = PrunedPlaneZ(pm, zp, x, y);
             if (a == 0.f) continue;
             const float d = std::fabs(a - ref);
             if (d < best_d || (d == best_d && zp == zplane)) {
@@ -204,8 +251,7 @@ float TerrainDrape::SurfaceZ(const float x, const float y, const uint32_t, const
     if (pm) {
         const auto planes = std::min<uint32_t>(n_planes, static_cast<uint32_t>(pm->size()));
         for (uint32_t zp = 1; zp < planes; ++zp) {
-            if (!PlaneContains((*pm)[zp], x, y)) continue;
-            const float a = QueryAltAt(x, y, zp);
+            const float a = PrunedPlaneZ(pm, zp, x, y);
             if (a != 0.f && (best == 0.f || a < best)) best = a;
         }
     }

--- a/GWToolboxdll/Utils/TerrainDrape.h
+++ b/GWToolboxdll/Utils/TerrainDrape.h
@@ -1,15 +1,28 @@
 #pragma once
 
 #include <cstdint>
+#include <span>
 
 // Surface-draping helpers for the in-world overlay modules (danger rings, loot beacons, skill range rings).
 // GW convention: "no altitude data" = 0.f, up is -z (highest surface = min z).
-// Plane 0 is a native heightfield read (any thread); non-zero planes use QueryAltitude, so DrapeZ/SurfaceZ are render-thread only.
+// Plane 0 is a native heightfield read (any thread); non-zero planes use QueryAltitude, so every multi-plane query here is render-thread only.
+// Multi-plane queries prune non-zero planes by trapezoid coverage before calling QueryAltitude; `drapeverify` measures that against the unpruned answer.
 namespace TerrainDrape {
     // Terrain surface z at (x,y) on plane 0 from the heightfield; 0.f when off-terrain or unloaded (native read, any thread).
     float NativeTerrainZ(float x, float y);
 
     float QueryAltAt(float x, float y, uint32_t zplane);
+
+    // "No plane had a surface" for the queries below; GW's 0.f means one plane has no data, which is still foldable into a multi-plane search.
+    inline constexpr float kNoAltitude = 3.402823466e+38f; // FLT_MAX; matches PropSurface::kNoData
+
+    float HighestZ(float x, float y, uint32_t n_planes);
+
+    // Restricted to `planes` so a shape can't drape onto an unrelated deck overhead.
+    float HighestZOnPlanes(float x, float y, std::span<const uint32_t> planes);
+
+    // Continuity draping: follows the surface a line actually walks across ramps and bridges.
+    float ClosestZ(float x, float y, uint32_t n_planes, float ref);
 
     // Surface altitude at (x,y) closest to `ref`: terrain + prop surfaces once the PropSurface index is baked, else terrain + walkable planes.
     float DrapeZ(float x, float y, uint32_t zplane, uint32_t n_planes, float ref);

--- a/GWToolboxdll/Widgets/Minimap/GameWorldRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/GameWorldRenderer.cpp
@@ -119,32 +119,7 @@ namespace {
         return a * t + b * (1.f - t);
     }
 
-    constexpr auto ALTITUDE_UNKNOWN = std::numeric_limits<float>::max();
-
-    // Highest static surface at (x,y) among candidate planes (GW up is -z, so highest = min altitude). QueryAltitude returns 0.f out-of-bounds (ignored); ALTITUDE_UNKNOWN if no plane has data.
-    float HighestSurfaceZ(const float x, const float y, const std::vector<uint32_t>& planes)
-    {
-        float best = ALTITUDE_UNKNOWN;
-        for (const uint32_t zp : planes) {
-            const float a = TerrainDrape::QueryAltAt(x, y, zp);
-            if (a != 0.f && (best == ALTITUDE_UNKNOWN || a < best))
-                best = a;
-        }
-        return best;
-    }
-
-    // Surface altitude at (x,y) closest to `prev` over all planes (continuity tracking): the line follows whichever surface it walks (deck/ramp/ground), so a straight visgraph edge rides a bridge instead of cutting through, and unlike "highest wins" never floats a ground sample onto an overhead deck. 0.f is out-of-bounds (skipped); ALTITUDE_UNKNOWN if no data.
-    float ClosestSurfaceZ(const float x, const float y, const uint32_t num_planes, const float prev)
-    {
-        float best = ALTITUDE_UNKNOWN, best_d = std::numeric_limits<float>::max();
-        for (uint32_t zp = 0; zp < num_planes; ++zp) {
-            const float a = TerrainDrape::QueryAltAt(x, y, zp);
-            if (a == 0.f) continue;
-            const float d = std::abs(a - prev);
-            if (d < best_d) { best_d = d; best = a; }
-        }
-        return best;
-    }
+    constexpr auto ALTITUDE_UNKNOWN = TerrainDrape::kNoAltitude;
 
     // ===== Batched navmesh-overlay line buffer =====
     // One line-list buffer for the navmesh overlay's tens of thousands of edges (per-line CustomLines were O(N^2) per map-load and re-draped on every move): drape it incrementally on the game thread, draw in a single call, render-thread only (no mutex).
@@ -188,7 +163,7 @@ namespace {
             auto surfaceZ = [&](float x, float y, float fallback) -> float {
                 const float a = TerrainDrape::QueryAltAt(x, y, plane);
                 if (a != 0.f) return a;                                      // edge's plane has floor here (the common case)
-                const float c = ClosestSurfaceZ(x, y, num_planes, fallback); // only at an edge lip with no plane surface
+                const float c = TerrainDrape::ClosestZ(x, y, num_planes, fallback); // only at an edge lip with no plane surface
                 return c == ALTITUDE_UNKNOWN ? fallback : c;
             };
             float prev = surfaceZ(ln.a.x, ln.a.y, 0.f);
@@ -309,7 +284,7 @@ namespace {
                     candidate_planes.push_back(pt.zplane);
             }
             for (size_t i = poly.vertices_processed; i < vertices.size(); i++, poly.vertices_processed++)
-                vertices[i].z = HighestSurfaceZ(vertices[i].x, vertices[i].y, candidate_planes);
+                vertices[i].z = TerrainDrape::HighestZOnPlanes(vertices[i].x, vertices[i].y, candidate_planes);
         }
         else {
             // Ordered path: drape on the navmesh-walkable plane at each sample, closest to the running height, so it
@@ -318,7 +293,7 @@ namespace {
             auto* nav = PathfindingWindow::GetResidentNavMesh();
             GW::GamePos seed_pos = poly.points.empty() ? GW::GamePos{} : poly.points.front();
             float prev = TerrainDrape::QueryAltAt(seed_pos.x, seed_pos.y, seed_pos.zplane);
-            if (prev == 0.f) prev = ClosestSurfaceZ(seed_pos.x, seed_pos.y, num_planes, -1.0e9f); // highest surface
+            if (prev == 0.f) prev = TerrainDrape::ClosestZ(seed_pos.x, seed_pos.y, num_planes, -1.0e9f); // highest surface
             for (size_t i = poly.vertices_processed; i < vertices.size(); i++, poly.vertices_processed++) {
                 float z;
                 if (nav) {
@@ -326,7 +301,7 @@ namespace {
                     if (z == ALTITUDE_UNKNOWN) z = prev; // over a gap with no walkable poly: hold height, don't sink to the ground
                 }
                 else {
-                    z = ClosestSurfaceZ(vertices[i].x, vertices[i].y, num_planes, prev); // navmesh not built yet
+                    z = TerrainDrape::ClosestZ(vertices[i].x, vertices[i].y, num_planes, prev); // navmesh not built yet
                 }
                 if (z != ALTITUDE_UNKNOWN) prev = z;
                 vertices[i].z = z;
@@ -453,7 +428,7 @@ void GameWorldRenderer::GenericPolyRenderable::Draw(IDirect3DDevice9* device)
                     if (z == ALTITUDE_UNKNOWN) z = prev; // gap with no walkable poly: hold height, don't sink to the ground
                 }
                 else {
-                    z = num_planes ? ClosestSurfaceZ(sx, sy, num_planes, prev) : ALTITUDE_UNKNOWN; // navmesh not built yet
+                    z = num_planes ? TerrainDrape::ClosestZ(sx, sy, num_planes, prev) : ALTITUDE_UNKNOWN; // navmesh not built yet
                 }
                 if (z != ALTITUDE_UNKNOWN) prev = z; else z = prev;
                 vertices[j].x = sx;


### PR DESCRIPTION
Follow-up to #2482. That PR removed the point-location cost from `NavMesh::DrapeHeightAt`; this one removes redundant `QueryAltitude` calls from the multi-plane queries that #2482 didn't touch.

## Problem

`GameWorldRenderer` and `RiverModule` each carried their own `HighestSurfaceZ` / `ClosestSurfaceZ` — four copies of the same all-planes `QueryAltitude` loop, with three different "no data" sentinels between them (`FLT_MAX` in one file, `1e30f` in the other).

None of the four pruned. Every one called into the game on *every* plane, including planes whose trapezoids are nowhere near the sample point. `TerrainDrape::SurfaceZ`/`DrapeZ` have skipped those planes since they landed — the renderer's local copies never got the same treatment.

## Change

Collapse the four into three shared queries:

| was | now |
|---|---|
| `GameWorldRenderer::HighestSurfaceZ` (candidate planes) | `TerrainDrape::HighestZOnPlanes` |
| `GameWorldRenderer::ClosestSurfaceZ` | `TerrainDrape::ClosestZ` |
| `RiverModule::HighestSurfaceZ` | `TerrainDrape::HighestZ` |
| `RiverModule::ClosestSurfaceZ` | `TerrainDrape::ClosestZ` |

All three route through one `PrunedPlaneZ`, which is now the single home of the pruning rule (plane 0 exempt: the terrain heightfield has data outside every walkable trapezoid, and draping wants it there). `SurfaceZ` and `DrapeZ` go through it too, so their open-coded `PlaneContains` + `QueryAltAt` pairs are gone and the rule lives in exactly one place.

`RiverModule`'s `kAltUnknown` and `GameWorldRenderer`'s `ALTITUDE_UNKNOWN` now both alias `TerrainDrape::kNoAltitude`. Every `kAltUnknown` use was an equality test, so the value change (`1e30f` -> `FLT_MAX`) is inert.

## Verification

**Not built for Windows — no MSVC toolchain in this environment.**

Checked by a standalone differential harness instead: all four old helpers against the three new ones, 200k random points over 7 synthetic overlapping plane layouts (including a plane declared but covering nothing). The new queries reproduce all four old helpers exactly, sentinels included, when `QueryAltitude`'s search radius is 0.

## Behaviour note — worth a look before merge

`QueryAltitude` takes a `radius` (default 5.f) and will return a plane's surface for a point slightly *outside* that plane's trapezoids. Containment here is strict, so those samples are now pruned and fall through to the next surface down. Re-running the harness with radius=5 diverges on 3-5% of points — inflated by the synthetic layout's small trapezoids, which over-represent edge-adjacency, but not zero.

This is the tradeoff `SurfaceZ`/`DrapeZ` already ship, which is why I matched it rather than adding tolerance. But it's newly applied to the river ribbon and the navmesh overlay. The place it would show first is the deck-lip fallback in `StepNavmeshBatchBuild` (`GameWorldRenderer.cpp:166`): a line running along a deck edge could snap down to the ground where it previously held the deck height.

`drapeverify` measures exactly this — worth a run on a multi-level map (Cathedral of Flames, or an outpost with bridges). If it does show, the fix is to inflate the containment test by the query radius rather than revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)