### PR TITLE
Cartographer/Pathing: fix the two dev build breaks

### DIFF
--- a/GWToolboxdll/Widgets/CartographerWidget.cpp
+++ b/GWToolboxdll/Widgets/CartographerWidget.cpp
@@ -601,7 +601,7 @@ namespace {
 
     bool ContextMenuItems(const GW::Vec2f& click_wm, const float px_per_wm_unit)
     {
-        if (!GetEnabled()) return true;
+        if (!CartographerWidget::GetEnabled()) return true;
         bool keep_open = true;
         ImGui::PushID("carto_ctx");
         ImGui::Separator();
@@ -852,7 +852,7 @@ namespace {
 
     void OnWorldMapOverlayDraw(ImDrawList* dl)
     {
-        if (!GetEnabled() || !map_on_world_map) return;
+        if (!CartographerWidget::GetEnabled() || !map_on_world_map) return;
         DrawMapOverlay(dl, [](const GW::Vec2f& wm, ImVec2& out) { return WorldMapWidget::WorldMapToScreen(wm, out); }, true);
         char status[160];
         BuildStatusText(status, sizeof(status));
@@ -863,7 +863,7 @@ namespace {
 
     void OnMissionMapOverlayDraw(ImDrawList* dl)
     {
-        if (!GetEnabled() || !map_on_world_map) return;
+        if (!CartographerWidget::GetEnabled() || !map_on_world_map) return;
         DrawMapOverlay(dl, [](const GW::Vec2f& wm, ImVec2& out) { return MissionMapWidget::WorldMapToScreen(wm, out); }, false);
     }
 } // namespace

--- a/GWToolboxdll/Windows/Pathfinding/Pathing.cpp
+++ b/GWToolboxdll/Windows/Pathfinding/Pathing.cpp
@@ -724,7 +724,7 @@ namespace Pathing {
         return closest;
     }
 
-    uint32_t FileHashToFileId(wchar_t* param_1)
+    uint32_t FileHashToFileId(const wchar_t* param_1)
     {
         if (!param_1) return 0;
         if (((0xff < *param_1) && (0xff < param_1[1])) && ((param_1[2] == 0 || ((0xff < param_1[2] && (param_1[3] == 0)))))) {


### PR DESCRIPTION
Two build fixes for `dev`, both verified with a full compile + link of `GWToolboxdll` via `scripts/build-wine-prefix.sh` (real MSVC x86 under Wine).

### 1. `error C3861: 'GetEnabled': identifier not found` — CartographerWidget.cpp

`GetEnabled()` is a static member of `CartographerWidget`, but three callers — `ContextMenuItems`, `OnWorldMapOverlayDraw` and `OnMissionMapOverlayDraw` — live in the file's anonymous namespace rather than in a member function, so the unqualified name never resolved.

MSVC reported the first; the other two are the same mistake and would have surfaced next. Cause: the widget conversion swapped a namespace-scope `enabled` bool for the inherited `visible`, and every read was rewritten as `GetEnabled()` without checking which side of the namespace boundary it sat on.

### 2. `error C2664: cannot convert 'const wchar_t *' to 'wchar_t *'` — Pathing.cpp

`PropModelInfo::model_file_name` is a `const wchar_t*`, but `Pathing.cpp`'s local copy of the hash decode took a mutable one despite only ever reading through it. `ArenaNetFileParser::FileHashToFileId` was already const-correct, which is why the WorldMapWidget, InfoWindow and PathingMapDataLoader call sites built fine.

### Build result

```
[59/60] Linking CXX shared library /src/bin/GWToolboxdll.dll
```

Clean — zero `error C####` / `error LNK####`, under `/W4 /WX`.

Not a runtime test: none of the cartography behaviour has been exercised in-game.

### Follow-up, not included

`Pathing.cpp`'s local `FileHashToFileId` is a straight duplicate of `ArenaNetFileParser::FileHashToFileId`. Left alone here to keep the fix minimal, but it could be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)