### PR TITLE
Cartographer: debug bake of per-continent standable squares

### DIFF
--- a/GWToolboxdll/Widgets/CartographerWidget.cpp
+++ b/GWToolboxdll/Widgets/CartographerWidget.cpp
@@ -601,7 +601,7 @@ namespace {
 
     bool ContextMenuItems(const GW::Vec2f& click_wm, const float px_per_wm_unit)
     {
-        if (!GetEnabled()) return true;
+        if (!CartographerWidget::GetEnabled()) return true;
         bool keep_open = true;
         ImGui::PushID("carto_ctx");
         ImGui::Separator();
@@ -852,7 +852,7 @@ namespace {
 
     void OnWorldMapOverlayDraw(ImDrawList* dl)
     {
-        if (!GetEnabled() || !map_on_world_map) return;
+        if (!CartographerWidget::GetEnabled() || !map_on_world_map) return;
         DrawMapOverlay(dl, [](const GW::Vec2f& wm, ImVec2& out) { return WorldMapWidget::WorldMapToScreen(wm, out); }, true);
         char status[160];
         BuildStatusText(status, sizeof(status));
@@ -863,7 +863,7 @@ namespace {
 
     void OnMissionMapOverlayDraw(ImDrawList* dl)
     {
-        if (!GetEnabled() || !map_on_world_map) return;
+        if (!CartographerWidget::GetEnabled() || !map_on_world_map) return;
         DrawMapOverlay(dl, [](const GW::Vec2f& wm, ImVec2& out) { return MissionMapWidget::WorldMapToScreen(wm, out); }, false);
     }
 } // namespace

--- a/GWToolboxdll/Widgets/CartographerWidget.cpp
+++ b/GWToolboxdll/Widgets/CartographerWidget.cpp
@@ -16,6 +16,12 @@
 #include <ImGuiAddons.h>
 #include <Logger.h>
 #include <Timer.h>
+#ifdef _DEBUG
+#include <fstream>
+#include <Modules/Resources.h>
+#include <Windows/Pathfinding/PathingMapDataLoader.h>
+#include <Windows/Pathfinding/PathfindingWindow.h>
+#endif
 #include <Utils/SettingsRegistry.h>
 #include <Utils/ToolboxUtils.h>
 #include <Widgets/CartographerWidget.h>
@@ -556,6 +562,212 @@ namespace {
         CARTO_LOG("[cartographer] custom fog point added at wm(%.0f, %.0f)", wm.x, wm.y);
     }
 
+
+#ifdef _DEBUG
+    // Bakes, per continent, which 32x32 tiles have ground you can stand on. Everything it needs is
+    // reachable without visiting a map: constant_maps_info gives the DAT file, AreaInfo gives the
+    // continent and world-map bounds, and the DAT gives the trapezoids. Stores standable rather
+    // than discoverable so the reveal radius stays a runtime choice.
+    struct ContinentBake {
+        std::unordered_set<uint64_t> standable; // (cy << 32) | (uint32)cx
+        int maps = 0;
+    };
+
+    struct BakeState {
+        bool running = false;
+        size_t next = 0;
+        std::vector<GW::Constants::MapID> queue;
+        std::map<int, ContinentBake> continents;
+        int on_world_map = 0;
+        int no_file_id = 0;
+        int load_failed = 0;
+        int no_bounds = 0;
+        clock_t started = 0;
+        std::string summary;
+    };
+    BakeState bake;
+
+    uint64_t TileKey(const int cx, const int cy)
+    {
+        return static_cast<uint64_t>(static_cast<uint32_t>(cy)) << 32 | static_cast<uint32_t>(cx);
+    }
+
+    // Trapezoids reachable from the map's largest connected component. Planes are all treated as
+    // open - which of them are blocked comes from the server at runtime - so this only drops
+    // genuinely disconnected geometry, which is what "pathable but not accessible" means offline.
+    std::unordered_set<const GW::PathingTrapezoid*> LargestComponent(const Pathing::PathingMapData& data)
+    {
+        std::unordered_map<const GW::PathingTrapezoid*, size_t> plane_of;
+        std::vector<const GW::PathingTrapezoid*> all;
+        for (size_t p = 0; p < data.planes.size(); p++) {
+            const auto& plane = data.planes[p];
+            for (uint32_t t = 0; t < plane.trapezoid_count; t++) {
+                plane_of[&plane.trapezoids[t]] = p;
+                all.push_back(&plane.trapezoids[t]);
+            }
+        }
+
+        std::unordered_set<const GW::PathingTrapezoid*> seen;
+        std::unordered_set<const GW::PathingTrapezoid*> best;
+        for (const auto* root : all) {
+            if (seen.contains(root)) continue;
+            std::unordered_set<const GW::PathingTrapezoid*> component;
+            std::vector<const GW::PathingTrapezoid*> queue{root};
+            component.insert(root);
+            seen.insert(root);
+            for (size_t head = 0; head < queue.size(); head++) {
+                const auto* trap = queue[head];
+                const auto expand = [&](const GW::PathingTrapezoid* next) {
+                    if (!next || !component.insert(next).second) return;
+                    seen.insert(next);
+                    queue.push_back(next);
+                };
+                for (const auto* adj : trap->adjacent) expand(adj);
+                const auto it = plane_of.find(trap);
+                if (it == plane_of.end() || it->second >= data.planes.size()) continue;
+                const auto& plane = data.planes[it->second];
+                const auto expand_portal = [&](const uint16_t idx) {
+                    if (idx >= plane.portal_count) return;
+                    const auto& portal = plane.portals[idx];
+                    if (portal.flags & 0x04) return;
+                    const auto* pair = portal.pair;
+                    if (!pair) return;
+                    for (uint32_t i = 0; i < pair->count; i++) expand(pair->trapezoids[i]);
+                };
+                expand_portal(trap->portal_left);
+                expand_portal(trap->portal_right);
+            }
+            if (component.size() > best.size()) best = std::move(component);
+        }
+        return best;
+    }
+
+    void BakeMap(const GW::Constants::MapID map_id, const int continent)
+    {
+        const uint32_t file_id = PathfindingWindow::GetMapFileId(map_id);
+        if (!file_id) {
+            bake.no_file_id++;
+            return;
+        }
+        Pathing::PathingMapData data;
+        if (!Pathing::LoadPathingMapDataFromDAT(file_id, &data)) {
+            bake.load_failed++;
+            return;
+        }
+        const auto component = LargestComponent(data);
+        auto& out = bake.continents[continent];
+        int marked = 0;
+        for (const auto& plane : data.planes) {
+            for (uint32_t t = 0; t < plane.trapezoid_count; t++) {
+                const auto& trap = plane.trapezoids[t];
+                if (!component.contains(&trap)) continue;
+                // The trapezoid's game-space box, converted through this map's own anchor. A tile
+                // is 3072 gwinches, so taking the box rather than the exact quad costs at most a
+                // sliver of over-marking on a slanted edge.
+                GW::GamePos lo{}, hi{};
+                lo.x = std::min(trap.XTL, trap.XBL);
+                lo.y = trap.YB;
+                hi.x = std::max(trap.XTR, trap.XBR);
+                hi.y = trap.YT;
+                GW::Vec2f a{}, b{};
+                if (!WorldMapWidget::GamePosToWorldMap(lo, a, map_id)) continue;
+                if (!WorldMapWidget::GamePosToWorldMap(hi, b, map_id)) continue;
+                const int x0 = static_cast<int>(floorf(std::min(a.x, b.x) / kWorldMapUnitsPerCell));
+                const int x1 = static_cast<int>(floorf(std::max(a.x, b.x) / kWorldMapUnitsPerCell));
+                const int y0 = static_cast<int>(floorf(std::min(a.y, b.y) / kWorldMapUnitsPerCell));
+                const int y1 = static_cast<int>(floorf(std::max(a.y, b.y) / kWorldMapUnitsPerCell));
+                for (int cy = y0; cy <= y1; cy++) {
+                    for (int cx = x0; cx <= x1; cx++) {
+                        if (out.standable.insert(TileKey(cx, cy)).second) marked++;
+                    }
+                }
+            }
+        }
+        out.maps++;
+        CARTO_LOG("[carto-bake] map %d (file 0x%X, continent %d): %d planes, +%d tiles",
+                  static_cast<int>(map_id), file_id, continent, static_cast<int>(data.planes.size()), marked);
+    }
+
+    void WriteBakeFiles()
+    {
+        for (const auto& [continent, data] : bake.continents) {
+            if (data.standable.empty()) continue;
+            int x0 = INT_MAX, y0 = INT_MAX, x1 = INT_MIN, y1 = INT_MIN;
+            for (const auto key : data.standable) {
+                const int cx = static_cast<int>(static_cast<uint32_t>(key & 0xffffffff));
+                const int cy = static_cast<int>(static_cast<uint32_t>(key >> 32));
+                x0 = std::min(x0, cx);
+                x1 = std::max(x1, cx);
+                y0 = std::min(y0, cy);
+                y1 = std::max(y1, cy);
+            }
+            const int w = x1 - x0 + 1;
+            const int h = y1 - y0 + 1;
+            std::vector<uint8_t> bits((static_cast<size_t>(w) * h + 7) / 8, 0);
+            for (const auto key : data.standable) {
+                const int cx = static_cast<int>(static_cast<uint32_t>(key & 0xffffffff)) - x0;
+                const int cy = static_cast<int>(static_cast<uint32_t>(key >> 32)) - y0;
+                const size_t bit = static_cast<size_t>(cy) * w + cx;
+                bits[bit >> 3] |= 1 << (bit & 7);
+            }
+            const int32_t header[5] = {continent, x0, y0, w, h};
+            const auto path = Resources::GetPath(L"cartography", std::format(L"standable_L{}.bin", continent));
+            std::ofstream file(path, std::ios::binary);
+            if (!file) {
+                CARTO_LOG("[carto-bake] could not write %ls", path.wstring().c_str());
+                continue;
+            }
+            file.write("CSM1", 4);
+            file.write(reinterpret_cast<const char*>(header), sizeof(header));
+            file.write(reinterpret_cast<const char*>(bits.data()), static_cast<std::streamsize>(bits.size()));
+            CARTO_LOG("[carto-bake] continent %d: %d maps, %u tiles, grid %dx%d at (%d,%d), %u bytes",
+                      continent, data.maps, static_cast<unsigned>(data.standable.size()), w, h, x0, y0,
+                      static_cast<unsigned>(bits.size()));
+        }
+    }
+
+    void StartBake()
+    {
+        bake = {};
+        bake.started = TIMER_INIT();
+        for (size_t i = 1; i < static_cast<size_t>(GW::Constants::MapID::Count); i++) {
+            const auto map_id = static_cast<GW::Constants::MapID>(i);
+            const auto* info = GW::Map::GetMapInfo(map_id);
+            if (!(info && info->GetIsOnWorldMap())) continue;
+            bake.on_world_map++;
+            ImRect bounds;
+            if (!GW::Map::GetMapWorldMapBounds(info, &bounds)) {
+                bake.no_bounds++;
+                continue;
+            }
+            bake.queue.push_back(map_id);
+        }
+        bake.running = true;
+        bake.summary = std::format("{} maps on the world map, queued", bake.queue.size());
+    }
+
+    // One map per tick: a DAT parse is far too slow to loop over ~450 of them in a frame.
+    void StepBake()
+    {
+        if (!bake.running) return;
+        if (bake.next >= bake.queue.size()) {
+            WriteBakeFiles();
+            bake.running = false;
+            unsigned tiles = 0;
+            for (const auto& [continent, data] : bake.continents) tiles += static_cast<unsigned>(data.standable.size());
+            bake.summary = std::format("done in {:.1f}s: {} continents, {} tiles, {} maps skipped (no DAT file), {} failed to load, {} without bounds",
+                                       TIMER_DIFF(bake.started) / 1000.f, bake.continents.size(), tiles,
+                                       bake.no_file_id, bake.load_failed, bake.no_bounds);
+            CARTO_LOG("[carto-bake] %s", bake.summary.c_str());
+            return;
+        }
+        const auto map_id = bake.queue[bake.next++];
+        const auto* info = GW::Map::GetMapInfo(map_id);
+        if (info) BakeMap(map_id, static_cast<int>(info->continent));
+        bake.summary = std::format("{}/{} maps...", bake.next, bake.queue.size());
+    }
+#endif
+
     void OnCartographyUpdated(GW::HookStatus*, GW::UI::UIMessage, void*, void*)
     {
         carto_dirty = true;
@@ -904,6 +1116,9 @@ void CartographerWidget::LoadSettings(SettingsDoc& doc, ToolboxIni* legacy)
 
 void CartographerWidget::Update(float)
 {
+#ifdef _DEBUG
+    StepBake();
+#endif
     if (!GetEnabled()) {
         if (target.valid) ResetState();
         return;
@@ -1171,7 +1386,42 @@ void CartographerWidget::DrawSettingsInternal()
     ImGui::Separator();
     ImGui::TextDisabled("This map: %u squares probed, %u standable, %u worth visiting", static_cast<unsigned>(probe->cells.size()), standable, useful);
     ImGui::TextDisabled("Foggy squares: %d reachable here, %d out of reach", map_fog_cells, unreachable_fog_cells);
+#ifdef _DEBUG
+    DrawBakeSettings();
+#endif
 }
+
+#ifdef _DEBUG
+void CartographerWidget::DrawBakeSettings()
+{
+    ImGui::Separator();
+    ImGui::Text("Continent bake (debug)");
+    ImGui::TextDisabled("Reads every world-map map's pathing data out of the DAT and records which\n32x32 squares have standable ground, per continent. One map per frame, so it\nruns for a while; results go to Settings/cartography/standable_L<n>.bin.");
+    ImGui::BeginDisabled(bake.running);
+    if (ImGui::Button("Bake standable squares for all continents")) {
+        GW::GameThread::Enqueue([] { StartBake(); });
+    }
+    ImGui::EndDisabled();
+    if (bake.running) {
+        ImGui::SameLine();
+        if (ImGui::Button("Cancel")) {
+            GW::GameThread::Enqueue([] {
+                bake.running = false;
+                bake.summary = "cancelled";
+            });
+        }
+        ImGui::ProgressBar(bake.queue.empty() ? 0.f : static_cast<float>(bake.next) / bake.queue.size());
+    }
+    if (!bake.summary.empty()) ImGui::TextWrapped("%s", bake.summary.c_str());
+    if (bake.on_world_map) {
+        ImGui::TextDisabled("%d maps on the world map; %d had no DAT file, %d failed to load, %d had no bounds",
+                            bake.on_world_map, bake.no_file_id, bake.load_failed, bake.no_bounds);
+    }
+    for (const auto& [continent, data] : bake.continents) {
+        ImGui::TextDisabled("  continent %d: %d maps, %u standable squares", continent, data.maps, static_cast<unsigned>(data.standable.size()));
+    }
+}
+#endif
 
 void CartographerWidget::SetEnabled(const bool on)
 {

--- a/GWToolboxdll/Widgets/CartographerWidget.h
+++ b/GWToolboxdll/Widgets/CartographerWidget.h
@@ -60,4 +60,8 @@ public:
     static void ClearCustomPoints();
     static void ClearDeclined();
     static void GetStatus(char* buf, size_t len);
+#ifdef _DEBUG
+    // Debug-only: bake the per-continent standable-square matrix out of the DAT.
+    static void DrawBakeSettings();
+#endif
 };

--- a/GWToolboxdll/Windows/Pathfinding/Pathing.cpp
+++ b/GWToolboxdll/Windows/Pathfinding/Pathing.cpp
@@ -724,7 +724,7 @@ namespace Pathing {
         return closest;
     }
 
-    uint32_t FileHashToFileId(wchar_t* param_1)
+    uint32_t FileHashToFileId(const wchar_t* param_1)
     {
         if (!param_1) return 0;
         if (((0xff < *param_1) && (0xff < param_1[1])) && ((param_1[2] == 0 || ((0xff < param_1[2] && (param_1[3] == 0)))))) {


### PR DESCRIPTION
Adds a debug-only button + status log in the Cartographer settings that bakes, per continent, which 32x32 world-map squares have standable ground.

**Stacked on #2488** — the two commits under this one are that PR's build fixes, without which `dev` doesn't compile. Rebasing onto `dev` after #2488 merges drops them by patch-id.

## What it does

Everything needed is reachable without visiting a map:

| need | source |
|---|---|
| map id → DAT file | `constant_maps_info` |
| map id → continent + world-map bounds | `GW::Map::GetMapInfo` / `GetMapWorldMapBounds` (AreaInfo is global) |
| file id → trapezoids | `Pathing::LoadPathingMapDataFromDAT` |
| game → world-map | `WorldMapWidget::GamePosToWorldMap(pos, out, map_id)` |

For every map with `GetIsOnWorldMap()`: load its pathing data, keep the **largest connected component** (adjacency + unblocked portals; all planes treated as open, since blocked-plane state only exists at runtime), convert each trapezoid through that map's own world-map anchor, mark the squares it covers, union per continent.

Runs **one map per frame** from `Update` — a DAT parse is far too slow to loop ~450 of them in a frame — and works whether or not the helper is enabled.

## Why standable and not discoverable

Discoverable is standable dilated by the reveal radius, and that radius is 1 or 3 depending on the Bird's Eye Compass. Baking discoverable would freeze a runtime choice; baking standable answers both, and the dilation is trivial.

## Status log

Live `n/total` progress with a cancel, then the counts needed to judge coverage — maps on the world map, how many had no DAT file, failed to load, or had no bounds — plus per-continent map and square totals. That answers the coverage question directly rather than by estimate.

## Output

`Settings/cartography/standable_L<n>.bin` — `CSM1` magic, continent, origin square, grid dims, one bit per square.

## Deliberate simplifications

- Trapezoids are rasterized by their **game-space box**, not the exact quad. At 3072 gwinches per square the over-mark on a slanted edge is a sliver.
- The component filter has **no seed** — `SpawnPoint` is declared in `maps_constant_data.h` but has no table behind it, so it keeps the largest component. Portal-prop seeding is the better version if that ever picks the wrong one.

## Testing

Compiles and links clean in `Debug` (the config it's gated to) via `scripts/build-wine-prefix.sh`. **The bake has never been run** — that needs a client, and the status log exists so its first run reports what it actually found rather than what I assumed.

Known limitation: this yields *revealable*, not *counts toward cartography %*. Reachable coastal water will mark as standable-adjacent because it genuinely is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)