### PR TITLE
Cartographer: drop the runtime bake

### DIFF
--- a/GWToolboxdll/Widgets/CartographerWidget.cpp
+++ b/GWToolboxdll/Widgets/CartographerWidget.cpp
@@ -16,12 +16,6 @@
 #include <ImGuiAddons.h>
 #include <Logger.h>
 #include <Timer.h>
-#ifdef _DEBUG
-#include <fstream>
-#include <Modules/Resources.h>
-#include <Windows/Pathfinding/PathingMapDataLoader.h>
-#include <Windows/Pathfinding/PathfindingWindow.h>
-#endif
 #include <Utils/SettingsRegistry.h>
 #include <Utils/ToolboxUtils.h>
 #include <Widgets/CartographerWidget.h>
@@ -631,223 +625,6 @@ namespace {
     }
 
 
-#ifdef _DEBUG
-    // Bakes, per continent, which 32x32 tiles have ground you can stand on. Everything it needs is
-    // reachable without visiting a map: the file id comes from GetMapFileId, AreaInfo gives the
-    // continent and world-map bounds, and the DAT gives the trapezoids. Stores standable rather
-    // than discoverable so the reveal radius stays a runtime choice.
-    struct ContinentBake {
-        std::unordered_set<uint64_t> standable; // (cy << 32) | (uint32)cx
-        int maps = 0;
-    };
-
-    struct BakeState {
-        bool running = false;
-        size_t next = 0;
-        std::vector<GW::Constants::MapID> queue;
-        std::map<int, ContinentBake> continents;
-        int on_world_map = 0;
-        int no_file_id = 0;
-        int area_fid_agrees = 0;
-        int area_fid_differs = 0;
-        int area_fid_missing = 0;
-        int load_failed = 0;
-        int no_bounds = 0;
-        clock_t started = 0;
-        std::string summary;
-    };
-    BakeState bake;
-
-    uint64_t TileKey(const int cx, const int cy)
-    {
-        return static_cast<uint64_t>(static_cast<uint32_t>(cy)) << 32 | static_cast<uint32_t>(cx);
-    }
-
-    // Trapezoids reachable from the map's largest connected component. Planes are all treated as
-    // open - which of them are blocked comes from the server at runtime - so this only drops
-    // genuinely disconnected geometry, which is what "pathable but not accessible" means offline.
-    std::unordered_set<const GW::PathingTrapezoid*> LargestComponent(const Pathing::PathingMapData& data)
-    {
-        std::unordered_map<const GW::PathingTrapezoid*, size_t> plane_of;
-        std::vector<const GW::PathingTrapezoid*> all;
-        for (size_t p = 0; p < data.planes.size(); p++) {
-            const auto& plane = data.planes[p];
-            for (uint32_t t = 0; t < plane.trapezoid_count; t++) {
-                plane_of[&plane.trapezoids[t]] = p;
-                all.push_back(&plane.trapezoids[t]);
-            }
-        }
-
-        std::unordered_set<const GW::PathingTrapezoid*> seen;
-        std::unordered_set<const GW::PathingTrapezoid*> best;
-        for (const auto* root : all) {
-            if (seen.contains(root)) continue;
-            std::unordered_set<const GW::PathingTrapezoid*> component;
-            std::vector<const GW::PathingTrapezoid*> queue{root};
-            component.insert(root);
-            seen.insert(root);
-            for (size_t head = 0; head < queue.size(); head++) {
-                const auto* trap = queue[head];
-                const auto expand = [&](const GW::PathingTrapezoid* next) {
-                    if (!next || !component.insert(next).second) return;
-                    seen.insert(next);
-                    queue.push_back(next);
-                };
-                for (const auto* adj : trap->adjacent) expand(adj);
-                const auto it = plane_of.find(trap);
-                if (it == plane_of.end() || it->second >= data.planes.size()) continue;
-                const auto& plane = data.planes[it->second];
-                const auto expand_portal = [&](const uint16_t idx) {
-                    if (idx >= plane.portal_count) return;
-                    const auto& portal = plane.portals[idx];
-                    if (portal.flags & 0x04) return;
-                    const auto* pair = portal.pair;
-                    if (!pair) return;
-                    for (uint32_t i = 0; i < pair->count; i++) expand(pair->trapezoids[i]);
-                };
-                expand_portal(trap->portal_left);
-                expand_portal(trap->portal_right);
-            }
-            if (component.size() > best.size()) best = std::move(component);
-        }
-        return best;
-    }
-
-    // Loads through GetMapFileId, which is the known-good path. AreaInfo::file_id is recorded
-    // alongside it but not trusted yet: nothing validates that it names a map file - readFromDat's
-    // second argument is a stream id, not a type - so a wrong id just yields no pathfinding chunk
-    // and looks like a load failure. The counters below are here to settle whether AreaInfo alone
-    // would do, since that is the version that survives a game update without a table in the repo.
-    void BakeMap(const GW::Constants::MapID map_id, const GW::AreaInfo* info, const int continent)
-    {
-        const uint32_t file_id = PathfindingWindow::GetMapFileId(map_id);
-        const uint32_t area_file_id = info ? info->file_id : 0;
-        if (!area_file_id) bake.area_fid_missing++;
-        else if (area_file_id == file_id) bake.area_fid_agrees++;
-        else bake.area_fid_differs++;
-        if (!file_id) {
-            bake.no_file_id++;
-            return;
-        }
-        Pathing::PathingMapData data;
-        if (!Pathing::LoadPathingMapDataFromDAT(file_id, &data)) {
-            bake.load_failed++;
-            return;
-        }
-        const auto component = LargestComponent(data);
-        auto& out = bake.continents[continent];
-        int marked = 0;
-        for (const auto& plane : data.planes) {
-            for (uint32_t t = 0; t < plane.trapezoid_count; t++) {
-                const auto& trap = plane.trapezoids[t];
-                if (!component.contains(&trap)) continue;
-                // The trapezoid's game-space box, converted through this map's own anchor. A tile
-                // is 3072 gwinches, so taking the box rather than the exact quad costs at most a
-                // sliver of over-marking on a slanted edge.
-                GW::GamePos lo{}, hi{};
-                lo.x = std::min(trap.XTL, trap.XBL);
-                lo.y = trap.YB;
-                hi.x = std::max(trap.XTR, trap.XBR);
-                hi.y = trap.YT;
-                GW::Vec2f a{}, b{};
-                if (!WorldMapWidget::GamePosToWorldMap(lo, a, map_id)) continue;
-                if (!WorldMapWidget::GamePosToWorldMap(hi, b, map_id)) continue;
-                const int x0 = static_cast<int>(floorf(std::min(a.x, b.x) / kWorldMapUnitsPerCell));
-                const int x1 = static_cast<int>(floorf(std::max(a.x, b.x) / kWorldMapUnitsPerCell));
-                const int y0 = static_cast<int>(floorf(std::min(a.y, b.y) / kWorldMapUnitsPerCell));
-                const int y1 = static_cast<int>(floorf(std::max(a.y, b.y) / kWorldMapUnitsPerCell));
-                for (int cy = y0; cy <= y1; cy++) {
-                    for (int cx = x0; cx <= x1; cx++) {
-                        if (out.standable.insert(TileKey(cx, cy)).second) marked++;
-                    }
-                }
-            }
-        }
-        out.maps++;
-        CARTO_LOG("[carto-bake] map %d (file 0x%X, continent %d): %d planes, +%d tiles",
-                  static_cast<int>(map_id), file_id, continent, static_cast<int>(data.planes.size()), marked);
-    }
-
-    void WriteBakeFiles()
-    {
-        for (const auto& [continent, data] : bake.continents) {
-            if (data.standable.empty()) continue;
-            int x0 = INT_MAX, y0 = INT_MAX, x1 = INT_MIN, y1 = INT_MIN;
-            for (const auto key : data.standable) {
-                const int cx = static_cast<int>(static_cast<uint32_t>(key & 0xffffffff));
-                const int cy = static_cast<int>(static_cast<uint32_t>(key >> 32));
-                x0 = std::min(x0, cx);
-                x1 = std::max(x1, cx);
-                y0 = std::min(y0, cy);
-                y1 = std::max(y1, cy);
-            }
-            const int w = x1 - x0 + 1;
-            const int h = y1 - y0 + 1;
-            std::vector<uint8_t> bits((static_cast<size_t>(w) * h + 7) / 8, 0);
-            for (const auto key : data.standable) {
-                const int cx = static_cast<int>(static_cast<uint32_t>(key & 0xffffffff)) - x0;
-                const int cy = static_cast<int>(static_cast<uint32_t>(key >> 32)) - y0;
-                const size_t bit = static_cast<size_t>(cy) * w + cx;
-                bits[bit >> 3] |= 1 << (bit & 7);
-            }
-            const int32_t header[5] = {continent, x0, y0, w, h};
-            const auto path = Resources::GetPath(L"cartography", std::format(L"standable_L{}.bin", continent));
-            std::ofstream file(path, std::ios::binary);
-            if (!file) {
-                CARTO_LOG("[carto-bake] could not write %ls", path.wstring().c_str());
-                continue;
-            }
-            file.write("CSM1", 4);
-            file.write(reinterpret_cast<const char*>(header), sizeof(header));
-            file.write(reinterpret_cast<const char*>(bits.data()), static_cast<std::streamsize>(bits.size()));
-            CARTO_LOG("[carto-bake] continent %d: %d maps, %u tiles, grid %dx%d at (%d,%d), %u bytes",
-                      continent, data.maps, static_cast<unsigned>(data.standable.size()), w, h, x0, y0,
-                      static_cast<unsigned>(bits.size()));
-        }
-    }
-
-    void StartBake()
-    {
-        bake = {};
-        bake.started = TIMER_INIT();
-        for (size_t i = 1; i < static_cast<size_t>(GW::Constants::MapID::Count); i++) {
-            const auto map_id = static_cast<GW::Constants::MapID>(i);
-            const auto* info = GW::Map::GetMapInfo(map_id);
-            if (!(info && info->GetIsOnWorldMap())) continue;
-            bake.on_world_map++;
-            ImRect bounds;
-            if (!GW::Map::GetMapWorldMapBounds(info, &bounds)) {
-                bake.no_bounds++;
-                continue;
-            }
-            bake.queue.push_back(map_id);
-        }
-        bake.running = true;
-        bake.summary = std::format("{} maps on the world map, queued", bake.queue.size());
-    }
-
-    // One map per tick: a DAT parse is far too slow to loop over ~450 of them in a frame.
-    void StepBake()
-    {
-        if (!bake.running) return;
-        if (bake.next >= bake.queue.size()) {
-            WriteBakeFiles();
-            bake.running = false;
-            unsigned tiles = 0;
-            for (const auto& [continent, data] : bake.continents) tiles += static_cast<unsigned>(data.standable.size());
-            bake.summary = std::format("done in {:.1f}s: {} continents, {} tiles, {} maps with no file id, {} failed to load, {} without bounds",
-                                       TIMER_DIFF(bake.started) / 1000.f, bake.continents.size(), tiles,
-                                       bake.no_file_id, bake.load_failed, bake.no_bounds);
-            CARTO_LOG("[carto-bake] %s", bake.summary.c_str());
-            return;
-        }
-        const auto map_id = bake.queue[bake.next++];
-        const auto* info = GW::Map::GetMapInfo(map_id);
-        if (info) BakeMap(map_id, info, static_cast<int>(info->continent));
-        bake.summary = std::format("{}/{} maps...", bake.next, bake.queue.size());
-    }
-#endif
-
     void OnCartographyUpdated(GW::HookStatus*, GW::UI::UIMessage, void*, void*)
     {
         carto_dirty = true;
@@ -1197,9 +974,6 @@ void CartographerWidget::LoadSettings(SettingsDoc& doc, ToolboxIni* legacy)
 
 void CartographerWidget::Update(float)
 {
-#ifdef _DEBUG
-    StepBake();
-#endif
     if (!GetEnabled()) {
         if (target.valid) ResetState();
         return;
@@ -1479,44 +1253,8 @@ void CartographerWidget::DrawSettingsInternal()
         ImGui::TextDisabled("Baked continent data: %dx%d squares at (%d,%d), radius %d",
                             continent_mask.w, continent_mask.h, continent_mask.x0, continent_mask.y0, continent_mask.radius);
     }
-#ifdef _DEBUG
-    DrawBakeSettings();
-#endif
 }
 
-#ifdef _DEBUG
-void CartographerWidget::DrawBakeSettings()
-{
-    ImGui::Separator();
-    ImGui::Text("Continent bake (debug)");
-    ImGui::TextDisabled("Reads every world-map map's pathing data out of the DAT and records which\n32x32 squares have standable ground, per continent. One map per frame, so it\nruns for a while; results go to Settings/cartography/standable_L<n>.bin.");
-    ImGui::BeginDisabled(bake.running);
-    if (ImGui::Button("Bake standable squares for all continents")) {
-        GW::GameThread::Enqueue([] { StartBake(); });
-    }
-    ImGui::EndDisabled();
-    if (bake.running) {
-        ImGui::SameLine();
-        if (ImGui::Button("Cancel")) {
-            GW::GameThread::Enqueue([] {
-                bake.running = false;
-                bake.summary = "cancelled";
-            });
-        }
-        ImGui::ProgressBar(bake.queue.empty() ? 0.f : static_cast<float>(bake.next) / bake.queue.size());
-    }
-    if (!bake.summary.empty()) ImGui::TextWrapped("%s", bake.summary.c_str());
-    if (bake.on_world_map) {
-        ImGui::TextDisabled("%d maps on the world map; %d with no file id, %d failed to load, %d had no bounds",
-                            bake.on_world_map, bake.no_file_id, bake.load_failed, bake.no_bounds);
-        ImGui::TextDisabled("AreaInfo::file_id vs GetMapFileId: %d agree, %d differ, %d absent",
-                            bake.area_fid_agrees, bake.area_fid_differs, bake.area_fid_missing);
-    }
-    for (const auto& [continent, data] : bake.continents) {
-        ImGui::TextDisabled("  continent %d: %d maps, %u standable squares", continent, data.maps, static_cast<unsigned>(data.standable.size()));
-    }
-}
-#endif
 
 void CartographerWidget::SetEnabled(const bool on)
 {

--- a/GWToolboxdll/Widgets/CartographerWidget.h
+++ b/GWToolboxdll/Widgets/CartographerWidget.h
@@ -60,8 +60,4 @@ public:
     static void ClearCustomPoints();
     static void ClearDeclined();
     static void GetStatus(char* buf, size_t len);
-#ifdef _DEBUG
-    // Debug-only: bake the per-continent standable-square matrix out of the DAT.
-    static void DrawBakeSettings();
-#endif
 };


### PR DESCRIPTION
The offline bake supersedes it. `tools/bake_cartography/` produces the same data from the same sources — `AreaInfo` for placement, `Gw.dat` for geometry — without needing a client, and its output ships in `CartographyData.h`. Nothing left for the in-game version to do.

**Removed:** the debug button and status log, the per-tick `StepBake` driver, the per-map trapezoid walk and largest-component search, the `.bin` writer, and the includes only they needed (`fstream`, `Resources.h`, `PathingMapDataLoader.h`, `PathfindingWindow.h`).

**−266 lines.** Nothing else in the widget referenced any of it.

The settings section keeps the live per-map stats and the baked-data readout; the debug-only `CARTO_LOG` macro stays, since it's used throughout.

Worth noting it earned its keep before going: it was written to report what it *found* rather than what I'd assumed, and the questions it existed to answer — which maps are placed on the world map, which have no file id, whether `AreaInfo::file_id` agrees with `maps_constant_data.h` — all got answered offline instead. The last of those by fetching the files from ArenaNet's servers directly, which is how the three texture-not-map ids in #2490 turned up.

Not compiled — no MSVC here. It's a deletion with no remaining references, so the risk is low, but it does touch includes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)