### PR TITLE
New module: Playstyle Restriction profiles

### DIFF
--- a/GWToolboxdll/Modules/ToolboxSettings.cpp
+++ b/GWToolboxdll/Modules/ToolboxSettings.cpp
@@ -73,6 +73,7 @@
 #include <Windows/PartyStatisticsWindow.h>
 #include <Windows/Pathfinding/PathfindingWindow.h>
 #include <Windows/PconsWindow.h>
+#include <Windows/PlaystyleRestrictionsWindow.h>
 #include <Windows/RerollWindow.h>
 #include <Windows/TradeWindow.h>
 #include <Windows/TravelWindow.h>
@@ -252,6 +253,7 @@ namespace {
         DropTrackerWindow::Instance(),
         GWMarketWindow::Instance(),
         InventorySorting::Instance(),
+        {PlaystyleRestrictionsWindow::Instance(), false},
         FavorTracker::Instance(),
         LoginModule::Instance(),
         {AccountInventoryWindow::Instance(), false},

--- a/GWToolboxdll/Windows/CompletionWindow.cpp
+++ b/GWToolboxdll/Windows/CompletionWindow.cpp
@@ -3050,7 +3050,7 @@ bool CompletionWindow::IsAreaComplete(const MapID map_id, CompletionCheck check)
     if (map_id == MapID::Tomb_of_the_Primeval_Kings)
         return true; // Topk special case
 
-    const auto map = GW::Map::GetMapInfo();
+    const auto map = GW::Map::GetMapInfo(map_id);
     const auto w = GW::GetWorldContext();
     if (!(map && w))
         return false;

--- a/GWToolboxdll/Windows/CompletionWindow.cpp
+++ b/GWToolboxdll/Windows/CompletionWindow.cpp
@@ -669,7 +669,7 @@ namespace {
             return false;
         if ((check & HardMode) && !ArrayBoolAt(w->missions_completed_hm, static_cast<uint32_t>(map_id)))
             return false;
-        const bool has_bonus = map->campaign != Campaign::EyeOfTheNorth;
+        const bool has_bonus = map->campaign != Campaign::EyeOfTheNorth && !(check & PrimaryOnly);
         if (has_bonus) {
             if ((check & NormalMode) && !ArrayBoolAt(w->missions_bonus, static_cast<uint32_t>(map_id)))
                 return false;
@@ -701,7 +701,7 @@ namespace {
             return false;
         if ((check & HardMode) && !ArrayBoolAt(completion->mission_hm, static_cast<uint32_t>(map_id)))
             return false;
-        const bool has_bonus = map->campaign != Campaign::EyeOfTheNorth;
+        const bool has_bonus = map->campaign != Campaign::EyeOfTheNorth && !(check & PrimaryOnly);
         if (has_bonus) {
             if ((check & NormalMode) && !ArrayBoolAt(completion->mission_bonus, static_cast<uint32_t>(map_id)))
                 return false;
@@ -3045,36 +3045,8 @@ CharacterCompletion* CompletionWindow::GetCharacterCompletion(const wchar_t* cha
 
 bool CompletionWindow::IsAreaComplete(const MapID map_id, CompletionCheck check)
 {
-    if (map_id == MapID::None)
-        return true;
-    if (map_id == MapID::Tomb_of_the_Primeval_Kings)
-        return true; // Topk special case
-
-    const auto map = GW::Map::GetMapInfo(map_id);
-    const auto w = GW::GetWorldContext();
-    if (!(map && w))
-        return false;
-    switch (map->type) {
-        case GW::RegionType::EliteMission:
-            return true;
-        case GW::RegionType::ExplorableZone:
-            if (map->continent == GW::Continent::BattleIsles)
-                return true; // Fow, Uw
-            return !map->GetIsOnWorldMap() || ArrayBoolAt(w->vanquished_areas, static_cast<uint32_t>(map_id));
-    }
-
-    if ((check & NormalMode) && !ArrayBoolAt(w->missions_completed, static_cast<uint32_t>(map_id)))
-        return false;
-    if ((check & HardMode) && !ArrayBoolAt(w->missions_completed_hm, static_cast<uint32_t>(map_id)))
-        return false;
-    const bool has_bonus = map->campaign != Campaign::EyeOfTheNorth;
-    if (has_bonus) {
-        if ((check & NormalMode) && !ArrayBoolAt(w->missions_bonus, static_cast<uint32_t>(map_id)))
-            return false;
-        if ((check & HardMode) && !ArrayBoolAt(w->missions_bonus_hm, static_cast<uint32_t>(map_id)))
-            return false;
-    }
-    return true;
+    // Qualified: unqualified lookup inside a member finds this same member, not the file-local one.
+    return ::IsAreaComplete(map_id, check);
 }
 
 bool CompletionWindow::IsAreaComplete(const wchar_t* player_name, const MapID map_id, CompletionCheck check)

--- a/GWToolboxdll/Windows/CompletionWindow.h
+++ b/GWToolboxdll/Windows/CompletionWindow.h
@@ -220,7 +220,9 @@ enum CompletionCheck : uint32_t {
     None,
     NormalMode,
     HardMode,
-    Both
+    Both,
+    // Primary objective only; drops the bonus requirement a mission otherwise carries.
+    PrimaryOnly = 4
 };
 
 struct CharacterCompletion {

--- a/GWToolboxdll/Windows/PlaystyleRestrictionsWindow.cpp
+++ b/GWToolboxdll/Windows/PlaystyleRestrictionsWindow.cpp
@@ -1,0 +1,645 @@
+#include "stdafx.h"
+
+#include <GWCA/Constants/Constants.h>
+#include <GWCA/Constants/ItemIDs.h>
+#include <GWCA/Constants/Maps.h>
+#include <GWCA/Constants/Skills.h>
+
+#include <GWCA/GameEntities/Agent.h>
+#include <GWCA/GameEntities/Item.h>
+#include <GWCA/GameEntities/Map.h>
+#include <GWCA/GameEntities/Party.h>
+#include <GWCA/GameEntities/Skill.h>
+#include <GWCA/GameEntities/Title.h>
+
+#include <GWCA/Managers/AgentMgr.h>
+#include <GWCA/Managers/GameThreadMgr.h>
+#include <GWCA/Managers/ItemMgr.h>
+#include <GWCA/Managers/MapMgr.h>
+#include <GWCA/Managers/MerchantMgr.h>
+#include <GWCA/Managers/PartyMgr.h>
+#include <GWCA/Managers/PlayerMgr.h>
+#include <GWCA/Managers/SkillbarMgr.h>
+#include <GWCA/Managers/UIMgr.h>
+
+#include <GWCA/Context/WorldContext.h>
+
+#include <GWCA/Utilities/Hook.h>
+
+#include <ImGuiAddons.h>
+#include <Logger.h>
+#include <Modules/InventoryItem.h>
+#include <Modules/Resources.h>
+#include <Utils/SettingsDoc.h>
+#include <Utils/SettingsRegistry.h>
+#include <Utils/ToolboxUtils.h>
+#include <Windows/PlaystyleRestrictionsWindow.h>
+
+using GW::Constants::Campaign;
+using GW::Constants::HeroID;
+using GW::Constants::MapID;
+using GW::Constants::TitleID;
+using Profile = PlaystyleRestrictionsWindow::Profile;
+
+namespace {
+    constexpr char profile_filename[] = "playstyle_restrictions.json";
+
+    Profile profile;
+    PlaystyleRestrictionsWindow::Settings settings;
+    GW::HookEntry hook_entry;
+
+    // Recomputed on map load / profile change: the mission-order scan walks every map info,
+    // far too heavy for the button-state message that reads it.
+    bool mission_entry_blocked = false;
+
+    bool Contains(const std::vector<uint32_t>& haystack, const uint32_t needle)
+    {
+        return std::ranges::find(haystack, needle) != haystack.end();
+    }
+
+    // ==== Static game data ====
+
+    const char* CampaignName(const Campaign campaign)
+    {
+        switch (campaign) {
+            case Campaign::Prophecies: return "Prophecies";
+            case Campaign::Factions: return "Factions";
+            case Campaign::Nightfall: return "Nightfall";
+            case Campaign::EyeOfTheNorth: return "Eye of the North";
+            case Campaign::BonusMissionPack: return "Bonus Mission Pack";
+            default: return "Core";
+        }
+    }
+
+    MapID FinalMission(const Campaign campaign)
+    {
+        switch (campaign) {
+            case Campaign::Prophecies: return MapID::Hells_Precipice;
+            case Campaign::Factions: return MapID::Imperial_Sanctum_outpost_mission;
+            case Campaign::Nightfall: return MapID::Abaddons_Gate;
+            case Campaign::EyeOfTheNorth: return MapID::A_Time_for_Heroes_mission;
+            default: return MapID::None;
+        }
+    }
+
+    const std::vector<TitleID>& CampaignTitles(const Campaign campaign)
+    {
+        static const std::vector<TitleID> none{};
+        static const std::vector<TitleID> proph{TitleID::ProtectorTyria, TitleID::GuardianTyria, TitleID::VanquisherTyria, TitleID::SkillHunterTyria, TitleID::TyrianCarto};
+        static const std::vector<TitleID> factions{TitleID::ProtectorCantha, TitleID::GuardianCantha, TitleID::VanquisherCantha, TitleID::SkillHunterCantha, TitleID::CanthanCarto};
+        static const std::vector<TitleID> nightfall{TitleID::ProtectorElona, TitleID::GuardianElona, TitleID::VanquisherElona, TitleID::SkillHunterElona, TitleID::ElonianCarto, TitleID::Sunspear, TitleID::Lightbringer};
+        static const std::vector<TitleID> eotn{TitleID::Asuran, TitleID::Deldrimor, TitleID::Vanguard, TitleID::Norn, TitleID::MasterOfTheNorth};
+        switch (campaign) {
+            case Campaign::Prophecies: return proph;
+            case Campaign::Factions: return factions;
+            case Campaign::Nightfall: return nightfall;
+            case Campaign::EyeOfTheNorth: return eotn;
+            default: return none;
+        }
+    }
+
+    // The game has no hero->campaign field; heroes not listed here (mercenaries) are core.
+    Campaign HeroCampaign(const HeroID hero_id)
+    {
+        switch (hero_id) {
+            case HeroID::Norgu: case HeroID::Goren: case HeroID::Tahlkora: case HeroID::MasterOfWhispers:
+            case HeroID::AcolyteJin: case HeroID::Koss: case HeroID::Dunkoro: case HeroID::AcolyteSousuke:
+            case HeroID::Melonni: case HeroID::ZhedShadowhoof: case HeroID::GeneralMorgahn: case HeroID::MargridTheSly:
+            case HeroID::Zenmai: case HeroID::Olias: case HeroID::Razah:
+                return Campaign::Nightfall;
+            case HeroID::KeiranThackeray: case HeroID::Jora: case HeroID::PyreFierceshot: case HeroID::Anton:
+            case HeroID::Livia: case HeroID::Hayda: case HeroID::Kahmu: case HeroID::Gwen:
+            case HeroID::Xandra: case HeroID::Vekk: case HeroID::Ogden:
+                return Campaign::EyeOfTheNorth;
+            case HeroID::Miku: case HeroID::ZeiRi:
+                return Campaign::Factions;
+            case HeroID::Devona: case HeroID::GhostOfAlthea:
+                return Campaign::Prophecies;
+            case HeroID::MOX:
+                return Campaign::BonusMissionPack;
+            default:
+                return Campaign::Core;
+        }
+    }
+
+    // ==== Progression state ====
+
+    // Primary objective only, Normal Mode: challenge rulesets gate on "did the story happen",
+    // not on bonuses, so CompletionWindow::IsAreaComplete (which also demands the bonus) is too strict.
+    bool IsMissionComplete(const MapID map_id)
+    {
+        const auto world = GW::GetWorldContext();
+        return world && ToolboxUtils::ArrayBoolAt(world->missions_completed, static_cast<uint32_t>(map_id));
+    }
+
+    bool IsCampaignComplete(const Campaign campaign)
+    {
+        const auto final_mission = FinalMission(campaign);
+        return final_mission != MapID::None && IsMissionComplete(final_mission);
+    }
+
+    bool AreCampaignTitlesMaxed(const Campaign campaign)
+    {
+        for (const auto title_id : CampaignTitles(campaign)) {
+            const auto title = GW::PlayerMgr::GetTitleTrack(title_id);
+            if (!title || title->current_title_tier_index < title->max_title_tier_index) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool IsCampaignUnlocked(const Campaign campaign)
+    {
+        if (campaign == Campaign::Core || campaign == Campaign::BonusMissionPack) {
+            return true;
+        }
+        const auto& order = profile.campaign_order;
+        const auto found = std::ranges::find(order, static_cast<uint32_t>(campaign));
+        if (found == order.end() || found == order.begin()) {
+            return true;
+        }
+        const auto previous = static_cast<Campaign>(*std::prev(found));
+        if (!IsCampaignComplete(previous)) {
+            return false;
+        }
+        return !profile.require_campaign_titles_maxed || AreCampaignTitlesMaxed(previous);
+    }
+
+    bool HasRequiredPreSearingTitles()
+    {
+        return std::ranges::all_of(profile.required_presearing_titles, [](const auto& required) {
+            const auto title = GW::PlayerMgr::GetTitleTrack(static_cast<TitleID>(required.title_id));
+            return title && title->current_title_tier_index >= required.min_tier;
+        });
+    }
+
+    // Every mission of this campaign that comes earlier in the story must already be done.
+    bool HasSkippedMissions(const GW::AreaInfo* area)
+    {
+        for (auto map_id = static_cast<MapID>(0); map_id < MapID::Count; map_id = static_cast<MapID>(static_cast<uint32_t>(map_id) + 1)) {
+            const auto other = GW::Map::GetMapInfo(map_id);
+            if (!other || other->campaign != area->campaign || !other->mission_chronology) {
+                continue;
+            }
+            if (other->mission_chronology < area->mission_chronology && !IsMissionComplete(map_id)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // Reason the given map is off-limits, or nullptr if it's allowed. Static storage: caller logs it immediately.
+    const char* GetMapBlockReason(const MapID map_id)
+    {
+        static char reason[128];
+        const auto area = GW::Map::GetMapInfo(map_id);
+        if (!area) {
+            return nullptr;
+        }
+        if (profile.gate_presearing_exit && GW::Map::IsPreSearing() && !GW::Map::IsPreSearing(map_id) && !HasRequiredPreSearingTitles()) {
+            return "your profile requires more titles before leaving pre-Searing";
+        }
+        if (profile.enforce_campaign_order && !IsCampaignUnlocked(area->campaign)) {
+            snprintf(reason, sizeof(reason), "%s is not unlocked yet under your profile's campaign order", CampaignName(area->campaign));
+            return reason;
+        }
+        return nullptr;
+    }
+
+    // ==== Item helpers ====
+
+    bool IsMajorOrSuperiorRune(const InventoryItem* item)
+    {
+        // Attribute runes carry their tier in the low byte of mod 0x21e8; vigor has one mod id per tier.
+        if (const auto mod = item->GetModifier(0x21e8)) {
+            return mod->arg2() >= 2;
+        }
+        return item->GetModifier(0x27e9) || item->GetModifier(0x27ea);
+    }
+
+    bool IsEliteTome(const InventoryItem* item)
+    {
+        const auto mod = item->GetModifier(0x2788);
+        const auto use_id = mod ? mod->arg() : 0;
+        return use_id >= 26 && use_id < 36;
+    }
+
+    // Reason this item can't be used, or nullptr.
+    const char* GetItemUseBlockReason(const GW::Item* raw)
+    {
+        const auto item = reinterpret_cast<const InventoryItem*>(raw);
+        if (Contains(profile.blocked_item_model_ids, item->model_id)) {
+            return "that item is on your profile's blocked list";
+        }
+        if (profile.lockpicks_hard_mode_only && item->model_id == static_cast<uint32_t>(GW::Constants::ItemID::Lockpick) && !GW::PartyMgr::GetIsPartyInHardMode()) {
+            return "your profile only allows lockpicks in Hard Mode";
+        }
+        if (profile.block_elite_tomes && IsEliteTome(item)) {
+            return "your profile blocks elite tomes";
+        }
+        if (profile.block_scrolls && item->type == GW::Constants::ItemType::Scroll) {
+            return "your profile blocks scrolls";
+        }
+        if (profile.block_consumables && item->type == GW::Constants::ItemType::Usable) {
+            return "your profile blocks consumables";
+        }
+        return nullptr;
+    }
+
+    // ==== Skill helpers ====
+
+    const char* GetSkillTemplateBlockReason(const GW::SkillbarMgr::SkillTemplate* skill_template)
+    {
+        static char reason[128];
+        if (profile.lock_skillbar) {
+            return "your profile locks the skillbar";
+        }
+        auto attribute = GW::Constants::AttributeByte::None;
+        for (const auto skill_id : skill_template->skills) {
+            const auto skill = GW::SkillbarMgr::GetSkillConstantData(skill_id);
+            if (!skill) {
+                continue;
+            }
+            if (profile.restrict_skills_to_unlocked_campaigns && !IsCampaignUnlocked(skill->campaign)) {
+                snprintf(reason, sizeof(reason), "that bar uses %s skills, which aren't unlocked yet", CampaignName(skill->campaign));
+                return reason;
+            }
+            if (profile.single_attribute_line && skill->attribute != GW::Constants::AttributeByte::None) {
+                if (attribute != GW::Constants::AttributeByte::None && attribute != skill->attribute) {
+                    return "your profile allows only one attribute line";
+                }
+                attribute = skill->attribute;
+            }
+        }
+        return nullptr;
+    }
+
+    // ==== Enforcement ====
+
+    void Deny(GW::HookStatus* status, const char* reason)
+    {
+        status->blocked = true;
+        Log::Warning("[Playstyle Restrictions] Blocked: %s", reason);
+    }
+
+    bool IsMissionEntryBlocked()
+    {
+        const auto map_id = GW::Map::GetMapID();
+        const auto area = GW::Map::GetMapInfo(map_id);
+        if (!area || !area->GetHasEnterButton()) {
+            return false;
+        }
+        const auto target = area->GetHasMissionMapsTo() ? static_cast<MapID>(area->mission_maps_to) : map_id;
+        if (GetMapBlockReason(target)) {
+            return true;
+        }
+        if (profile.block_mission_skipping && HasSkippedMissions(area)) {
+            return true;
+        }
+        if (profile.min_level_for_gated_areas && area->min_level) {
+            const auto me = GW::Agents::GetControlledCharacter();
+            if (me && me->level < profile.min_level_for_gated_areas) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    void OnUIMessage(GW::HookStatus* status, const GW::UI::UIMessage message_id, void* wparam, void*)
+    {
+        if (!settings.enforce || status->blocked) {
+            return;
+        }
+        switch (message_id) {
+            case GW::UI::UIMessage::kTravel: {
+                const auto destination = static_cast<MapID*>(wparam);
+                if (const auto reason = destination ? GetMapBlockReason(*destination) : nullptr) {
+                    Deny(status, reason);
+                }
+            }
+            break;
+            case GW::UI::UIMessage::kDisableEnterMissionBtn: {
+                // The game re-enables the button on every party change; keep it disabled while gated.
+                if (wparam == nullptr && mission_entry_blocked) {
+                    status->blocked = true;
+                }
+            }
+            break;
+            case GW::UI::UIMessage::kShowXunlaiChest: {
+                if (profile.block_xunlai_chest) {
+                    Deny(status, "your profile blocks the Xunlai Chest");
+                }
+            }
+            break;
+            case GW::UI::UIMessage::kPartyAddHero: {
+                const auto member = wparam ? static_cast<GW::HeroPartyMember**>(wparam)[1] : nullptr;
+                const auto me = GW::Agents::GetControlledCharacter();
+                if (!member || !me || member->owner_player_id != me->login_number) {
+                    break;
+                }
+                const auto hero_id = member->hero_id;
+                if (Contains(profile.hero_allow_list, static_cast<uint32_t>(hero_id))) {
+                    break;
+                }
+                if (Contains(profile.hero_block_list, static_cast<uint32_t>(hero_id))) {
+                    Deny(status, "that hero is on your profile's blocked list");
+                    break;
+                }
+                if (profile.max_party_heroes && GW::PartyMgr::GetPartyHeroCount() >= profile.max_party_heroes) {
+                    Deny(status, "your profile caps the hero roster");
+                    break;
+                }
+                if (profile.restrict_heroes_to_unlocked_campaigns && !IsCampaignUnlocked(HeroCampaign(hero_id))) {
+                    Deny(status, "that hero's campaign isn't unlocked yet");
+                }
+            }
+            break;
+            case GW::UI::UIMessage::kSendUseItem: {
+                const auto packet = static_cast<GW::UI::UIPacket::kSendUseItem*>(wparam);
+                const auto item = packet ? GW::Items::GetItemById(packet->item_id) : nullptr;
+                if (const auto reason = item ? GetItemUseBlockReason(item) : nullptr) {
+                    Deny(status, reason);
+                }
+            }
+            break;
+            case GW::UI::UIMessage::kEquipItem: {
+                const auto item = wparam ? GW::Items::GetItemById(*static_cast<uint32_t*>(wparam)) : nullptr;
+                if (item && Contains(profile.blocked_item_model_ids, item->model_id)) {
+                    Deny(status, "that item is on your profile's blocked list");
+                }
+            }
+            break;
+            case GW::UI::UIMessage::kSendMerchantTransactItem: {
+                const auto packet = static_cast<GW::UI::UIPacket::kSendMerchantTransactItem*>(wparam);
+                if (!packet || packet->type == GW::Merchant::TransactionType::MerchantSell || packet->type == GW::Merchant::TransactionType::TraderSell) {
+                    break;
+                }
+                for (uint32_t i = 0; i < packet->recv.item_count; i++) {
+                    const auto raw = GW::Items::GetItemById(packet->recv.item_ids[i]);
+                    if (!raw) {
+                        continue;
+                    }
+                    if (profile.block_zaishen_coin_purchase && raw->GetIsZcoin()) {
+                        Deny(status, "your profile blocks buying Zaishen Coins");
+                        return;
+                    }
+                    const auto item = reinterpret_cast<const InventoryItem*>(raw);
+                    if (profile.block_purchased_runes && raw->type == GW::Constants::ItemType::Rune_Mod && IsMajorOrSuperiorRune(item)) {
+                        Deny(status, "your profile only allows major/superior runes picked up as loot");
+                        return;
+                    }
+                    if (Contains(profile.blocked_item_model_ids, raw->model_id)) {
+                        Deny(status, "that item is on your profile's blocked list");
+                        return;
+                    }
+                }
+            }
+            break;
+            case GW::UI::UIMessage::kSendLoadSkillTemplate: {
+                const auto packet = static_cast<GW::UI::UIPacket::kSendLoadSkillTemplate*>(wparam);
+                if (!packet || !packet->skill_template) {
+                    break;
+                }
+                if (profile.lock_hero_skillbars && packet->agent_id != GW::Agents::GetControlledCharacterId()) {
+                    Deny(status, "your profile locks hero skillbars");
+                    break;
+                }
+                if (const auto reason = GetSkillTemplateBlockReason(packet->skill_template)) {
+                    Deny(status, reason);
+                }
+            }
+            break;
+            default:
+                break;
+        }
+    }
+
+    void RefreshEnterMissionButton()
+    {
+        mission_entry_blocked = settings.enforce && IsMissionEntryBlocked();
+        if (mission_entry_blocked) {
+            GW::UI::SendUIMessage(GW::UI::UIMessage::kDisableEnterMissionBtn, reinterpret_cast<void*>(1));
+        }
+    }
+
+    // ==== Profile persistence ====
+
+    bool WriteProfile(const std::filesystem::path& path)
+    {
+        std::string buffer;
+        if (glz::write<glz::opts{.prettify = true}>(profile, buffer)) {
+            return false;
+        }
+        std::ofstream file(path, std::ios::binary | std::ios::trunc);
+        if (!file) {
+            return false;
+        }
+        file.write(buffer.data(), static_cast<std::streamsize>(buffer.size()));
+        return true;
+    }
+
+    bool ReadProfile(const std::filesystem::path& path)
+    {
+        std::ifstream file(path, std::ios::binary);
+        if (!file) {
+            return false;
+        }
+        const std::string buffer{std::istreambuf_iterator(file), {}};
+        Profile loaded;
+        if (glz::read<glz::opts{.error_on_unknown_keys = false}>(loaded, buffer)) {
+            return false;
+        }
+        profile = std::move(loaded);
+        return true;
+    }
+
+    // ==== UI ====
+
+    void DrawCampaignOrder()
+    {
+        for (size_t i = 0; i < profile.campaign_order.size(); i++) {
+            const auto campaign = static_cast<Campaign>(profile.campaign_order[i]);
+            ImGui::Text("%d. %s", static_cast<int>(i) + 1, CampaignName(campaign));
+            ImGui::SameLine(ImGui::GetContentRegionAvail().x - 60.f);
+            ImGui::PushID(static_cast<int>(i));
+            if (ImGui::ArrowButton("up", ImGuiDir_Up) && i > 0) {
+                std::swap(profile.campaign_order[i], profile.campaign_order[i - 1]);
+            }
+            ImGui::SameLine();
+            if (ImGui::ArrowButton("down", ImGuiDir_Down) && i + 1 < profile.campaign_order.size()) {
+                std::swap(profile.campaign_order[i], profile.campaign_order[i + 1]);
+            }
+            ImGui::PopID();
+        }
+    }
+
+    void DrawIdList(const char* label, std::vector<uint32_t>& ids, const char* help)
+    {
+        std::string joined;
+        for (const auto id : ids) {
+            joined += (joined.empty() ? "" : ",") + std::to_string(id);
+        }
+        if (ImGui::InputText(label, joined, 256)) {
+            ids.clear();
+            for (const char* p = joined.c_str(); *p;) {
+                char* end = nullptr;
+                const auto parsed = strtoul(p, &end, 10);
+                if (end == p) {
+                    break;
+                }
+                ids.push_back(static_cast<uint32_t>(parsed));
+                p = *end ? end + 1 : end;
+            }
+        }
+        ImGui::ShowHelp(help);
+    }
+}
+
+void PlaystyleRestrictionsWindow::Initialize()
+{
+    ToolboxWindow::Initialize();
+    SettingsRegistry::Register(this, settings);
+
+    constexpr GW::UI::UIMessage blockable[] = {
+        GW::UI::UIMessage::kTravel,
+        GW::UI::UIMessage::kDisableEnterMissionBtn,
+        GW::UI::UIMessage::kShowXunlaiChest,
+        GW::UI::UIMessage::kPartyAddHero,
+        GW::UI::UIMessage::kSendUseItem,
+        GW::UI::UIMessage::kEquipItem,
+        GW::UI::UIMessage::kSendMerchantTransactItem,
+        GW::UI::UIMessage::kSendLoadSkillTemplate
+    };
+    for (const auto message_id : blockable) {
+        GW::UI::RegisterUIMessageCallback(&hook_entry, message_id, OnUIMessage);
+    }
+    GW::UI::RegisterUIMessageCallback(&hook_entry, GW::UI::UIMessage::kMapLoaded, [](GW::HookStatus*, GW::UI::UIMessage, void*, void*) {
+        RefreshEnterMissionButton();
+    }, 0x8000);
+}
+
+void PlaystyleRestrictionsWindow::Terminate()
+{
+    ToolboxWindow::Terminate();
+    GW::UI::RemoveUIMessageCallback(&hook_entry);
+}
+
+void PlaystyleRestrictionsWindow::Draw(IDirect3DDevice9*)
+{
+    if (!visible) {
+        return;
+    }
+    ImGui::SetNextWindowSize(ImVec2(480, 640), ImGuiCond_FirstUseEver);
+    if (!ImGui::Begin(Name(), GetVisiblePtr(), GetWinFlags())) {
+        return ImGui::End();
+    }
+
+    ImGui::InputText("Profile name", profile.profile_name, 64);
+    ImGui::InputText("Author", profile.author, 64);
+    ImGui::InputText("Notes", profile.notes, 256);
+    if (ImGui::Checkbox("Enforce this profile", &settings.enforce)) {
+        GW::GameThread::Enqueue(RefreshEnterMissionButton);
+    }
+    ImGui::ShowHelp("Turn off to keep the profile but stop blocking anything");
+    ImGui::Separator();
+
+    if (ImGui::CollapsingHeader("Campaign progression", ImGuiTreeNodeFlags_DefaultOpen)) {
+        ImGui::Checkbox("Enforce campaign order", &profile.enforce_campaign_order);
+        ImGui::ShowHelp("Block travelling into, and entering missions of, a campaign whose predecessor isn't finished");
+        if (profile.enforce_campaign_order) {
+            DrawCampaignOrder();
+            ImGui::Checkbox("Also require the previous campaign's titles maxed", &profile.require_campaign_titles_maxed);
+            ImGui::ShowHelp("Protector, Guardian, Vanquisher, Skill Hunter and Cartographer for that campaign (plus Sunspear/Lightbringer for Nightfall). Account-wide titles are never counted.");
+        }
+        ImGui::Checkbox("Missions must be done in story order", &profile.block_mission_skipping);
+        ImGui::ShowHelp("Greys out Enter Mission until every earlier mission of that campaign is complete");
+        ImGui::Checkbox("Require titles before leaving pre-Searing", &profile.gate_presearing_exit);
+        ImGui::ShowHelp("Defaults to Legendary Defender of Ascalon and Survivor rank 1");
+        ImGui::InputScalar("Minimum level for gated areas", ImGuiDataType_U32, &profile.min_level_for_gated_areas);
+        ImGui::ShowHelp("Blocks Enter Mission for any area with a level requirement until you reach this level. 0 disables.");
+    }
+
+    if (ImGui::CollapsingHeader("Heroes")) {
+        ImGui::Checkbox("Heroes limited to unlocked campaigns", &profile.restrict_heroes_to_unlocked_campaigns);
+        ImGui::ShowHelp("No Olias before Nightfall is unlocked, no Mox in Prophecies, and so on");
+        ImGui::InputScalar("Maximum heroes in party", ImGuiDataType_U32, &profile.max_party_heroes);
+        ImGui::ShowHelp("0 for no cap");
+        ImGui::Checkbox("Lock hero skillbars", &profile.lock_hero_skillbars);
+        DrawIdList("Always-allowed heroes", profile.hero_allow_list, "Comma-separated hero ids, exempt from every hero rule (e.g. Reforged Devona)");
+        DrawIdList("Never-allowed heroes", profile.hero_block_list, "Comma-separated hero ids");
+    }
+
+    if (ImGui::CollapsingHeader("Skills")) {
+        ImGui::Checkbox("Skills limited to unlocked campaigns", &profile.restrict_skills_to_unlocked_campaigns);
+        ImGui::ShowHelp("Approximates \"what a fresh account would have unlocked\" by the campaign the skill belongs to");
+        ImGui::Checkbox("One attribute line only", &profile.single_attribute_line);
+        ImGui::Checkbox("Lock the skillbar entirely", &profile.lock_skillbar);
+        ImGui::Checkbox("No elite tomes", &profile.block_elite_tomes);
+    }
+
+    if (ImGui::CollapsingHeader("Items and equipment")) {
+        ImGui::Checkbox("No consumables", &profile.block_consumables);
+        ImGui::Checkbox("No scrolls", &profile.block_scrolls);
+        ImGui::Checkbox("Lockpicks in Hard Mode only", &profile.lockpicks_hard_mode_only);
+        ImGui::ShowHelp("Normal Mode stays regular-keys-only even once Hard Mode is unlocked");
+        ImGui::Checkbox("No buying major/superior runes", &profile.block_purchased_runes);
+        ImGui::ShowHelp("Only blocks the purchase; the same rune picked up as loot stays legal");
+        ImGui::Checkbox("No buying Zaishen Coins", &profile.block_zaishen_coin_purchase);
+        DrawIdList("Blocked item model ids", profile.blocked_item_model_ids, "Comma-separated model ids that can't be used, equipped or bought (bonus and holiday weapons, Fire Imp, ...)");
+    }
+
+    if (ImGui::CollapsingHeader("Storage")) {
+        ImGui::Checkbox("No Xunlai Chest", &profile.block_xunlai_chest);
+    }
+
+    ImGui::Separator();
+    if (ImGui::Button("Save profile to file...")) {
+        Resources::SaveFileDialog([](const char* path) {
+            if (!path) {
+                return;
+            }
+            GW::GameThread::Enqueue([chosen = std::filesystem::path(path)] {
+                if (!WriteProfile(chosen)) {
+                    Log::Error("Failed to write playstyle restriction profile");
+                }
+            });
+        }, "json", Resources::GetPath(profile_filename).string().c_str());
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Load profile from file...")) {
+        Resources::OpenFileDialog([](const char* path) {
+            if (!path) {
+                return;
+            }
+            GW::GameThread::Enqueue([chosen = std::filesystem::path(path)] {
+                if (!ReadProfile(chosen)) {
+                    return Log::Error("Failed to read playstyle restriction profile");
+                }
+                Log::Info("Loaded playstyle restriction profile \"%s\"", profile.profile_name.c_str());
+                RefreshEnterMissionButton();
+            });
+        }, "json", Resources::GetPath(profile_filename).string().c_str());
+    }
+    ImGui::End();
+}
+
+void PlaystyleRestrictionsWindow::DrawSettingsInternal()
+{
+    ToolboxWindow::DrawSettingsInternal();
+    ImGui::TextDisabled("Gates are enforced where the client routes the action through something toolbox can block; anything else stays on the honour system.");
+}
+
+void PlaystyleRestrictionsWindow::LoadSettings(SettingsDoc& doc, ToolboxIni* legacy)
+{
+    ToolboxWindow::LoadSettings(doc, legacy);
+    doc.GetStruct(Name(), settings);
+    ReadProfile(Resources::GetPath(profile_filename));
+}
+
+void PlaystyleRestrictionsWindow::SaveSettings(SettingsDoc& doc)
+{
+    ToolboxWindow::SaveSettings(doc);
+    doc.SetStruct(Name(), settings);
+    WriteProfile(Resources::GetPath(profile_filename));
+}

--- a/GWToolboxdll/Windows/PlaystyleRestrictionsWindow.cpp
+++ b/GWToolboxdll/Windows/PlaystyleRestrictionsWindow.cpp
@@ -22,8 +22,6 @@
 #include <GWCA/Managers/SkillbarMgr.h>
 #include <GWCA/Managers/UIMgr.h>
 
-#include <GWCA/Context/WorldContext.h>
-
 #include <GWCA/Utilities/Hook.h>
 
 #include <ImGuiAddons.h>
@@ -33,6 +31,7 @@
 #include <Utils/SettingsDoc.h>
 #include <Utils/SettingsRegistry.h>
 #include <Utils/ToolboxUtils.h>
+#include <Windows/CompletionWindow.h>
 #include <Windows/PlaystyleRestrictionsWindow.h>
 
 using GW::Constants::Campaign;
@@ -124,12 +123,9 @@ namespace {
 
     // ==== Progression state ====
 
-    // Primary objective only, Normal Mode: challenge rulesets gate on "did the story happen",
-    // not on bonuses, so CompletionWindow::IsAreaComplete (which also demands the bonus) is too strict.
     bool IsMissionComplete(const MapID map_id)
     {
-        const auto world = GW::GetWorldContext();
-        return world && ToolboxUtils::ArrayBoolAt(world->missions_completed, static_cast<uint32_t>(map_id));
+        return CompletionWindow::IsAreaComplete(map_id, profile.require_hard_mode ? CompletionCheck::Both : CompletionCheck::NormalMode);
     }
 
     bool IsCampaignComplete(const Campaign campaign)
@@ -552,6 +548,8 @@ void PlaystyleRestrictionsWindow::Draw(IDirect3DDevice9*)
             ImGui::Checkbox("Also require the previous campaign's titles maxed", &profile.require_campaign_titles_maxed);
             ImGui::ShowHelp("Protector, Guardian, Vanquisher, Skill Hunter and Cartographer for that campaign (plus Sunspear/Lightbringer for Nightfall). Account-wide titles are never counted.");
         }
+        ImGui::Checkbox("Missions count only when done in Hard Mode too", &profile.require_hard_mode);
+        ImGui::ShowHelp("Applies to every mission check below. Either way a mission counts as done only with its bonus objective, matching the Completion window.");
         ImGui::Checkbox("Missions must be done in story order", &profile.block_mission_skipping);
         ImGui::ShowHelp("Greys out Enter Mission until every earlier mission of that campaign is complete");
         ImGui::Checkbox("Require titles before leaving pre-Searing", &profile.gate_presearing_exit);

--- a/GWToolboxdll/Windows/PlaystyleRestrictionsWindow.cpp
+++ b/GWToolboxdll/Windows/PlaystyleRestrictionsWindow.cpp
@@ -125,7 +125,11 @@ namespace {
 
     bool IsMissionComplete(const MapID map_id)
     {
-        return CompletionWindow::IsAreaComplete(map_id, profile.require_hard_mode ? CompletionCheck::Both : CompletionCheck::NormalMode);
+        auto check = profile.require_hard_mode ? CompletionCheck::Both : CompletionCheck::NormalMode;
+        if (!profile.require_mission_bonuses) {
+            check = static_cast<CompletionCheck>(check | CompletionCheck::PrimaryOnly);
+        }
+        return CompletionWindow::IsAreaComplete(map_id, check);
     }
 
     bool IsCampaignComplete(const Campaign campaign)
@@ -549,7 +553,8 @@ void PlaystyleRestrictionsWindow::Draw(IDirect3DDevice9*)
             ImGui::ShowHelp("Protector, Guardian, Vanquisher, Skill Hunter and Cartographer for that campaign (plus Sunspear/Lightbringer for Nightfall). Account-wide titles are never counted.");
         }
         ImGui::Checkbox("Missions count only when done in Hard Mode too", &profile.require_hard_mode);
-        ImGui::ShowHelp("Applies to every mission check below. Either way a mission counts as done only with its bonus objective, matching the Completion window.");
+        ImGui::ShowHelp("Applies to every mission check on this page");
+        ImGui::Checkbox("Missions also need their bonus objective", &profile.require_mission_bonuses);
         ImGui::Checkbox("Missions must be done in story order", &profile.block_mission_skipping);
         ImGui::ShowHelp("Greys out Enter Mission until every earlier mission of that campaign is complete");
         ImGui::Checkbox("Require titles before leaving pre-Searing", &profile.gate_presearing_exit);

--- a/GWToolboxdll/Windows/PlaystyleRestrictionsWindow.h
+++ b/GWToolboxdll/Windows/PlaystyleRestrictionsWindow.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <ToolboxWindow.h>
+
+// Self-imposed challenge-mode gates ("Copperman" and friends): a shareable profile of
+// restrictions that are enforced client-side wherever the game routes the action through
+// a UI message we can block. See site/src/content/docs/windows/playstyle-restrictions.md
+class PlaystyleRestrictionsWindow : public ToolboxWindow {
+    PlaystyleRestrictionsWindow() = default;
+    ~PlaystyleRestrictionsWindow() override = default;
+
+public:
+    static PlaystyleRestrictionsWindow& Instance()
+    {
+        static PlaystyleRestrictionsWindow instance;
+        return instance;
+    }
+
+    [[nodiscard]] const char* Name() const override { return "Playstyle Restrictions"; }
+    [[nodiscard]] const char* Description() const override { return "Enforce a shareable profile of self-imposed challenge-run restrictions"; }
+    [[nodiscard]] const char* Icon() const override { return ICON_FA_LOCK; }
+
+    struct RequiredTitle {
+        uint32_t title_id = 0; // GW::Constants::TitleID
+        uint32_t min_tier = 1;
+    };
+
+    // The shareable ruleset. Lives in its own json file, not in the toolbox settings doc,
+    // so it can be handed to another player verbatim.
+    struct Profile {
+        std::string profile_name = "Unnamed profile";
+        std::string author;
+        std::string notes;
+
+        std::vector<uint32_t> campaign_order = {1, 2, 3, 4}; // GW::Constants::Campaign
+        bool enforce_campaign_order = false;
+        bool block_mission_skipping = false;
+        bool require_campaign_titles_maxed = false;
+        bool gate_presearing_exit = false;
+        std::vector<RequiredTitle> required_presearing_titles = {{22, 1}, {9, 1}}; // LDoA, Survivor
+        uint32_t min_level_for_gated_areas = 0;
+
+        bool restrict_heroes_to_unlocked_campaigns = false;
+        uint32_t max_party_heroes = 0; // 0 = uncapped
+        bool lock_hero_skillbars = false;
+        std::vector<uint32_t> hero_allow_list; // GW::Constants::HeroID, always permitted
+        std::vector<uint32_t> hero_block_list;
+
+        bool restrict_skills_to_unlocked_campaigns = false;
+        bool single_attribute_line = false;
+        bool lock_skillbar = false;
+        bool block_elite_tomes = false;
+
+        bool block_consumables = false;
+        bool block_scrolls = false;
+        bool lockpicks_hard_mode_only = false;
+        bool block_purchased_runes = false; // major/superior only; loot-dropped ones stay legal
+        bool block_zaishen_coin_purchase = false;
+        std::vector<uint32_t> blocked_item_model_ids; // bonus/holiday weapons etc
+
+        bool block_xunlai_chest = false;
+    };
+
+    struct Settings {
+        bool enforce = true;
+    };
+
+    void Initialize() override;
+    void Terminate() override;
+    void Draw(IDirect3DDevice9* pDevice) override;
+    void DrawSettingsInternal() override;
+    void LoadSettings(SettingsDoc& doc, ToolboxIni* legacy) override;
+    void SaveSettings(SettingsDoc& doc) override;
+};

--- a/GWToolboxdll/Windows/PlaystyleRestrictionsWindow.h
+++ b/GWToolboxdll/Windows/PlaystyleRestrictionsWindow.h
@@ -37,6 +37,7 @@ public:
         bool block_mission_skipping = false;
         bool require_campaign_titles_maxed = false;
         bool require_hard_mode = false;
+        bool require_mission_bonuses = false;
         bool gate_presearing_exit = false;
         std::vector<RequiredTitle> required_presearing_titles = {{22, 1}, {9, 1}}; // LDoA, Survivor
         uint32_t min_level_for_gated_areas = 0;

--- a/GWToolboxdll/Windows/PlaystyleRestrictionsWindow.h
+++ b/GWToolboxdll/Windows/PlaystyleRestrictionsWindow.h
@@ -36,6 +36,7 @@ public:
         bool enforce_campaign_order = false;
         bool block_mission_skipping = false;
         bool require_campaign_titles_maxed = false;
+        bool require_hard_mode = false;
         bool gate_presearing_exit = false;
         std::vector<RequiredTitle> required_presearing_titles = {{22, 1}, {9, 1}}; // LDoA, Survivor
         uint32_t min_level_for_gated_areas = 0;

--- a/site/src/content/docs/playstyle_restrictions.mdx
+++ b/site/src/content/docs/playstyle_restrictions.mdx
@@ -14,8 +14,9 @@ The profile is the rules; your progress through them is read live from the game,
 
 ## Campaign progression
 
-- **Enforce campaign order** — blocks map travel into, and Enter Mission inside, a campaign whose predecessor isn't finished. The order is yours to arrange; the default is Prophecies → Factions → Nightfall → Eye of the North. A campaign counts as finished when its final mission is complete in Normal Mode.
+- **Enforce campaign order** — blocks map travel into, and Enter Mission inside, a campaign whose predecessor isn't finished. The order is yours to arrange; the default is Prophecies → Factions → Nightfall → Eye of the North. A campaign counts as finished when its final mission is complete, using the same definition as the [Completion](/docs/completion) window — primary objective *and* bonus.
 - **Also require the previous campaign's titles maxed** — additionally requires Protector, Guardian, Vanquisher, Skill Hunter and Cartographer for that campaign (plus Sunspear and Lightbringer for Nightfall). Account-wide titles such as Party or Sweet Tooth are never counted.
+- **Missions count only when done in Hard Mode too** — applies to every mission check on this page; off means Normal Mode is enough.
 - **Missions must be done in story order** — greys out Enter Mission until every earlier mission of that campaign is complete, so missions can't be skipped by being run ahead.
 - **Require titles before leaving pre-Searing** — blocks the trip out of pre-Searing until the listed titles are earned. Defaults to Legendary Defender of Ascalon and Survivor rank 1.
 - **Minimum level for gated areas** — blocks Enter Mission for any area that carries a level requirement until you reach the level you set here.

--- a/site/src/content/docs/playstyle_restrictions.mdx
+++ b/site/src/content/docs/playstyle_restrictions.mdx
@@ -1,0 +1,57 @@
+---
+title: "Playstyle Restrictions"
+description: "Build, share and enforce a profile of self-imposed challenge-run restrictions such as Copperman mode."
+section: windows
+---
+
+import ToolboxPath from '../../components/ToolboxPath.astro';
+
+Open from <ToolboxPath kind="window" steps={["Toolbox", "Playstyle Restrictions"]} />. Per-window options live under <ToolboxPath steps={["Settings", "Playstyle Restrictions"]} />.
+
+Challenge runs like "Copperman" — play the campaigns in release order, gate heroes, skills and gear to what a fresh account would naturally have — are normally enforced by honour system. This window turns that ruleset into a **profile**: a checklist of restrictions that GWToolbox enforces where it can, saved as a `.json` file you can hand to anyone else running the same challenge.
+
+The profile is the rules; your progress through them is read live from the game, so nothing extra needs saving per character.
+
+## Campaign progression
+
+- **Enforce campaign order** — blocks map travel into, and Enter Mission inside, a campaign whose predecessor isn't finished. The order is yours to arrange; the default is Prophecies → Factions → Nightfall → Eye of the North. A campaign counts as finished when its final mission is complete in Normal Mode.
+- **Also require the previous campaign's titles maxed** — additionally requires Protector, Guardian, Vanquisher, Skill Hunter and Cartographer for that campaign (plus Sunspear and Lightbringer for Nightfall). Account-wide titles such as Party or Sweet Tooth are never counted.
+- **Missions must be done in story order** — greys out Enter Mission until every earlier mission of that campaign is complete, so missions can't be skipped by being run ahead.
+- **Require titles before leaving pre-Searing** — blocks the trip out of pre-Searing until the listed titles are earned. Defaults to Legendary Defender of Ascalon and Survivor rank 1.
+- **Minimum level for gated areas** — blocks Enter Mission for any area that carries a level requirement until you reach the level you set here.
+
+## Heroes
+
+- **Heroes limited to unlocked campaigns** — no Olias before Nightfall is unlocked, no MOX in Prophecies.
+- **Maximum heroes in party** — caps the roster.
+- **Lock hero skillbars** — blocks loading a template onto anyone but yourself.
+- **Always-allowed / never-allowed heroes** — comma-separated hero ids. The allow list wins over every other hero rule, which is how you make exceptions such as Reforged Devona.
+
+## Skills
+
+- **Skills limited to unlocked campaigns** — refuses a skill template containing skills from a campaign you haven't unlocked. This approximates "what a fresh account would have unlocked" by campaign rather than by individual quest.
+- **One attribute line only** — refuses a bar that spends on more than one attribute.
+- **Lock the skillbar entirely** — refuses every template load.
+- **No elite tomes**.
+
+## Items and equipment
+
+- **No consumables** / **No scrolls**.
+- **Lockpicks in Hard Mode only** — Normal Mode stays regular-keys-only even after Hard Mode is unlocked.
+- **No buying major/superior runes** — blocks the *purchase* only; the same rune picked up as loot stays legal.
+- **No buying Zaishen Coins**.
+- **Blocked item model ids** — comma-separated model ids that can't be used, equipped or bought. Use this for bonus and holiday weapons, Fire Imp, and anything else your group bans.
+
+## Storage
+
+- **No Xunlai Chest** — the chest simply won't open. A "fresh account" run just leaves this off.
+
+## Sharing a profile
+
+**Save profile to file...** writes every toggle above to a `.json` file; **Load profile from file...** reads one back. The file is the whole ruleset, so authoring it once and sharing it verbatim reproduces the same restrictions for everyone else. Your own copy is also kept in `playstyle_restrictions.json` in your GWToolbox settings folder.
+
+**Enforce this profile** turns blocking on and off without losing the profile.
+
+## What is not enforced
+
+The module gates what the client routes through an action it can block, and does not police anything else. Character creation choices, who you trade with, walking through a portal into a gated zone, and any rule you break outside the game client are on you — as is the exported file itself, which is plain text.

--- a/site/src/content/docs/playstyle_restrictions.mdx
+++ b/site/src/content/docs/playstyle_restrictions.mdx
@@ -14,9 +14,10 @@ The profile is the rules; your progress through them is read live from the game,
 
 ## Campaign progression
 
-- **Enforce campaign order** — blocks map travel into, and Enter Mission inside, a campaign whose predecessor isn't finished. The order is yours to arrange; the default is Prophecies → Factions → Nightfall → Eye of the North. A campaign counts as finished when its final mission is complete, using the same definition as the [Completion](/docs/completion) window — primary objective *and* bonus.
+- **Enforce campaign order** — blocks map travel into, and Enter Mission inside, a campaign whose predecessor isn't finished. The order is yours to arrange; the default is Prophecies → Factions → Nightfall → Eye of the North. A campaign counts as finished when its final mission is complete.
 - **Also require the previous campaign's titles maxed** — additionally requires Protector, Guardian, Vanquisher, Skill Hunter and Cartographer for that campaign (plus Sunspear and Lightbringer for Nightfall). Account-wide titles such as Party or Sweet Tooth are never counted.
 - **Missions count only when done in Hard Mode too** — applies to every mission check on this page; off means Normal Mode is enough.
+- **Missions also need their bonus objective** — off by default, so a mission counts once its primary objective is done. Turn it on for a stricter run.
 - **Missions must be done in story order** — greys out Enter Mission until every earlier mission of that campaign is complete, so missions can't be skipped by being run ahead.
 - **Require titles before leaving pre-Searing** — blocks the trip out of pre-Searing until the listed titles are earned. Defaults to Legendary Defender of Ascalon and Survivor rank 1.
 - **Minimum level for gated areas** — blocks Enter Mission for any area that carries a level requirement until you reach the level you set here.

--- a/site/src/lib/nav.ts
+++ b/site/src/lib/nav.ts
@@ -41,6 +41,7 @@ export const navGroups: NavGroup[] = [
       { slug: 'armory_window', label: 'Armory' },
       { slug: 'duping_window', label: 'Duping' },
       { slug: 'account_inventory', label: 'Account Inventory' },
+      { slug: 'playstyle_restrictions', label: 'Playstyle Restrictions' },
     ],
   },
   {


### PR DESCRIPTION
Closes #2491.

Adds a **Playstyle Restrictions** window: a checklist of challenge-run gates that gets saved to / loaded from a `.json` file, so a group can share one ruleset instead of a wall of text.

Enforcement hangs off the UI messages the client routes player actions through, so a blocked action never becomes a packet.

| Restriction | Hook |
| --- | --- |
| Campaign order (configurable), optionally "previous campaign's titles maxed"; pre-Searing exit gated on titles | `kTravel` |
| Missions in story order (`mission_chronology`), area level gates | Enter Mission button held disabled via `kDisableEnterMissionBtn` |
| Heroes by native campaign, roster cap, allow/block lists | `kPartyAddHero` |
| Skills by campaign, single attribute line, locked bar, locked hero bars | `kSendLoadSkillTemplate` |
| Consumables, scrolls, elite tomes, lockpicks in HM only, blocked model ids | `kSendUseItem` |
| Purchased major/superior runes, Zaishen Coins, blocked model ids | `kSendMerchantTransactItem` |
| Blocked model ids | `kEquipItem` |
| Xunlai Chest | `kShowXunlaiChest` |

Per the issue's resolved questions: no warn/violation layer (Q6) — it gates what it can gate and stays quiet otherwise; runes are a buy-vs-pickup distinction only (Q1); skill unlocks are approximated per campaign rather than per quest (Q3); no Fresh Account flag (Q5); no party syncing (Q7); no trade-off wheel (Q2).

Progress state is read live from the game, so there's no separate per-character save file to keep in sync.

### CompletionWindow changes (2 separate commits)

- `b52520b95` fixed `GW::Map::GetMapInfo()` → `GetMapInfo(map_id)` in the file-local `IsAreaComplete`. The public `CompletionWindow::IsAreaComplete` overload was a near-duplicate and still had the bug; fixed there too, and the public overload now **delegates** to the file-local one so there's only one copy left.
- New `CompletionCheck::PrimaryOnly` flag drops the bonus-objective requirement. A mission otherwise only counts as complete with its bonus, which is right for protector/guardian tracking but too strict as a progression gate. Exposed as a per-profile toggle (off by default) alongside a Hard Mode toggle.

### Not implemented, and why

- **Elite armour set required before advancing** — no reliable client-side way to identify an armour piece's tier.
- **Zaishen quest board limited to unlocked campaigns** — needs a ZQuest → campaign table and a dialog-id map that doesn't exist yet.
- **Forced dye auto-apply** — cosmetic auto-apply rather than a gate; nothing to block.
- **Walking through a portal** into a gated zone is server-driven; map travel and Enter Mission are gated, portals are not.

Docs: `site/src/content/docs/playstyle_restrictions.mdx` + `nav.ts` entry; `npm run build` passes and the page lands in `llms.txt`.

⚠️ **Not compile-tested** — no MSVC/Windows toolchain in this environment. Needs a build before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)