### PR TITLE
Actually find the blockmap assert: FindAssertion never matched it

### DIFF
--- a/GWToolboxdll/Modules/CrashFixesModule.cpp
+++ b/GWToolboxdll/Modules/CrashFixesModule.cpp
@@ -9,32 +9,37 @@
 #include "CrashFixesModule.h"
 
 namespace {
-    GW::MemoryPatcher blockmap_dims_x_assert_patch;
-    GW::MemoryPatcher blockmap_dims_y_assert_patch;
+    // Tripped on every map reveal packet by any map whose AreaInfo rect disagrees with its pathmap dimensions;
+    // Kodonur Crossroads and Sunjiang Horde do as of build 38848.
+    constexpr char blockmap_dims_assertion[] =
+        "blockMapDims.x == missionRect.x1 - missionRect.x0 && blockMapDims.y == missionRect.y1 - missionRect.y0";
+
+    constexpr char skip_assert_call[] = "\x83\xC4\x04\x90\x90"; // ADD ESP,4 (the pushed line number), then pad
+
+    GW::MemoryPatcher blockmap_dims_assert_patch;
 }
 
 void CrashFixesModule::Initialize()
 {
     ToolboxModule::Initialize();
 
-    const auto y_check_address = GW::Scanner::FindAssertion("ChCliApi.cpp", "blockMapDims.x == missionRect.x1 - missionRect.x0 && blockMapDims.y == missionRect.y1 - missionRect.y0", 0, -5);
-    DEBUG_ASSERT(y_check_address && *(uint8_t*)y_check_address == 0x74); // je <matched>
-    if (y_check_address) {
-        blockmap_dims_y_assert_patch.SetPatch(y_check_address, "\xeb", 1);
-        blockmap_dims_y_assert_patch.TogglePatch(true);
-
-        const auto x_check_address = y_check_address - 10;
-        DEBUG_ASSERT(*(uint8_t*)x_check_address == 0x75); // jne <report>
-        blockmap_dims_x_assert_patch.SetPatch(x_check_address, "\x90\x90", 2);
-        blockmap_dims_x_assert_patch.TogglePatch(true);
+    // Not FindAssertion: it needs PUSH <line>, MOV EDX,<file>, MOV ECX,<msg> contiguous, and here the compiler
+    // emits the MOV EDX before the PUSH, so that pattern never matches. Anchor on the message reference instead.
+    const auto message_operand = GW::Scanner::FindUseOfString(blockmap_dims_assertion);
+    const auto call_address = message_operand ? message_operand + 4 : 0;
+    if (call_address && *(uint8_t*)call_address == 0xE8) {
+        // The handler isn't noreturn here; the instructions after the call reload the rect pointers and fall into
+        // the paint loop, so skipping the call resumes the path the code already intended.
+        blockmap_dims_assert_patch.SetPatch(call_address, skip_assert_call, 5);
+        blockmap_dims_assert_patch.TogglePatch(true);
     }
-    Log::Log("[CrashFixes] blockmap_dims_x_assert_patch = %p, blockmap_dims_y_assert_patch = %p\n",
-             blockmap_dims_x_assert_patch.GetAddress(), blockmap_dims_y_assert_patch.GetAddress());
+    DEBUG_ASSERT(blockmap_dims_assert_patch.GetAddress());
+
+    Log::Log("[CrashFixes] blockmap_dims_assert_patch = %p\n", blockmap_dims_assert_patch.GetAddress());
 }
 
 void CrashFixesModule::Terminate()
 {
     ToolboxModule::Terminate();
-    blockmap_dims_x_assert_patch.Reset();
-    blockmap_dims_y_assert_patch.Reset();
+    blockmap_dims_assert_patch.Reset();
 }


### PR DESCRIPTION
## The problem

`CrashFixesModule` has never patched anything. `GW::Scanner::FindAssertion` matches `PUSH <line>` / `MOV EDX,<file>` / `MOV ECX,<msg>` as **contiguous** instructions. At this particular assert site the compiler spills `ECX` and emits the `MOV EDX` *before* the `PUSH`, so the pattern can't match and the scan returns `0`:

```
00817d8c  MOV  dword ptr [EBP-0x8],ECX
00817d8f  MOV  EDX,0xa94d2c        ; "ChCliApi.cpp"
00817d94  PUSH 0xdf                ; line
00817d99  MOV  ECX,0xa94e48        ; "blockMapDims.x == missionRect.x1 - ..."
00817d9e  CALL 0x00487bc0          ; assert handler
```

`DEBUG_ASSERT` caught it in debug; release just logged `nullptr` and moved on. So players running toolbox were still getting the forced crash — which is what's being reported.

## The fix

Anchor on the assertion message's own relocation (`Scanner::FindUseOfString`) instead of the instruction-order pattern, and neuter the 5-byte `CALL` rather than the two conditional jumps in front of it:

- Robust to the operand ordering, and to the assert moving line — it has already moved from `ChCliApi.cpp(223)` in 38833 to `(238)` in 38848, which is where the old hardcoded `-10` offset would also have been at risk.
- Fails safe: if the byte at `msg_ref + 4` isn't `0xE8` we patch nothing and log it.
- The compiler didn't treat the handler as `noreturn` here — `00817da3` reloads the rect pointers and falls into the paint loop — so skipping the call resumes the path the code already intended. `ADD ESP,4` keeps the stack balanced.

## Background

The assert compares the **static `AreaInfo` rect table** (`0x0096de38 + id*0x7c`, `+0x48..0x54`, or the `_dupe` at `+0x58..0x64`, selected by `worldctx+0x238`) against the **map's own pathmap dimensions**. Two independent data sources; a map where they disagree asserts on every reveal packet, deterministically. Each rect edge is shifted `>>5` independently, so an edge that isn't 32-aligned mismatches by one on its own.

Kodonur Crossroads and Sunjiang Horde are currently in that state on build 38848. ANet's "fixed a client crash related to playing certain cinematics" touched this file (hence the line shift) but left this check alone.

## Testing

Not built here — no MSVC in this environment. Byte-level analysis is against build 38833; the reported crash is 38848, where addresses shift but the message anchor doesn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)