### PR TITLE
Fix Nicholas Sandford item tooltip showing the wrong collection date

### DIFF
--- a/GWToolboxdll/Modules/ItemTooltipModule.cpp
+++ b/GWToolboxdll/Modules/ItemTooltipModule.cpp
@@ -184,6 +184,9 @@ namespace {
 
         static std::wstring last_item_name;
         static std::wstring last_nicholas_text;
+        static time_t last_nicholas_text_time = 0;
+
+        const auto current_time = time(nullptr);
 
         auto append = [&](std::wstring text) {
             if (!description.empty()) description += L"\x2";
@@ -191,19 +194,19 @@ namespace {
             last_nicholas_text = text;
         };
 
-        if (item->name_enc == last_item_name) {
-            append(last_nicholas_text);
+        // Cached text holds a relative time ("in 3 days"), so it has to be recalculated once it's had chance to go stale
+        if (item->name_enc == last_item_name && current_time - last_nicholas_text_time < 60) {
+            if (!last_nicholas_text.empty()) append(last_nicholas_text);
             return;
         }
         last_nicholas_text.clear();
         last_item_name = item->name_enc;
-
-        const auto current_time = time(nullptr);
+        last_nicholas_text_time = current_time;
 
         if (GW::Map::IsPreSearing()) {
             const auto info = DailyQuests::GetNicholasSandfordItemInfo(item->name_enc);
             if (!info) return;
-            const auto collection_time = DailyQuests::GetTimestampFromNicholasSandford(info);
+            const auto collection_time = DailyQuests::GetTimestampFromNicholasSandford(info, current_time);
             if (collection_time <= current_time)
                 append(std::format(L"Nicholas Sandford collects {} of these right now!", 5));
             else
@@ -217,8 +220,8 @@ namespace {
 
         const auto ingredient_nick_info = ingredient ? DailyQuests::GetNicholasItemInfo(ingredient->nicholas_item) : nullptr;
 
-        const auto info_time = info ? DailyQuests::GetTimestampFromNicholasTheTraveller(info) : std::numeric_limits<time_t>::max();
-        const auto ingredient_time = ingredient_nick_info ? DailyQuests::GetTimestampFromNicholasTheTraveller(ingredient_nick_info) : std::numeric_limits<time_t>::max();
+        const auto info_time = info ? DailyQuests::GetTimestampFromNicholasTheTraveller(info, current_time) : std::numeric_limits<time_t>::max();
+        const auto ingredient_time = ingredient_nick_info ? DailyQuests::GetTimestampFromNicholasTheTraveller(ingredient_nick_info, current_time) : std::numeric_limits<time_t>::max();
 
         if (info && info_time <= ingredient_time) {
             const auto quantity_for_total_gifts = info->quantity * 5;

--- a/GWToolboxdll/Windows/DailyQuestsWindow.cpp
+++ b/GWToolboxdll/Windows/DailyQuestsWindow.cpp
@@ -2004,18 +2004,22 @@ const DailyQuests::NicholasIngredientInfo* DailyQuests::GetNicholasIngredientInf
     return 0;
 }
 
-time_t DailyQuests::GetTimestampFromNicholasSandford(QuestData* data)
+time_t DailyQuests::GetTimestampFromNicholasSandford(QuestData* data, time_t now)
 {
     constexpr time_t NICHOLAS_PRE_START_DATE = 1239260400;
     constexpr int SECONDSINADAY = 86400;
-    auto index = -1;
+    if (!now) now = time(nullptr);
+    // The 52 day cycle only contains 13 different items, so each one comes up several times.
+    // Check every slot holding this item and return the soonest, not just the first slot in the table.
+    auto next_event_time = std::numeric_limits<time_t>::max();
     for (auto i = 0; i < static_cast<int>(NICHOLAS_PRE_COUNT); i++) {
-        if (&nicholas_sandford_cycles[i] == data) {
-            index = i;
+        if (nicholas_sandford_cycles[i].enc_name != data->enc_name) {
+            continue;
         }
+        next_event_time = std::min(next_event_time, GetNextEventTime(NICHOLAS_PRE_START_DATE, now, i, NICHOLAS_PRE_COUNT, SECONDSINADAY));
     }
-    assert(index != -1);
-    return GetNextEventTime(NICHOLAS_PRE_START_DATE, time(nullptr), index, NICHOLAS_PRE_COUNT, SECONDSINADAY);
+    assert(next_event_time != std::numeric_limits<time_t>::max());
+    return next_event_time;
 }
 
 DailyQuests::DailyQuestResult DailyQuests::GetNicholasTheTraveller(time_t unix)
@@ -2104,12 +2108,13 @@ const DailyQuests::ZaishenCoinReward* DailyQuests::GetZaishenCoinReward(GW::Cons
     return it != zaishen_coin_rewards.end() ? &it->second : nullptr;
 }
 
-time_t DailyQuests::GetTimestampFromNicholasTheTraveller(NicholasCycleData* data)
+time_t DailyQuests::GetTimestampFromNicholasTheTraveller(NicholasCycleData* data, time_t now)
 {
     /*
     This function returns the next start time of the cycle data or the
     current time if the cycle is ongoing
     */
+    if (!now) now = time(nullptr);
     auto index = -1;
     for (auto i = 0; i < NICHOLAS_POST_COUNT; i++) {
         if (&nicholas_cycles[i] == data) {
@@ -2118,5 +2123,5 @@ time_t DailyQuests::GetTimestampFromNicholasTheTraveller(NicholasCycleData* data
     }
 
     assert(index != -1);
-    return GetNextEventTime(NICHOLAS_POST_START_DATE, time(nullptr), index, NICHOLAS_POST_COUNT, SECONDSINAWEEK);
+    return GetNextEventTime(NICHOLAS_POST_START_DATE, now, index, NICHOLAS_POST_COUNT, SECONDSINAWEEK);
 }

--- a/GWToolboxdll/Windows/DailyQuestsWindow.h
+++ b/GWToolboxdll/Windows/DailyQuestsWindow.h
@@ -86,9 +86,12 @@ public:
     static DailyQuestResult GetZaishenMission(time_t unix = 0);
     static DailyQuestResult GetZaishenCombat(time_t unix = 0);
     static DailyQuestResult GetNicholasTheTraveller(time_t unix = 0);
-    static time_t GetTimestampFromNicholasTheTraveller(DailyQuests::NicholasCycleData* data);
+    // Returns the next time Nicholas the Traveler collects this item, or `now` if he's collecting it already
+    static time_t GetTimestampFromNicholasTheTraveller(DailyQuests::NicholasCycleData* data, time_t now = 0);
     static DailyQuestResult GetNicholasSandford(time_t unix = 0);
-    static time_t GetTimestampFromNicholasSandford(DailyQuests::QuestData* data);
+    // Returns the next time Nicholas Sandford collects this item, or `now` if he's collecting it already.
+    // Items appear several times in the pre-searing cycle; the soonest occurrence is returned.
+    static time_t GetTimestampFromNicholasSandford(DailyQuests::QuestData* data, time_t now = 0);
     static DailyQuestResult GetVanguardQuest(time_t unix = 0);
     static DailyQuestResult GetWantedByShiningBlade(time_t unix = 0);
     static DailyQuestResult GetWeeklyPvEBonus(time_t unix = 0);


### PR DESCRIPTION
### Problem

Hovering an item in pre-searing shows e.g. *"Nicholas Sandford collects 5 of these in 18 days!"* when he is in fact collecting it **today**.

`nicholas_sandford_cycles[]` is 52 days long but holds only 13 distinct items, so every item occupies 3-5 slots:

```
WornBelts      -> slots [17, 32, 38, 50]
DullCarapaces  -> slots [8, 33, 45, 51]
BakedHusks     -> slots [1, 9, 26, 40]
```

`GetNicholasSandfordItemInfo()` returns the **first** matching entry, and `GetTimestampFromNicholasSandford()` resolved that pointer back to its index and asked when *that single slot* next comes round - ignoring the other occurrences. The result is right for roughly a quarter of the items and can be up to 51 days out, and the `collection_time <= current_time` ("collects these right now!") branch in `ItemTooltipModule` could only fire on the days matching an item's first slot.

Measured at 2026-08-21 05:41 UTC (cycle index 50, Worn Belts):

| item | before | actual |
|---|---|---|
| Worn Belts | in 18 days (Sep 8) | right now |
| Dull Carapaces | in 9 days (Aug 30) | today, 07:00 UTC |

The cycle table itself is correct - all 52 entries match the wiki's daily activities schedule, as does the 07:00 UTC epoch. Nicholas the Traveler is unaffected (all 137 entries are distinct).

### Fix

- `GetTimestampFromNicholasSandford()` now matches on the item's encoded name across the whole cycle and returns the soonest occurrence.
- Both `GetTimestampFrom…` helpers take the caller's timestamp instead of re-reading the clock; a clock tick between `ItemTooltipModule`'s `time(nullptr)` and the helper's own call silently lost the "right now" branch.
- The cached tooltip text is expired after 60s, since it embeds a relative time that otherwise went stale (and never refreshed across the daily rollover) while hovering the same item.

Not compiled locally - no toolchain in this environment, leaving that to CI.