### PR TITLE
Fix Quest Module's "Mission Map" checkbox being a no-op

### DIFF
--- a/GWToolboxdll/Widgets/MissionMapWidget.cpp
+++ b/GWToolboxdll/Widgets/MissionMapWidget.cpp
@@ -583,7 +583,8 @@ namespace {
         for (const auto& line : lines) {
             if (!line->visible) continue;
             if (line->world_coords) continue; // world coords, not game coords; drawn by DrawWorldCoordRouteLines
-            if (!line->draw_on_mission_map && !(settings.draw_all_minimap_lines && line->draw_on_minimap) && !(settings.draw_all_terrain_lines && line->draw_on_terrain)) continue;
+            const bool draw_all_override = !line->created_by_toolbox && ((settings.draw_all_minimap_lines && line->draw_on_minimap) || (settings.draw_all_terrain_lines && line->draw_on_terrain));
+            if (!line->draw_on_mission_map && !draw_all_override) continue;
             if (line->map != map_id) continue;
             if (line->from_player_pos && player_pos) {
                 minimap_lines.push_back(D3DLine(*player_pos, line->p2, LINE_HALF_THICKNESS, static_cast<DWORD>(line->color)));


### PR DESCRIPTION
Reported by Redeemer on Discord: the Quest Module's **Mission Map** checkbox had no visible effect - the quest path on the mission map was toggled by the **Minimap** checkbox instead.

**Cause:** `EnqueueMinimapLines` in `MissionMapWidget.cpp` treated the Mission Map widget's "Draw all minimap lines" option (on by default) as an override for *every* line. Quest path lines set `draw_on_minimap` from the Quest Module's Minimap checkbox, so they were drawn on the mission map regardless of their own `draw_on_mission_map` flag.

**Fix:** the draw-all opt-ins now only apply to user-created custom lines, which have no per-line mission-map checkbox. Toolbox-generated lines (quest paths, pathfinding routes) honour their own `draw_on_mission_map` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)