### PR TITLE
Settings search: only offer settings the Settings window actually draws

### DIFF
--- a/GWToolboxdll/Modules/Updater.h
+++ b/GWToolboxdll/Modules/Updater.h
@@ -21,7 +21,8 @@ public:
     }
 
     [[nodiscard]] const char* Name() const override { return "Updater"; }
-    // DrawSettingInternal() called via ToolboxSettings; don't draw it again
+    // DrawSettingInternal() called via ToolboxSettings; don't draw it again, and point settings search there
+    [[nodiscard]] const char* SettingsName() const override { return "Toolbox Settings"; }
     bool HasSettings() override { return false; }
 
     enum class ReleaseType : int {

--- a/GWToolboxdll/Utils/SettingsRegistry.cpp
+++ b/GWToolboxdll/Utils/SettingsRegistry.cpp
@@ -20,7 +20,7 @@ namespace {
 } // namespace
 
 namespace SettingsRegistry {
-    void detail::AddEntry(ToolboxModule* module, const std::string_view key, const Type type, void* ptr, const bool from_struct, const std::string_view description)
+    void detail::AddEntry(ToolboxModule* module, const std::string_view key, const Type type, void* ptr, const bool from_struct, const bool in_settings_window, const std::string_view description)
     {
         const auto found = std::ranges::find_if(entries, [module, key](const Entry& e) {
             return e.module == module && e.key == key;
@@ -34,6 +34,7 @@ namespace SettingsRegistry {
         entry.type = type;
         entry.ptr = ptr;
         entry.from_struct = from_struct;
+        entry.in_settings_window = in_settings_window;
     }
 
     void detail::LogUnsupportedMember(ToolboxModule* module, const std::string_view key)
@@ -43,37 +44,37 @@ namespace SettingsRegistry {
 
     void RegisterField(ToolboxModule* module, const std::string_view key, bool* ptr, const std::string_view description)
     {
-        detail::AddEntry(module, key, Type::Bool, ptr, false, description);
+        detail::AddEntry(module, key, Type::Bool, ptr, false, true, description);
     }
 
     void RegisterField(ToolboxModule* module, const std::string_view key, int* ptr, const std::string_view description)
     {
-        detail::AddEntry(module, key, Type::Int, ptr, false, description);
+        detail::AddEntry(module, key, Type::Int, ptr, false, true, description);
     }
 
     void RegisterField(ToolboxModule* module, const std::string_view key, unsigned int* ptr, const std::string_view description)
     {
-        detail::AddEntry(module, key, Type::Uint, ptr, false, description);
+        detail::AddEntry(module, key, Type::Uint, ptr, false, true, description);
     }
 
     void RegisterField(ToolboxModule* module, const std::string_view key, float* ptr, const std::string_view description)
     {
-        detail::AddEntry(module, key, Type::Float, ptr, false, description);
+        detail::AddEntry(module, key, Type::Float, ptr, false, true, description);
     }
 
     void RegisterField(ToolboxModule* module, const std::string_view key, std::string* ptr, const std::string_view description)
     {
-        detail::AddEntry(module, key, Type::String, ptr, false, description);
+        detail::AddEntry(module, key, Type::String, ptr, false, true, description);
     }
 
     void RegisterField(ToolboxModule* module, const std::string_view key, Colors::SettingColor* ptr, const std::string_view description)
     {
-        detail::AddEntry(module, key, Type::Color, &ptr->value, false, description);
+        detail::AddEntry(module, key, Type::Color, &ptr->value, false, true, description);
     }
 
     void RegisterField(ToolboxModule* module, const std::string_view key, std::array<float, 2>* ptr, const std::string_view description)
     {
-        detail::AddEntry(module, key, Type::Float2, ptr, false, description);
+        detail::AddEntry(module, key, Type::Float2, ptr, false, true, description);
     }
 
     void Describe(ToolboxModule* module, const std::string_view key, const std::string_view label, const std::string_view description)

--- a/GWToolboxdll/Utils/SettingsRegistry.h
+++ b/GWToolboxdll/Utils/SettingsRegistry.h
@@ -28,38 +28,39 @@ namespace SettingsRegistry {
         Type type = Type::Bool;
         void* ptr = nullptr;     // live value; Color entries point at the raw ::Color
         bool from_struct = false;
+        bool in_settings_window = true; // false when the module draws this setting in its own UI instead
     };
 
     namespace detail {
-        void AddEntry(ToolboxModule* module, std::string_view key, Type type, void* ptr, bool from_struct, std::string_view description = {});
+        void AddEntry(ToolboxModule* module, std::string_view key, Type type, void* ptr, bool from_struct, bool in_settings_window = true, std::string_view description = {});
         void LogUnsupportedMember(ToolboxModule* module, std::string_view key);
 
         template <typename M>
-        void RegisterMember(ToolboxModule* module, const std::string_view key, M& member)
+        void RegisterMember(ToolboxModule* module, const std::string_view key, M& member, const bool in_settings_window)
         {
             if constexpr (std::same_as<M, bool>) {
-                AddEntry(module, key, Type::Bool, &member, true);
+                AddEntry(module, key, Type::Bool, &member, true, in_settings_window);
             }
             else if constexpr (std::same_as<M, int>) {
-                AddEntry(module, key, Type::Int, &member, true);
+                AddEntry(module, key, Type::Int, &member, true, in_settings_window);
             }
             else if constexpr (std::same_as<M, unsigned int>) {
-                AddEntry(module, key, Type::Uint, &member, true);
+                AddEntry(module, key, Type::Uint, &member, true, in_settings_window);
             }
             else if constexpr (std::same_as<M, float>) {
-                AddEntry(module, key, Type::Float, &member, true);
+                AddEntry(module, key, Type::Float, &member, true, in_settings_window);
             }
             else if constexpr (std::same_as<M, std::string>) {
-                AddEntry(module, key, Type::String, &member, true);
+                AddEntry(module, key, Type::String, &member, true, in_settings_window);
             }
             else if constexpr (std::same_as<M, Colors::SettingColor>) {
-                AddEntry(module, key, Type::Color, &member.value, true);
+                AddEntry(module, key, Type::Color, &member.value, true, in_settings_window);
             }
             else if constexpr (std::same_as<M, std::array<float, 2>>) {
-                AddEntry(module, key, Type::Float2, &member, true);
+                AddEntry(module, key, Type::Float2, &member, true, in_settings_window);
             }
             else if constexpr (std::is_enum_v<M> && sizeof(M) == sizeof(int)) {
-                AddEntry(module, key, Type::Int, &member, true);
+                AddEntry(module, key, Type::Int, &member, true, in_settings_window);
             }
             else {
                 // Still persisted by glaze via the struct round-trip, just not searchable/chat-settable.
@@ -72,13 +73,15 @@ namespace SettingsRegistry {
     // search, chat commands and the INI fallback. Persistence is the module's job: its
     // LoadSettings/SaveSettings overrides call doc.GetStruct/SetStruct(Name(), settings) so every
     // module keeps a dedicated debugging point.
+    // Pass in_settings_window = false when the module draws these settings in its own UI rather than in
+    // the Settings window, so settings search doesn't offer results that lead nowhere.
     template <typename T>
-    void Register(ToolboxModule* module, T& settings)
+    void Register(ToolboxModule* module, T& settings, const bool in_settings_window = true)
     {
         static_assert(glz::reflectable<T>, "Settings struct must be a plain glaze-reflectable aggregate");
         auto tie = glz::to_tie(settings);
         [&]<size_t... I>(std::index_sequence<I...>) {
-            (detail::RegisterMember(module, glz::reflect<T>::keys[I], glz::get<I>(tie)), ...);
+            (detail::RegisterMember(module, glz::reflect<T>::keys[I], glz::get<I>(tie), in_settings_window), ...);
         }(std::make_index_sequence<glz::reflect<T>::size>{});
     }
 

--- a/GWToolboxdll/Widgets/WorldMapWidget.cpp
+++ b/GWToolboxdll/Widgets/WorldMapWidget.cpp
@@ -943,7 +943,9 @@ GW::Constants::MapID WorldMapWidget::GetMapIdForLocation(const GW::Vec2f& world_
 void WorldMapWidget::Initialize()
 {
     ToolboxWidget::Initialize();
-    SettingsRegistry::Register(this, settings);
+    // These are all drawn by the controls window on the world map itself, not in the Settings window,
+    // so keep them out of settings search - a result here would navigate to a section without them.
+    SettingsRegistry::Register(this, settings, false);
 
     memset(show_elite_capture_locations, true, sizeof(show_elite_capture_locations));
     quest_icon_texture = GwDatModule::LoadTextureFromFileId(0x1b4d5);
@@ -1477,5 +1479,5 @@ bool WorldMapWidget::WndProc(const UINT Message, WPARAM, LPARAM lParam)
 
 void WorldMapWidget::DrawSettingsInternal()
 {
-    ImGui::Text("Note: only visible in Hard Mode explorable areas.");
+    ImGui::TextDisabled("The world map options (show all areas, quest markers, elite capture locations, ...)\nare drawn on the world map itself - open the world map to change them.");
 }

--- a/GWToolboxdll/Windows/SettingsWindow.cpp
+++ b/GWToolboxdll/Windows/SettingsWindow.cpp
@@ -152,6 +152,31 @@ namespace {
         ctx->TestEngineHookItems = locate.HooksNeeded();
     }
 
+    // Section a module's registered settings can actually be navigated to, or empty if it doesn't draw
+    // any settings content in this window (e.g. a module that draws its settings in its own UI instead).
+    // Usually SettingsName(), but a module is free to register its content into someone else's section.
+    std::string NavSectionForModule(ToolboxModule* module)
+    {
+        if (!module) {
+            return {};
+        }
+        const auto& callbacks = ToolboxModule::GetSettingsCallbacks();
+        const auto* settings_name = module->SettingsName();
+        if (callbacks.contains(settings_name)) {
+            return settings_name;
+        }
+        std::string found;
+        for (const auto& [section, list] : callbacks) {
+            const auto drawn_here = std::ranges::any_of(list, [module](const SectionDrawCallbackInfo& info) {
+                return info.module == module;
+            });
+            if (drawn_here && (found.empty() || section < found)) {
+                found = section;
+            }
+        }
+        return found;
+    }
+
     std::vector<SearchResult> BuildSearchResults(const std::string& query_lower)
     {
         std::vector<SearchResult> results;
@@ -162,6 +187,9 @@ namespace {
             }
         }
         for (const auto& e : SettingsRegistry::GetEntries()) {
+            if (!e.in_settings_window) {
+                continue; // Drawn by the module's own UI; navigating here would land on nothing
+            }
             auto best = MatchScore(TextUtils::ToLower(e.label), query_lower);
             for (const auto& text : {e.section, e.description}) {
                 if (text.empty()) {
@@ -172,8 +200,11 @@ namespace {
                     best = score;
                 }
             }
-            if (best >= 0) {
-                results.push_back({e.module->SettingsName(), e.label, best});
+            if (best < 0) {
+                continue;
+            }
+            if (const auto nav_section = NavSectionForModule(e.module); !nav_section.empty()) {
+                results.push_back({nav_section, e.label, best});
             }
         }
         for (const auto& [section, label] : sub_sections) {


### PR DESCRIPTION
Reported on Discord: searching settings turns up World Map entries that lead nowhere — the section they navigate to doesn't contain them, because all of the world map's options are drawn in the controls panel on the world map itself.

Two causes, both fixed here:

- **Entries whose module draws them elsewhere.** `SettingsRegistry::Register` takes an `in_settings_window` flag; `WorldMapWidget` passes `false` for its settings struct, so search skips them. Base-class UI-element fields (visible, size/position, ...) are registered separately and are still drawn in the Settings window, so they stay searchable, and `/tb_setting` is unaffected.
- **Entries navigating to a section that doesn't exist.** Search used `module->SettingsName()` as the nav target, which is wrong for any module that registers its content into another module's section — `ItemTooltipModule` ("Inventory Settings") and `ResignLogModule` ("Game Settings") both did, and `Updater` (drawn by `ToolboxSettings`) had no section at all. The nav section is now resolved from the settings content the module actually registered, entries with no section are dropped, and `Updater::SettingsName()` points at "Toolbox Settings".

The World Map settings section now explains where its options live instead of the stale "only visible in Hard Mode explorable areas" note.

Not build-verified locally (the wine-MSVC container build can't bind-mount the repo on this host); relying on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)