### PR TITLE
Cartographer: record why the mask dilates by one tile

### DIFF
--- a/GWToolboxdll/Widgets/CartographerWidget.cpp
+++ b/GWToolboxdll/Widgets/CartographerWidget.cpp
@@ -421,8 +421,10 @@ namespace {
 
     // The baked standable tiles for the continent we are on, dilated by ONE tile so a lookup answers
     // "could standing somewhere credit this tile" in one test. One tile regardless of the Bird's Eye
-    // Compass: the bake's standable set is also its navmesh model, so a tile the wide rings could
-    // reach is already a tile something stands next to. Dilating by 3 claimed fog nothing can credit.
+    // Compass: the client dilates by one itself. FUN_00721d00 builds the map's reveal grid - 1 for
+    // geometry, 2 for touching it, 0 elsewhere - and FUN_00817d00 writes tiles outside your own 3x3
+    // block only where that grid is set, so the wide rings reach further without reaching anything
+    // new. Dilating by 3 claimed fog nothing can credit.
     // Built once per continent; the live probe still covers the map we are actually in, which the
     // bake does not have for the handful of maps with no file id.
     constexpr int kMaskRadius = 1;

--- a/tools/bake_cartography/README.md
+++ b/tools/bake_cartography/README.md
@@ -72,8 +72,13 @@ breaking the syntax.
 
 ## What it stores
 
-Standable, not discoverable. Discoverable is this dilated by the reveal radius, and that radius
-depends on the Bird's Eye Compass, so it stays a runtime choice.
+Standable, not discoverable. Discoverable is this dilated by **one** tile, whatever compass you
+carry - which is why `kMaskRadius` is 1 and not the reveal radius. The client builds its own
+per-map grid at tile resolution in `FUN_00721d00`: `1` where the map has geometry, `2` where a
+tile merely touches one that does, `0` elsewhere. The reveal, `FUN_00817d00`, writes a tile
+outside your own 3x3 block only where that grid is non-zero, so a Bird's Eye Compass widens how
+far away you may stand and nothing else. Two tiles past the edge of the terrain cannot be
+uncovered at all.
 
 Each map is reduced to its **largest connected component** (trapezoid adjacency plus unblocked
 portals, all planes treated as open since blocked-plane state only exists at runtime) so terrain


### PR DESCRIPTION
Comment/docs only - no behaviour change.

`kMaskRadius = 1` and `CellQualifies`'s 3x3 navmesh test are both already correct on `dev`; this just writes down the client-side proof that 1 is the right number, and fixes the bake README, which still said the baked set gets dilated by the reveal radius.

From the current `Gw.exe`:

- `FUN_00721d00` builds the map's reveal grid at tile resolution - `1` where the map has geometry, `2` where a tile merely touches one that does, `0` elsewhere.
- `FUN_00817d00` writes a tile outside your own 3x3 block only where that grid is non-zero; the 3x3 block itself is unconditional.

So the union over every tile you could stand in is the terrain dilated by exactly one, and a Bird's Eye Compass only widens how far away you may stand while that happens. Two tiles past the edge of the terrain cannot be uncovered by anything - which is what Redeemer reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)