### PR TITLE
docs(agents): hard NO COMMENTS rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,8 @@
 
 Instructions for any AI agent in this repo. (`CLAUDE.md` just imports this.)
 
-- **Comments (rule #1):** ZERO comments that just restate what the code does - if it's obvious from reading the code, don't write it. Comment ONLY what the code cannot express (e.g. *why* we hook a game function this way instead of the simpler one), and keep it SHORT - 1-2 lines, no prose blocks. Exempt: `// ===` banners, license/file headers.
+- **NO COMMENTS (rule #1):** Do not write comments. Not to restate the code, not to narrate a block, not to leave TODOs, not to park dead code. Make the code say it instead - name the variable, name the function, split the expression. The ONLY allowed exception is a *why* the code genuinely cannot express (e.g. why we hook the harder game function instead of the obvious one), and even then it is **one line, max two - never more than 2 lines**. Anything longer belongs in `site/` docs or a PR description, not in the source. Also exempt: `// ===` banners, license/file headers, and vendored third-party files (`imgui_impl_*`, `imconfig.h`, `ToolboxIni.*`, `sha1.*`) - leave those alone.
+- **Deleting comments:** when you touch a file that already has comments violating rule #1, delete them as you go. Never re-add one to "explain" your change.
 - **Variables:** prefer `auto` when the initializer makes the type clear (`const auto x = TIMER_INIT();`).
 - **Functions:** don't extract a function for a few lines of logic used at only one call site; inline it. Extract only when it's called from more than one place, or the logic is substantial enough to warrant a name of its own.
 - **Reuse:** before adding a string/formatting or ImGui/dialog helper, check `Utils/TextUtils.h` and `Utils/GuiUtils.h` - there's often one already.


### PR DESCRIPTION
Tightens rule #1 in `AGENTS.md` (which `CLAUDE.md` imports) from "keep comments short" to a flat **no comments** rule:

- no restating code, no block narration, no TODOs, no commented-out code
- the only exception is a *why* the code can't express, capped at **2 lines**
- anything longer goes in `site/` docs or the PR description
- exempt: `// ===` banners, license/file headers, vendored third-party files
- plus: delete offending comments in files you touch, never re-add one

Follow-up PR strips the existing >2-line comment blocks from the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)