### PR TITLE
docs(agents): add performance-audit skill

### DIFF
--- a/.agents/skills/performance-audit/SKILL.md
+++ b/.agents/skills/performance-audit/SKILL.md
@@ -85,6 +85,12 @@ rebuild inside `Draw`. The fix pattern is always: cache the result, key it on wh
 changed (anchor position, map id, party, skill), and throttle with `TIMER_DIFF` when the input
 changes continuously.
 
+Also check the *inside* of these loops for invariants that could be hoisted. The reachability
+walk tested every adjacency against every travel portal and recomputed `sinf`/`cosf` from the
+portal's facing on each one; precomputing the gate line once per map (`3d23ad84`) removed
+hundreds of thousands of trig calls. Anything derived only from map-static data belongs in the
+per-map cache, not the inner loop.
+
 ```
 grep -rn "QueryAltitude\|DrapeHeightAt\|SurfaceZ" GWToolboxdll
 grep -rn "Pathing\|BuildPath\|GeneratePath" GWToolboxdll/Windows/Pathfinding GWToolboxdll/Widgets
@@ -127,9 +133,16 @@ grep -rnE "std::vector<[^>]+> [a-z_]+;" GWToolboxdll --include=*.cpp   # locals 
   codebase has ~150 `std::map` declarations; the ones that matter are those touched per frame.
 - Repeated `.find()` on the same key in one function - do it once.
 - `operator[]` on a map in a read path (it inserts, and grows the map forever).
+- **Spatial data in a `std::map<std::pair<int,int>,...>` / `std::set<std::pair<int,int>>`.** One
+  node allocation plus a log-n descent per touch, over a build that touches every trapezoid on
+  the map, is the difference between a hitch and no hitch. The Cartographer's `NavCells`
+  (`3d23ad84`) moved to a dense `std::vector<uint8_t>` grid with an `x0/y0/width/height` origin
+  and an `Index(cx, cy)` helper. Use that shape whenever the key space is a bounded grid.
+- Returning a container by value from a cache accessor - hand back a `const&`.
 
 ```
 grep -rn "std::map<std::string\|unordered_map<std::string" GWToolboxdll
+grep -rn "std::map<std::pair\|std::set<std::pair" GWToolboxdll
 ```
 
 ### F. Debug-build amplifiers
@@ -152,11 +165,21 @@ Real code smells that debug builds punish hardest, worth fixing regardless:
 grep -rn "ifstream\|ofstream\|CreateFileW\|curl_easy_perform" GWToolboxdll/Widgets GWToolboxdll/Windows
 ```
 
-### H. Polling where an event exists
-`Update()` that re-reads game state every frame to detect a change usually has a GWCA callback
-available (`UIMgr` messages, `StoC` packet callbacks, `Map` state). Polling costs a frame's work
-80 times over; a callback costs nothing while idle. Conversely, check that registered UI message
-callbacks are cheap - the Performance window breaks these out per message id for a reason.
+### H. Polling where an event exists, and recomputing where a diff would do
+- `Update()` that re-reads game state every frame (or on a 1s timer) to detect a change usually
+  has a GWCA callback available (`UIMgr` messages, `StoC` packet callbacks, `Map` state). Polling
+  costs a frame's work 80 times over; a callback costs nothing while idle. If no callback looks
+  right, the client almost certainly broadcasts one - use Ghidra to find it, as `75fbfeee` did
+  (traced the reveal packet handler to UI message `0x10000090` and replaced a per-second
+  recompute with a hook on it).
+- When the event says only "something changed", **diff instead of rebuilding**: keep a snapshot,
+  XOR against the live data, and recompute only the entries that flipped.
+- **Refresh the one thing, not everything.** `905b79a3`: the allegiance handler flashed the
+  global name-tag filter off and on, rebuilding every tag in the instance, when the packet
+  carried the agent id and a per-agent refresh existed. Look for global invalidations
+  (`clear()`, "reset all", visibility toggles) triggered by a single-entity event.
+- Conversely, check that registered UI message callbacks are cheap - the Performance window
+  breaks these out per message id for a reason.
 
 ### I. Work done while idle, hidden or irrelevant
 - `Update()` doing full work when the module's window is not `visible`, the feature is disabled
@@ -165,6 +188,57 @@ callbacks are cheap - the Performance window breaks these out per message id for
 - Timers ticking and strings rebuilding for a hidden widget.
   Early-out at the top: `if (!visible) return;`, `if (!enabled) return;`,
   `if (!GW::Map::GetIsMapLoaded()) return;`.
+- **Gate every entry point, not just `Update`.** `e4d3805c` had the world-map relevance check on
+  `Update` but not on the overlay draw or the context menus, so those kept working (and drawing
+  stale state) on maps the check was meant to exclude.
+
+### J. Cache design and invalidation
+Most fixes above are caches, and most cache bugs here are *lifetime* bugs, not miss-rate bugs:
+
+- **Keyed on the wrong thing.** The key must be exactly the state that changes the answer -
+  `map_id`, `InstanceType`, blocked planes, character name (`e4d3805c` keys the Cartographer
+  sweep on the character, because which tiles matter depends on that character's fog). Too
+  narrow and it serves stale data; too broad and it never hits.
+- **Thrown away by a transient reset.** `ResetState()` clearing a session-valid per-map sweep on
+  every map change and every enable/disable toggle meant returning to a map paid the full cost
+  again. Split "transient overlay state" from "expensive, still-valid computation".
+- **Caching a degenerate result.** If the computation can return "I could not tell" (no player
+  yet, no pathing context), do *not* store it - that pins the wrong assumption for the life of
+  the map. Both `3d23ad84` and `e4d3805c` carry explicit comments about exactly this trap.
+- **Rebuilt against an empty input.** `CopyBlockedPlanes` returning nothing when there is no
+  pathing context made the key compare unequal every call, turning a per-map build into a
+  per-frame full-map sweep. Bail out rather than building against missing data.
+- A cache accessor should return `const&`, and callers should not copy it.
+
+### K. Duplicated and redundant work
+- **The same expensive helper reimplemented in several modules.** `57c399e3` found four copies
+  of an all-planes `QueryAltitude` loop across `GameWorldRenderer` and `RiverModule`, none of
+  them pruning planes that had no geometry near the point, with three different "no data"
+  sentinels. Consolidating into `TerrainDrape` fixed the cost in all four at once.
+- **The same game function hooked twice.** `e07d1583`: `DialogModule` and `TextToSpeechModule`
+  both hooked the NPC dialog frame callback; GWCA resolves through the JMP at the entry, so the
+  second hook chained onto the first (and crashed the client). Two detours is also two costs -
+  `grep -rn "CreateHook\|RenderHook" GWToolboxdll` and look for the same target twice.
+- **Runtime computation of data that could ship baked.** `9bb0a10b` deleted the Cartographer's
+  in-game bake - a per-tick `StepBake` driver doing a per-map trapezoid walk - because
+  `tools/bake_cartography` produces the same table offline into `CartographyData.h`. If a
+  computation only depends on `Gw.dat` / `AreaInfo` / constants, it does not belong at runtime.
+
+### L. Leaks, unbounded growth and stuck state
+Not per-frame cost, but they show up as "toolbox gets slower the longer I play":
+
+- Resource leaks per event - `047cde98` leaked a GDI bitmap on *every cursor change*. Check
+  `CreateBitmap`/`CreateDIBSection`/`LoadImage`/`CreateTexture` for a matching delete on every
+  path, including early returns.
+- Containers that only ever grow: histories, per-agent maps never cleared on map change, caches
+  with no eviction and no key on instance.
+- State machines that leave a "busy" flag set on a failure path. `fde6b8cf`: `RecalculateMap`
+  bailed after `Recalculate` had already set `calculating`, so `IsCalculating()` blocked every
+  `Update` for 5 seconds. A stuck flag can mask *or* cause a perf complaint.
+- The inverse, worth checking when a perf symptom makes no sense: a fast path that is never
+  taken. `1e4350da` was a one-character fix - `hook_attempted` initialised to `true`, so
+  `EnsureHook()` always early-returned and the compositor hook was never installed. Confirm the
+  code you are about to optimise actually runs.
 
 ## 4. Verify before claiming a fix
 
@@ -179,7 +253,7 @@ callbacks are cheap - the Performance window breaks these out per message id for
 
 Produce a ranked table, worst first:
 
-| # | Location (`file:line`) | Class (A-I) | What runs per frame | Est. cost / evidence | Fix |
+| # | Location (`file:line`) | Class (A-L) | What runs per frame | Est. cost / evidence | Fix |
 |---|---|---|---|---|---|
 
 Then, for the top items, a short paragraph each: why it is hot, the cheapest correct fix, and
@@ -195,7 +269,11 @@ Start here when the audit is unscoped:
   `CustomRenderer`: per-agent, per-vertex, per-frame D3D work.
 - `Modules/*Module.cpp` world overlays - `DangerRings`, `SkillRangeRings`, `LootBeacons`,
   `River`, `Weather`: all take the device and drape geometry.
-- `Windows/Pathfinding/*` and `Widgets/CartographerWidget.cpp` - map-sized data structures.
+- `Utils/GameWorldCompositor.cpp` and `Utils/TerrainDrape.*` - shared by every world overlay, so
+  a cost here is paid several times over.
+- `Windows/Pathfinding/*`, `Modules/CartographerModule.cpp`, `Widgets/CartographerWidget.cpp` -
+  map-sized data structures, whole-map graph walks, session-lifetime caches.
+- `Modules/GameSettings.cpp` - hooks a lot of client UI and runs on hover/name-tag paths.
 - Unbounded-history windows - `ObjectiveTimerWindow`, `DropTrackerWindow`, `CompletionWindow`,
   `AccountInventoryWindow`, `FriendListWindow`.
 - Per-agent widgets - `EnemyWindow`, `InfoWindow`, `PartyWindowModule`, `BondsWidget`,

--- a/.agents/skills/performance-audit/SKILL.md
+++ b/.agents/skills/performance-audit/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: performance-audit
+description: Audit GWToolbox++ for in-game performance problems - FPS drops, stutter, slow modules/widgets, hot per-frame code. Use when asked to "audit performance", "find what's tanking FPS", "why is toolbox slow", "profile a module", or before a release to sweep for regressions. Covers the frame cost model, the built-in Performance window, a per-class checklist with grep recipes, and the fix patterns already used in this repo.
+---
+
+# GWToolbox++ performance audit
+
+Toolbox runs inside the Guild Wars client's frame. Every microsecond a module spends is a
+microsecond the game does not get, and the costs are additive across ~80 modules, so
+"only 200us" in five widgets is a visible framerate loss. This skill finds that work.
+
+## 1. Know the cost model before reading any code
+
+Two hot entry points per module (`GWToolboxdll/ToolboxModule.h`):
+
+- `Update(float delta)` - **game thread**, once per frame, for *every loaded module* whether or
+  not its window is visible. Cheapest place to be wrong and the most commonly abused.
+- `Draw(IDirect3DDevice9*)` - **render thread**, inside the ImGui frame, for every *enabled*
+  module. UI elements draw their window here; plain modules paint overlays here.
+
+Plus: GWCA hooks/callbacks (`UIMgr` message callbacks, packet callbacks, `RenderHook`),
+and direct D3D work in the world renderers (`Widgets/Minimap/*`, `Modules/*Module.cpp` overlays).
+
+Three multipliers to keep in mind:
+
+- **Per frame x per module x per element.** A loop over agents/items/rows inside `Draw` is
+  O(frame x N). ImGui submits real layout work per item even for off-screen rows.
+- **Debug builds.** MSVC iterator debugging and non-inlined `std::` wrappers make container
+  churn 10-50x worse. Marc's "debug builds manhandle my pc" is usually a real hot path
+  amplified, not a debug-only artifact - find the underlying churn, don't dismiss it.
+- **D3D state.** Anything touching the device between GW's own draws must save/restore state.
+  Doing that the naive way (`CreateStateBlock(D3DSBT_ALL)`) costs ~45us *per use per frame*;
+  the explicit `D3DStateGuard` in `GWToolboxdll/D3DContainers.cpp` costs ~0.5us.
+
+## 2. Measure first
+
+Toolbox has a built-in profiler: **Windows -> Performance** (`Windows/PerformanceWindow.cpp`).
+It reports min/avg/max microseconds over a rolling 5s window for:
+
+- frame period, total toolbox `Update`, total toolbox `Draw`, D3D `Present`
+- per-module `update` and `draw`
+- per-module UI message callback cost, keyed by message id
+
+Settings: `slow_threshold_us` (highlight threshold) and `stream_to_csv`, which appends 1s
+snapshots to `performance_log_<compiler>.csv` in the settings folder. The window's **Compare**
+tab loads two CSVs and diffs them - that is the before/after harness for any fix.
+
+Ask for (or capture) a CSV from the scenario that hurts: idle in an outpost, busy explorable
+with a full party, and the specific window/widget open. Anything over ~100us avg is worth a
+look; over ~1000us is a bug.
+
+If no numbers are available, say so and treat the static findings below as *candidates*, not
+confirmed regressions.
+
+## 3. Static audit checklist
+
+Work through these classes. For each hit, judge it against: *does this run every frame? does
+it scale with agents/items/rows? does it allocate? does it touch the device, disk or network?*
+
+### A. D3D state and device churn
+- `CreateStateBlock`, `GetRenderState`/`SetRenderState` loops, `GetTransform`, `GetTexture`
+  called outside an actual draw.
+- Renderers that construct a `D3DStateGuard` (or set up the pipeline) even when they end up
+  drawing nothing - guard the early-out *first*, then take the state.
+- Vertex buffer re-creation per frame instead of a persistent buffer + `Lock(D3DLOCK_DISCARD)`.
+- New states written by a renderer but missing from the guarded lists in `D3DContainers.cpp`
+  (a correctness bug, not perf - flag it).
+
+```
+grep -rn "CreateStateBlock\|SetRenderState\|CreateVertexBuffer" GWToolboxdll
+grep -rn "D3DStateGuard" GWToolboxdll
+```
+
+### B. Unbudgeted per-frame recomputation of geometry / pathing
+The repeat offender in this codebase. Terrain draping, navmesh queries and path re-anchoring
+are O(map) and were each an FPS collapse until cached:
+
+- `perf(skill-range-rings)`: re-draped ~1000 vertices x n planes every frame -> cache geometry,
+  re-drape only when the anchor moves.
+- `perf(in-game rendering)`: `NavMesh::DrapeHeightAt` linear-scanned up to 0x8000 trapezoids per
+  vertex per frame -> CSR row buckets + throttled re-anchor.
+
+Look for `QueryAltitude`, `DrapeHeightAt`, `SurfaceZ`, pathfinding calls, and any geometry
+rebuild inside `Draw`. The fix pattern is always: cache the result, key it on what actually
+changed (anchor position, map id, party, skill), and throttle with `TIMER_DIFF` when the input
+changes continuously.
+
+```
+grep -rn "QueryAltitude\|DrapeHeightAt\|SurfaceZ" GWToolboxdll
+grep -rn "Pathing\|BuildPath\|GeneratePath" GWToolboxdll/Windows/Pathfinding GWToolboxdll/Widgets
+```
+
+### C. Per-frame scans and unbounded ImGui lists
+- `GW::Agents::GetAgentArray()` / item array / party array walked inside `Draw` or `Update`
+  when a cached, event-invalidated view would do.
+- Nested loops over agents x effects, agents x skills, items x filters.
+- Lists that grow without bound (past runs, chat log, drop history, completion tables) drawn
+  row-per-item. Even a collapsed `CollapsingHeader` costs a label measure plus item layout.
+  The established fix (`ObjectiveTimerWindow`) is: filter first, then for off-screen rows
+  coalesce contiguous runs into a single `ImGui::Dummy` so the scroll extent stays correct.
+- `ImGui::BeginTable` over thousands of rows without `ImGuiListClipper`.
+
+```
+grep -rn "GetAgentArray()\|GetPartyInfo()\|GetItemArray" GWToolboxdll
+grep -rn "IsRectVisible\|ImGuiListClipper" GWToolboxdll   # who already culls - and who doesn't
+```
+
+### D. Allocation and string churn per frame
+- `std::format` / `std::string` concatenation / `snprintf` into a fresh string, per row, per
+  frame. Cache the formatted text and only rebuild when the value changes (see
+  `ObjectiveSet::GetDurationStr`'s `cached_time`).
+- `std::vector` built and destroyed each frame - hoist to a member and `clear()` + `reserve()`,
+  or make it `static` at namespace scope in the module's anonymous namespace.
+- Returning containers by value from helpers called in a loop.
+- `std::to_string`/`std::stringstream` anywhere in a draw path.
+
+```
+grep -rn "std::format\|std::to_string\|stringstream" GWToolboxdll/Widgets GWToolboxdll/Windows
+grep -rnE "std::vector<[^>]+> [a-z_]+;" GWToolboxdll --include=*.cpp   # locals in hot functions
+```
+
+### E. Containers and lookups
+- `std::map` / `std::unordered_map` keyed by `std::string` looked up every frame - each lookup
+  hashes or compares a string, and often *constructs* one from a `const char*`. Prefer an id,
+  an enum, a `string_view` key, or resolving the iterator once and holding it.
+- `std::map` where a flat `std::vector` + index would be both smaller and cache-friendly. The
+  codebase has ~150 `std::map` declarations; the ones that matter are those touched per frame.
+- Repeated `.find()` on the same key in one function - do it once.
+- `operator[]` on a map in a read path (it inserts, and grows the map forever).
+
+```
+grep -rn "std::map<std::string\|unordered_map<std::string" GWToolboxdll
+```
+
+### F. Debug-build amplifiers
+Real code smells that debug builds punish hardest, worth fixing regardless:
+
+- Passing containers by value; range-for over a temporary.
+- `at()` in loops; index-checked access in tight loops - take `.data()` once and index the raw
+  pointer, or take a `std::span` over it.
+- Deep helper chains that only inline in release (tiny getters inside per-vertex loops).
+- `std::function` called per element instead of a template/lambda.
+
+### G. Blocking work on the frame threads
+- File IO (`std::ifstream`/`std::ofstream`/`CreateFile`), `Resources::` loads, texture decode,
+  network calls, `std::mutex` contention, JSON parse - none of these belong in `Update`/`Draw`.
+  Push them through `Resources::EnqueueWorkerTask` (47 call sites already do) or make them lazy
+  (`perf(account-inventory): fetch item icons lazily during draw`).
+- Settings saved on change per frame instead of debounced.
+
+```
+grep -rn "ifstream\|ofstream\|CreateFileW\|curl_easy_perform" GWToolboxdll/Widgets GWToolboxdll/Windows
+```
+
+### H. Polling where an event exists
+`Update()` that re-reads game state every frame to detect a change usually has a GWCA callback
+available (`UIMgr` messages, `StoC` packet callbacks, `Map` state). Polling costs a frame's work
+80 times over; a callback costs nothing while idle. Conversely, check that registered UI message
+callbacks are cheap - the Performance window breaks these out per message id for a reason.
+
+### I. Work done while idle, hidden or irrelevant
+- `Update()` doing full work when the module's window is not `visible`, the feature is disabled
+  in settings, or the player is in an outpost / loading screen / not in a relevant map.
+- Overlay renderers running with zero elements to draw.
+- Timers ticking and strings rebuilding for a hidden widget.
+  Early-out at the top: `if (!visible) return;`, `if (!enabled) return;`,
+  `if (!GW::Map::GetIsMapLoaded()) return;`.
+
+## 4. Verify before claiming a fix
+
+1. Re-run the same scenario with `stream_to_csv` on, before and after, and diff in the Compare
+   tab. Quote the module's avg/max us both ways.
+2. Confirm behaviour is unchanged - especially for D3D changes (state must be fully restored;
+   GW's own rendering corrupting is worse than the frame cost) and for list culling (scroll
+   extent, filtering, click targets).
+3. Check both build configs if the finding was debug-specific.
+
+## 5. Report format
+
+Produce a ranked table, worst first:
+
+| # | Location (`file:line`) | Class (A-I) | What runs per frame | Est. cost / evidence | Fix |
+|---|---|---|---|---|---|
+
+Then, for the top items, a short paragraph each: why it is hot, the cheapest correct fix, and
+whether it needs a measurement to confirm. Separate **confirmed** (backed by a Performance
+window number) from **suspected** (static reading only). Do not pad the list with micro-opts
+that no measurement supports - say plainly when a candidate is probably harmless.
+
+## 6. High-risk areas in this codebase
+
+Start here when the audit is unscoped:
+
+- `Widgets/Minimap/*` - `AgentRenderer`, `GameWorldRenderer`, `PingsLinesRenderer`, `PmapRenderer`,
+  `CustomRenderer`: per-agent, per-vertex, per-frame D3D work.
+- `Modules/*Module.cpp` world overlays - `DangerRings`, `SkillRangeRings`, `LootBeacons`,
+  `River`, `Weather`: all take the device and drape geometry.
+- `Windows/Pathfinding/*` and `Widgets/CartographerWidget.cpp` - map-sized data structures.
+- Unbounded-history windows - `ObjectiveTimerWindow`, `DropTrackerWindow`, `CompletionWindow`,
+  `AccountInventoryWindow`, `FriendListWindow`.
+- Per-agent widgets - `EnemyWindow`, `InfoWindow`, `PartyWindowModule`, `BondsWidget`,
+  `EffectsMonitorWidget`, `SkillMonitorWidget`.
+- Anything added recently: `git log --oneline -30 origin/dev` and review new `Draw`/`Update`
+  bodies, which is where regressions actually enter.
+
+See `references/fix-patterns.md` for the concrete before/after shapes used in past fixes.
+
+## Conventions
+
+Follow `AGENTS.md`: no comments that restate the code. A perf fix that is non-obvious (why a
+cache is keyed the way it is, why the explicit state list exists) gets 1-2 lines explaining
+*why*, like the header comment on `D3DStateGuard`.

--- a/.agents/skills/performance-audit/references/fix-patterns.md
+++ b/.agents/skills/performance-audit/references/fix-patterns.md
@@ -97,7 +97,137 @@ percentage that is `std::format`-ed inside `Draw`.
 - `91994a5e perf(account-inventory): fetch item icons lazily during draw` - only request the
   resource for rows actually being drawn.
 
-## 7. Compute natively instead of querying the client per element
+## 7. Cache a whole-map computation, keyed on its real invalidation state
+
+`3d23ad84 perf fix` (Pathing)
+
+`FindReachableTrapezoids` visits every adjacency on the map and tests each against every travel
+portal - far too expensive per query. The accessor caches it and rebuilds only when the state
+that can change the answer changes:
+
+```cpp
+const std::unordered_set<const GW::PathingTrapezoid*>& CachedReachableTrapezoids()
+{
+    const auto map_id = GW::Map::GetMapID();
+    const auto instance_type = GW::Map::GetInstanceType();
+    std::vector<uint32_t> blocked;
+    CopyBlockedPlanes(blocked);
+    if (map_id != reachable_cache_map || instance_type != reachable_cache_instance || blocked != reachable_cache_blocked_planes) {
+        auto found = FindReachableTrapezoids();
+        // Empty means it could not find the player to start from, which callers read as
+        // "assume everything is reachable". Keeping that would pin the assumption for the
+        // life of the map; the walk bails immediately in that state, so retrying is free.
+        if (found.empty()) return reachable_cache = {};
+        reachable_cache = std::move(found);
+        reachable_cache_blocked_planes = std::move(blocked);
+        reachable_cache_map = map_id;
+        reachable_cache_instance = instance_type;
+    }
+    return reachable_cache;
+}
+```
+
+Three things to copy: the key is map + instance + gate state (nothing else moves regions in and
+out of reach), the accessor returns `const&`, and a **degenerate result is never stored**.
+
+Related failure in the same commit: `EnsureNavCells` rebuilt when `CopyBlockedPlanes` returned
+nothing (no pathing context), so the key never matched and a per-map build became a per-frame
+full-map sweep. Bail instead of building against missing input.
+
+`e4d3805c` adds the lifetime half: keep the expensive per-map result in a session cache
+(`std::map<MapID, MapProbe>`, keyed additionally on the character), and let `ResetState()` clear
+only transient overlay state - not the sweep.
+
+## 8. Hoist inner-loop invariants into the per-map cache
+
+`3d23ad84 perf fix` (Pathing) - `CrossesTravelPortal` is called for every adjacency in the
+reachability walk, hundreds of thousands of times, and each call recomputed the portal's gate
+line from its facing:
+
+```cpp
+const float cos_f = cosf(portal.facing_radians);   // per call, per portal
+const float sin_f = sinf(portal.facing_radians);
+const GW::Vec2f left{...}, right{...};
+```
+
+Fix: resolve each portal to a `PortalDoorway { left, right, pos, radius_sq, has_facing }` once
+when the per-map portal cache is built, and let the hot loop read the precomputed line.
+
+## 9. Dense grid instead of a map keyed by cell
+
+`3d23ad84 perf fix` (CartographerWidget) - `std::map<std::pair<int,int>, GW::GamePos>` plus
+`std::set<std::pair<int,int>>` became a flat grid, because the build touches every trapezoid on
+the map and "a tree node plus a log-n descent per touch is the difference between a hitch and
+no hitch":
+
+```cpp
+struct NavCells {
+    int x0 = 0, y0 = 0, width = 0, height = 0;
+    std::vector<uint8_t> ground, standable;
+    std::vector<GW::GamePos> stand;
+    std::vector<float> line_x, line_y;   // grid lines in game coords, one conversion per line
+    bool InGrid(int cx, int cy) const;
+    size_t Index(int cx, int cy) const { return static_cast<size_t>(cy - y0) * width + (cx - x0); }
+};
+```
+
+The `line_x`/`line_y` arrays are the same idea one level down: one coordinate conversion per
+grid line instead of two per trapezoid touched, and being the same call on the same input they
+cannot drift from the anchor.
+
+## 10. Hook the client's own change message instead of polling
+
+`75fbfeee Cartographer: recompute on the client's own carto-updated message`
+
+Traced in Ghidra: the StoC reveal handler writes the tile block and broadcasts UI message
+`0x10000090` with no payload. The module hooks that instead of recomputing every second. Because
+the message only says "something changed", it diffs a snapshot of the client's bitmap to find
+what actually flipped:
+
+```cpp
+for (uint32_t i = 0; i < grid.dword_count; i++) {
+    const uint32_t changed = carto_snapshot[i] ^ grid.bits[i];
+    if (!changed) continue;
+    carto_snapshot[i] = grid.bits[i];
+    ...  // emit only the tiles whose bit flipped
+}
+```
+
+If the snapshot size does not match, fall back to a wholesale rebuild - there is no basis for a
+diff.
+
+## 11. Refresh the one entity, not the whole instance
+
+`905b79a3 Refresh only the agent whose allegiance changed` - the handler toggled the global name
+tag filter off and on, which rebuilds every tag in the instance, for a packet that carried the
+agent id. GWCA gained `RefreshAgentNameTag`; the global-toggle signature and its two globals
+were deleted. Look for the same shape wherever a single-entity event triggers a global reset.
+
+Related: `13969de7 Game Settings: cache nametag player colors per map instance` - resolving a
+name colour walked the friend list and guild roster *on every hover*; now cached in an
+`unordered_map` keyed by player name and cleared on map load and party join/leave.
+
+And `26ffb484` - prefer the client's own forced-refresh helper over faking a refresh by
+toggling state.
+
+## 12. Move the computation offline
+
+`9bb0a10b Cartographer: drop the runtime bake` - the in-game bake (a per-tick `StepBake` driver,
+a per-map trapezoid walk, a largest-component search and a `.bin` writer) was deleted once
+`tools/bake_cartography/` produced the same table offline from the same sources into
+`CartographyData.h`. If a computation depends only on `Gw.dat`, `AreaInfo` or constants, it does
+not need a client and does not belong at runtime.
+
+## 13. Consolidate duplicated helpers, then optimise once
+
+`57c399e3 refactor(in-game rendering): share one pruned multi-plane altitude query` -
+`GameWorldRenderer` and `RiverModule` each carried their own `HighestSurfaceZ`/`ClosestSurfaceZ`:
+four copies of the same all-planes `QueryAltitude` loop, three different "no data" sentinels, and
+none of them pruning planes with no trapezoid near the point (which `TerrainDrape` had been doing
+for a while). Collapsed into `TerrainDrape::HighestZ`/`HighestZOnPlanes`/`ClosestZ` over one
+`PrunedPlaneZ`. When you find the same hot helper copy-pasted, fix the copies into one first.
+
+## 14. Compute natively instead of querying the client per element
 
 `a96dff52 perf(terrain): compute draped altitude natively instead of per-frame QueryAltitude` -
 when a GW API call is the inner loop, see whether the data can be read once and evaluated in

--- a/.agents/skills/performance-audit/references/fix-patterns.md
+++ b/.agents/skills/performance-audit/references/fix-patterns.md
@@ -1,0 +1,112 @@
+# Fix patterns used in this repo
+
+Concrete shapes taken from merged perf fixes. Prefer reusing these over inventing a new
+mechanism; they are already reviewed and tested against the game.
+
+## 1. Explicit D3D state save instead of a full state block
+
+`723b9560 fix performance on idle objectivetimer continuously saving full d3d block`
+
+Before - ~45us per use per frame, and the block is invalidated by a GW device Reset:
+
+```cpp
+struct D3DStateGuard {
+    IDirect3DStateBlock9* block = nullptr;
+    explicit D3DStateGuard(IDirect3DDevice9* dev) { dev->CreateStateBlock(D3DSBT_ALL, &block); }
+    ~D3DStateGuard() { if (block) { block->Apply(); block->Release(); } }
+};
+```
+
+After - `GWToolboxdll/D3DContainers.cpp` saves only the union of states toolbox actually writes
+(`GUARDED_RENDER_STATES`, `GUARDED_TEXTURE_STAGE_STATES`, `GUARDED_SAMPLER_STATES`, transforms,
+shaders, streams, viewport, scissor), ~0.5us. When a renderer starts setting a new state, extend
+those lists - otherwise GW's rendering gets corrupted.
+
+Second half of that fix: renderers took the guard (and set up the pipeline) even when they had
+nothing to draw. Early-out before constructing the guard.
+
+## 2. Cache draped geometry, invalidate on anchor movement
+
+`8b0b7304 perf(skill-range-rings): cache draped geometry, re-drape only when anchor moves`
+
+```cpp
+if (anchor_pos != cached_anchor || map_id != cached_map_id) {
+    RebuildDrapedGeometry();
+    cached_anchor = anchor_pos;
+    cached_map_id = map_id;
+}
+DrawCached();
+```
+
+For an input that changes every frame (player position), add a threshold and/or a `TIMER_DIFF`
+throttle so a walking player does not rebuild continuously.
+
+## 3. Index instead of linear scan
+
+`f918923f perf(in-game rendering): index navmesh point-location, throttle path re-anchor`
+
+`NavMesh::DrapeHeightAt` scanned every ground trapezoid (up to 0x8000) per vertex per frame.
+Fix: bucket trapezoids into Y rows (CSR) at build time; a query scans one row plus a small
+overflow list for trapezoids too tall to bucket. Validated against the exhaustive scan over 80k
+queries before landing - do the same when replacing an exact algorithm with an indexed one.
+
+## 4. Cull off-screen rows in unbounded lists
+
+`61893e1e objectivetimerwindow giga slow drawing`
+
+Split the filter out of `Draw` so it is cheap to ask, then coalesce contiguous off-screen
+collapsed rows into a single `Dummy` (keeps the scroll extent correct):
+
+```cpp
+const float row_height = ImGui::GetFrameHeight();
+const float spacing = ImGui::GetStyle().ItemSpacing.y;
+float skipped_height = 0.f;
+const auto flush_skipped = [&skipped_height] {
+    if (skipped_height > 0.f) {
+        ImGui::Dummy(ImVec2(1.f, skipped_height));
+        skipped_height = 0.f;
+    }
+};
+for (auto& row : rows) {
+    if (row.IsFilteredOut()) continue;
+    if (row.IsCollapsedRow()) {
+        const float y = ImGui::GetCursorScreenPos().y + (skipped_height > 0.f ? skipped_height + spacing : 0.f);
+        if (!ImGui::IsRectVisible({0.f, y}, {1.f, y + row_height})) {
+            skipped_height = skipped_height > 0.f ? skipped_height + spacing + row_height : row_height;
+            continue;
+        }
+    }
+    flush_skipped();
+    row.Draw();
+}
+flush_skipped();
+```
+
+For uniform-height tables, `ImGuiListClipper` is simpler - use it when rows do not vary.
+
+## 5. Cache formatted strings
+
+`ObjectiveTimerWindow::ObjectiveSet::GetDurationStr` keeps a `cached_time` buffer and only
+re-formats when the underlying value changes. Same idea for any per-row label, timer or
+percentage that is `std::format`-ed inside `Draw`.
+
+## 6. Move the work off the frame thread, or make it lazy
+
+- `Resources::EnqueueWorkerTask([data = std::move(data)] { WriteToDisk(data); })` - the pattern
+  the Performance window itself uses to stream CSV without touching disk in the draw loop.
+- `91994a5e perf(account-inventory): fetch item icons lazily during draw` - only request the
+  resource for rows actually being drawn.
+
+## 7. Compute natively instead of querying the client per element
+
+`a96dff52 perf(terrain): compute draped altitude natively instead of per-frame QueryAltitude` -
+when a GW API call is the inner loop, see whether the data can be read once and evaluated in
+toolbox instead. Ghidra is available for finding the underlying structures.
+
+## Measuring a fix
+
+1. Windows -> Performance, enable `stream_to_csv`.
+2. Reproduce the scenario for at least ~30s, note the module's avg/max us.
+3. Apply the fix, repeat into a second CSV, diff in the **Compare** tab.
+4. CSVs are per-compiler (`performance_log_msvc-*.csv` / `performance_log_clang-*.csv`) in the
+   settings folder - compare like with like.


### PR DESCRIPTION
Adds `.agents/skills/performance-audit/` - a skill for auditing GWToolbox++ for in-game performance problems, per the discussion about cleaning up before release.

**`SKILL.md`**
- The frame cost model: `Update` (game thread, every loaded module, visible or not) vs `Draw` (render thread, inside the ImGui frame), plus the three multipliers - per frame x per module x per element, debug-build container churn, and D3D state cost.
- Measure first: the built-in **Windows -> Performance** window (per-module update/draw/UI-message us, `slow_threshold_us`, `stream_to_csv` + the Compare tab as the before/after harness).
- A nine-class checklist with grep recipes: D3D state churn, unbudgeted geometry/pathing recompute, per-frame agent scans and unbounded ImGui lists, allocation/string churn, `std::map`-keyed-by-string lookups, debug-build amplifiers (iterator debug, `.data()`/span access), blocking IO on the frame thread, polling where a GWCA callback exists, and work done while hidden/idle.
- A report format that separates measured findings from statically-suspected ones, and a list of the high-risk areas (minimap renderers, world overlays, pathfinding/cartographer, unbounded-history windows, per-agent widgets).

**`references/fix-patterns.md`** - before/after shapes lifted from merged fixes: the explicit `D3DStateGuard` (~45us -> ~0.5us), cached draping keyed on anchor movement, CSR navmesh indexing, the ObjectiveTimer off-screen row coalescing, cached formatted strings, and `Resources::EnqueueWorkerTask` offload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)