### PR TITLE
docs(agents): make debug-build container cost a first-class audit class

### DIFF
--- a/.agents/skills/performance-audit/SKILL.md
+++ b/.agents/skills/performance-audit/SKILL.md
@@ -11,12 +11,18 @@ microsecond the game does not get, and the costs are additive across ~80 modules
 
 ## 1. Know the cost model before reading any code
 
-Two hot entry points per module (`GWToolboxdll/ToolboxModule.h`):
+Two hot entry points per module (`GWToolboxdll/ToolboxModule.h`), dispatched from
+`GWToolbox::Update` and `GWToolbox::Draw` (`GWToolboxdll/GWToolbox.cpp`):
 
-- `Update(float delta)` - **game thread**, once per frame, for *every loaded module* whether or
-  not its window is visible. Cheapest place to be wrong and the most commonly abused.
-- `Draw(IDirect3DDevice9*)` - **render thread**, inside the ImGui frame, for every *enabled*
-  module. UI elements draw their window here; plain modules paint overlays here.
+- `Update(float delta)` - **game thread**, once per frame, for every module in
+  `modules_enabled`. "Enabled" is not "visible": a window the user has closed still gets
+  `Update` every frame. Cheapest place to be wrong and the most commonly abused.
+- `Draw(IDirect3DDevice9*)` - **render thread**, inside the ImGui frame. UI elements draw their
+  window; plain modules in `other_modules_enabled` paint overlays. The loop is gated on
+  `GW::UI::GetIsUIDrawn()`, and skips elements without `ShowOnWorldMap()` while the world map is
+  up - but **`Draw` is called on every enabled element regardless of `visible`**; the
+  `if (!visible) return;` at the top of each `Draw` is the element's own responsibility. An
+  element that does work before that check pays it while closed.
 
 Plus: GWCA hooks/callbacks (`UIMgr` message callbacks, packet callbacks, `RenderHook`),
 and direct D3D work in the world renderers (`Widgets/Minimap/*`, `Modules/*Module.cpp` overlays).
@@ -47,6 +53,12 @@ Settings: `slow_threshold_us` (highlight threshold) and `stream_to_csv`, which a
 snapshots to `performance_log_<compiler>.csv` in the settings folder. The window's **Compare**
 tab loads two CSVs and diffs them - that is the before/after harness for any fix.
 
+**The instrumentation only runs while that window is open** - `PerformanceWindow::Draw` calls
+`GWToolbox::SetProfilingEnabled(visible)`, and every timing site is gated on it. That includes
+the hitch logger: with profiling on, any `Update`/`Draw` over 60ms writes a
+`[hitch] <Module>::Draw took N us` line to `log.txt`, which is the fastest way to catch a
+one-off stall that a 1s average hides. Ask for the log as well as the CSV.
+
 Ask for (or capture) a CSV from the scenario that hurts: idle in an outpost, busy explorable
 with a full party, and the specific window/widget open. Anything over ~100us avg is worth a
 look; over ~1000us is a bug.
@@ -58,6 +70,9 @@ confirmed regressions.
 
 Work through these classes. For each hit, judge it against: *does this run every frame? does
 it scale with agents/items/rows? does it allocate? does it touch the device, disk or network?*
+
+The classes overlap by design (a hot `std::map` is both E and F; a per-frame rebuild is both B
+and J). Report each finding once, under whichever class drives the fix.
 
 ### A. D3D state and device churn
 - `CreateStateBlock`, `GetRenderState`/`SetRenderState` loops, `GetTransform`, `GetTexture`
@@ -131,8 +146,9 @@ grep -rnE "std::vector<[^>]+> [a-z_]+;" GWToolboxdll --include=*.cpp   # locals 
 - `std::map` / `std::unordered_map` keyed by `std::string` looked up every frame - each lookup
   hashes or compares a string, and often *constructs* one from a `const char*`. Prefer an id,
   an enum, a `string_view` key, or resolving the iterator once and holding it.
-- `std::map` where a flat `std::vector` + index would be both smaller and cache-friendly. The
-  codebase has ~150 `std::map` declarations; the ones that matter are those touched per frame.
+- `std::map` where a flat `std::vector` + index would be both smaller and cache-friendly. There
+  are well over a hundred `std::map` declarations in the DLL; the ones that matter are the ones
+  touched per frame, so let the profiler or the call path pick them, not the grep count.
 - Repeated `.find()` on the same key in one function - do it once.
 - `operator[]` on a map in a read path (it inserts, and grows the map forever).
 - **Spatial data in a `std::map<std::pair<int,int>,...>` / `std::set<std::pair<int,int>>`.** One
@@ -216,15 +232,18 @@ far more often than it should - check class B/C/J before settling for the micro-
 
 ```
 grep -rn "\.at(" GWToolboxdll
-grep -rn "\[[a-z_]*\] =\|\[key\]\|\[name\]" GWToolboxdll --include=*.cpp   # map operator[] in read paths
-grep -rn "push_back" GWToolboxdll | grep -v reserve   # then check the enclosing loop
 grep -rn "std::function<" GWToolboxdll
+grep -rn -B3 "push_back\|emplace_back" GWToolboxdll --include=*.cpp | grep -A3 "for (\|while ("   # growth inside a loop; check for a reserve() above it
 ```
+
+`operator[]`-on-a-map has no usable grep - it looks identical to array indexing. Find it by
+reading the modules the Performance window flags, or by grepping the map's variable name
+(`grep -rn "<map_name>\[" GWToolboxdll`) once you know which map is hot.
 
 ### G. Blocking work on the frame threads
 - File IO (`std::ifstream`/`std::ofstream`/`CreateFile`), `Resources::` loads, texture decode,
   network calls, `std::mutex` contention, JSON parse - none of these belong in `Update`/`Draw`.
-  Push them through `Resources::EnqueueWorkerTask` (47 call sites already do) or make them lazy
+  Push them through `Resources::EnqueueWorkerTask` (already the norm across the DLL) or make them lazy
   (`perf(account-inventory): fetch item icons lazily during draw`).
 - Settings saved on change per frame instead of debounced.
 
@@ -308,6 +327,10 @@ Not per-frame cost, but they show up as "toolbox gets slower the longer I play":
   code you are about to optimise actually runs.
 
 ## 4. Verify before claiming a fix
+
+If you cannot run the client (headless, no GW install), you cannot complete this section - say
+so explicitly, label every finding **suspected**, and hand over the exact scenario and the
+module name to watch in the Performance window. Do not describe an unmeasured change as a fix.
 
 1. Re-run the same scenario with `stream_to_csv` on, before and after, and diff in the Compare
    tab. Quote the module's avg/max us both ways.

--- a/.agents/skills/performance-audit/SKILL.md
+++ b/.agents/skills/performance-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: performance-audit
-description: Audit GWToolbox++ for in-game performance problems - FPS drops, stutter, slow modules/widgets, hot per-frame code. Use when asked to "audit performance", "find what's tanking FPS", "why is toolbox slow", "profile a module", or before a release to sweep for regressions. Covers the frame cost model, the built-in Performance window, a per-class checklist with grep recipes, and the fix patterns already used in this repo.
+description: Audit GWToolbox++ for in-game performance problems - FPS drops, stutter, slow modules/widgets, hot per-frame code, and Debug-build container overhead (we play in Debug, so iterator debugging cost counts). Use when asked to "audit performance", "find what's tanking FPS", "why is toolbox slow in debug", "profile a module", or before a release to sweep for regressions. Covers the frame cost model, the built-in Performance window, a per-class checklist with grep recipes, and the fix patterns already used in this repo.
 ---
 
 # GWToolbox++ performance audit
@@ -25,9 +25,11 @@ Three multipliers to keep in mind:
 
 - **Per frame x per module x per element.** A loop over agents/items/rows inside `Draw` is
   O(frame x N). ImGui submits real layout work per item even for off-screen rows.
-- **Debug builds.** MSVC iterator debugging and non-inlined `std::` wrappers make container
-  churn 10-50x worse. Marc's "debug builds manhandle my pc" is usually a real hot path
-  amplified, not a debug-only artifact - find the underlying churn, don't dismiss it.
+- **Debug builds are a first-class target, not an afterthought.** The team *plays* in Debug so
+  crashes are caught at runtime, so Debug framerate matters as much as Release. MSVC iterator
+  debugging and non-inlined `std::` wrappers make container access 10-50x more expensive there
+  - see class F, which is the one class where a Debug-only measurement is enough to justify a
+  fix.
 - **D3D state.** Anything touching the device between GW's own draws must save/restore state.
   Doing that the naive way (`CreateStateBlock(D3DSBT_ALL)`) costs ~45us *per use per frame*;
   the explicit `D3DStateGuard` in `GWToolboxdll/D3DContainers.cpp` costs ~0.5us.
@@ -145,14 +147,79 @@ grep -rn "std::map<std::string\|unordered_map<std::string" GWToolboxdll
 grep -rn "std::map<std::pair\|std::set<std::pair" GWToolboxdll
 ```
 
-### F. Debug-build amplifiers
-Real code smells that debug builds punish hardest, worth fixing regardless:
+### F. Debug-build container overhead
 
-- Passing containers by value; range-for over a temporary.
-- `at()` in loops; index-checked access in tight loops - take `.data()` once and index the raw
-  pointer, or take a `std::span` over it.
-- Deep helper chains that only inline in release (tiny getters inside per-vertex loops).
-- `std::function` called per element instead of a template/lambda.
+**We play in Debug.** Running the Debug build in-game is how crashes get caught, so a module
+that is fine in Release and unusable in Debug is a real bug to this project, not a build
+artifact. Treat a Debug-only regression as actionable on its own.
+
+`CMAKE_MSVC_RUNTIME_LIBRARY` is `MultiThreadedDebug` for the Debug config, which means MSVC's
+default `_ITERATOR_DEBUG_LEVEL=2`: every iterator carries a back-pointer to its container and is
+registered in a linked list, every `++`/`*`/comparison validates against the owner, every
+container mutation walks and invalidates that list, and none of the `std::` wrappers inline. A
+`std::map` lookup that is a handful of compares in Release becomes a checked tree walk with
+debug-heap allocation on every node insert.
+
+Do **not** try to fix this by flipping `_ITERATOR_DEBUG_LEVEL` project-wide: the level is part
+of the ABI, `Dependencies/GWCA/lib/gwca.lib` ships as one prebuilt binary used by both configs,
+and the vcpkg deps are built to their triplet's default. MSVC's `detect_mismatch` linker check
+exists precisely because mixing levels is an ODR violation. Fix the hot code instead.
+
+**`std::vector` - take the buffer once.** In a hot loop, hoist `.data()` and `.size()` and index
+the raw pointer (or wrap it in a `std::span`), so the loop pays no per-element owner check:
+
+```cpp
+const auto* items = v.data();
+const size_t count = v.size();
+for (size_t i = 0; i < count; i++) { ... items[i] ... }
+```
+
+Only "when safe to do so": the container must not be resized or reallocated inside the loop
+(that dangles the pointer - which is exactly what iterator debugging would have caught for you),
+indices must come from `size()`, and `data()` may be null when empty, so early-out on `empty()`.
+Use `.data()`, never `&v[0]`, which asserts on an empty vector. For anything not measurably hot,
+leave the range-for - the checks are worth having.
+
+**`std::map` / `std::unordered_map` - look up once, hold the result.** Every lookup in Debug is
+a checked walk, and the usual sin is doing several against the same key:
+
+```cpp
+const auto it = m.find(key);        // once
+if (it == m.end()) return;
+auto& entry = it->second;           // then work through the reference
+```
+
+- Never `m[key]` in a read path - it default-constructs and inserts, growing the map forever and
+  allocating a node through the debug heap.
+- Iterate once with `for (auto& [k, v] : m)` rather than looping keys and looking each one up.
+- Better still, get out of the node-based container: for a bounded integer/enum key use a flat
+  `std::vector`/`std::array` indexed directly, which is both faster in Release and free of the
+  per-node debug bookkeeping (see the `NavCells` grid in class E). For a small set, a sorted
+  `std::vector` plus `std::ranges::lower_bound`, or even a linear scan, beats a `std::map`.
+- Cache the resolved pointer/reference across frames when the key is stable (module state, the
+  player's agent, the current map's entry) instead of re-looking it up every frame.
+
+**Everything else in a hot loop:**
+- `at()` anywhere in a loop - bounds-checked in both configs, and non-inlined in Debug.
+- Passing containers by value, range-for over a temporary, returning containers by value from a
+  helper called per element. Pass `const&` or `std::span`.
+- `push_back` in a loop without `reserve()` - each reallocation is a debug-heap alloc plus a
+  full iterator-invalidation sweep.
+- Deep helper chains that only inline in Release (tiny getters inside per-vertex loops).
+- `std::function` called per element instead of a template parameter or a plain lambda.
+- `std::string` temporaries (`substr`, concatenation, `c_str()` round-trips) - prefer
+  `std::string_view` over the existing buffer.
+
+Sanity check the direction of a "fix": if raw-pointer access makes a loop dramatically faster in
+Debug but changes nothing in Release, the win is real but it is *also* telling you the loop runs
+far more often than it should - check class B/C/J before settling for the micro-optimisation.
+
+```
+grep -rn "\.at(" GWToolboxdll
+grep -rn "\[[a-z_]*\] =\|\[key\]\|\[name\]" GWToolboxdll --include=*.cpp   # map operator[] in read paths
+grep -rn "push_back" GWToolboxdll | grep -v reserve   # then check the enclosing loop
+grep -rn "std::function<" GWToolboxdll
+```
 
 ### G. Blocking work on the frame threads
 - File IO (`std::ifstream`/`std::ofstream`/`CreateFile`), `Resources::` loads, texture decode,
@@ -247,7 +314,13 @@ Not per-frame cost, but they show up as "toolbox gets slower the longer I play":
 2. Confirm behaviour is unchanged - especially for D3D changes (state must be fully restored;
    GW's own rendering corrupting is worse than the frame cost) and for list culling (scroll
    extent, filtering, click targets).
-3. Check both build configs if the finding was debug-specific.
+3. **Measure Debug and Release separately, and report both.** The CSVs are already written per
+   compiler (`performance_log_msvc-*.csv` / `performance_log_clang-*.csv`); keep the configs
+   apart too. A fix that only helps Debug still counts - we play in Debug - but say so rather
+   than implying a Release win that is not there.
+4. For a `.data()`/raw-pointer change, re-check the safety conditions by hand: nothing resizes
+   the container inside the loop, indices are bounded by `size()`, and the empty case is handled.
+   You have removed the checking that would have caught a mistake there.
 
 ## 5. Report format
 

--- a/.agents/skills/performance-audit/references/fix-patterns.md
+++ b/.agents/skills/performance-audit/references/fix-patterns.md
@@ -233,6 +233,49 @@ for a while). Collapsed into `TerrainDrape::HighestZ`/`HighestZOnPlanes`/`Closes
 when a GW API call is the inner loop, see whether the data can be read once and evaluated in
 toolbox instead. Ghidra is available for finding the underlying structures.
 
+## 15. Sidestep iterator debugging in hot loops
+
+We play in Debug, and the Debug config links `MultiThreadedDebug`, so `_ITERATOR_DEBUG_LEVEL=2`
+is in force: checked iterators, an owner back-pointer per iterator, an invalidation sweep per
+mutation, and no inlining of the `std::` wrappers. Flipping the level project-wide is not an
+option - it is an ABI property, and `Dependencies/GWCA/lib/gwca.lib` is one prebuilt binary
+shared by both configs.
+
+Vector, per-element hot loop:
+
+```cpp
+// Before - two checked iterator operations per element, none inlined in Debug
+for (const auto& item : items) { Consume(item); }
+
+// After - one bounds-derived index, raw buffer access
+if (items.empty()) return;
+const auto* data = items.data();
+const size_t count = items.size();
+for (size_t i = 0; i < count; i++) { Consume(data[i]); }
+```
+
+Safe only when nothing inside the loop resizes `items`, the indices come from `size()`, and the
+empty case is handled (`data()` may be null; `&items[0]` asserts). Do this in measured hot loops
+only - elsewhere the checks are worth keeping, which is the whole reason we run Debug.
+
+Map, repeated lookups on one key:
+
+```cpp
+// Before - three checked tree walks, and operator[] inserts
+if (m.count(key)) { Use(m[key]); m[key].hits++; }
+
+// After - one walk, then work through the reference
+if (const auto it = m.find(key); it != m.end()) {
+    auto& entry = it->second;
+    Use(entry);
+    entry.hits++;
+}
+```
+
+And prefer getting out of the node-based container entirely when the key space allows it - a
+dense `std::vector` indexed by a bounded integer (pattern 9) has no nodes to allocate and no
+per-node debug bookkeeping, in either config.
+
 ## Measuring a fix
 
 1. Windows -> Performance, enable `stream_to_csv`.


### PR DESCRIPTION
Follow-up to #2513 (which merged while this was being written).

We run the Debug build in-game to catch crashes at runtime, so Debug framerate is a real target - the skill previously treated debug cost as an amplifier of a "real" release problem, which is the wrong framing.

**Class F rewritten:**
- What `_ITERATOR_DEBUG_LEVEL=2` actually costs (the Debug config links `MultiThreadedDebug`, so it's on): an owner back-pointer per iterator, validation on every `++`/`*`/compare, an invalidation sweep on every mutation, and no inlining of the `std::` wrappers.
- Why we can't just flip the level: it's an ABI property, `Dependencies/GWCA/lib/gwca.lib` is one prebuilt binary shared by both configs, and mixing levels is what MSVC's `detect_mismatch` check exists to catch. Fix the hot code instead.
- **Vectors:** hoist `.data()`/`.size()` and index the raw buffer in measured hot loops - with the safety conditions spelled out (nothing resizes inside the loop, indices bounded by `size()`, `data()` may be null when empty, `.data()` not `&v[0]`). Explicitly scoped to hot loops: elsewhere the checks are the reason we run Debug.
- **Maps:** one `find()` held by reference instead of repeated lookups; never `operator[]` in a read path (it inserts and allocates a node through the debug heap); iterate once rather than looping keys and looking each up; prefer a dense `std::vector` indexed by a bounded key over a node-based container, which wins in both configs.
- Plus `at()` in loops, `push_back` without `reserve`, containers by value, `std::function` per element, `std::string` temporaries.
- Sanity check: a `.data()` rewrite that helps Debug a lot and Release not at all is also telling you the loop runs more often than it should - check the caching/per-frame classes before settling for the micro-opt.

**Verify step** now says to measure Debug and Release separately and report both (a Debug-only win counts, but say so), and to hand-check the safety conditions on any raw-pointer change since you've removed the checking that would have caught the mistake.

`references/fix-patterns.md` gains pattern 15 with the before/after for both the vector loop and the repeated map lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)