### PR TITLE
perf: resolve hot container lookups once; fix the dev build break in Pathing

### DIFF
--- a/GWToolboxdll/Modules/GameSettings.cpp
+++ b/GWToolboxdll/Modules/GameSettings.cpp
@@ -620,10 +620,9 @@ namespace {
                 if (IsPlayerInParty(pending_reinvite.identifier)) {
                     return;
                 }
-                const auto aliases = PartyWindowModule::Instance().GetAliasedPlayerNames();
-                if (aliases.contains(player->name)) {
-                    const auto orig_name = aliases.at(player->name).c_str();
-                    GW::PartyMgr::InvitePlayer(orig_name);
+                const auto& aliases = PartyWindowModule::Instance().GetAliasedPlayerNames();
+                if (const auto found_alias = aliases.find(player->name); found_alias != aliases.end()) {
+                    GW::PartyMgr::InvitePlayer(found_alias->second.c_str());
                 }
                 else {
                     GW::PartyMgr::InvitePlayer(pending_reinvite.identifier);
@@ -1282,9 +1281,10 @@ namespace {
                     const auto title_id = static_cast<GW::Constants::TitleID>(reinterpret_cast<uint32_t>(wParam));
                     const auto title = GW::PlayerMgr::GetTitleTrack(title_id);
                     // @Cleanup: I don't think this behaves itself.
-                    if (title && title->max_title_tier_index == title->current_title_tier_index && last_recorded_tiers.contains(title_id) && last_recorded_tiers[title_id] != title->current_title_tier_index) {
+                    const auto recorded_tier = last_recorded_tiers.find(title_id);
+                    if (title && title->max_title_tier_index == title->current_title_tier_index && recorded_tier != last_recorded_tiers.end() && recorded_tier->second != title->current_title_tier_index) {
                         if (GW::Map::GetIsMapLoaded() && !GW::UI::IsLoadingScreenShown()) pending_screenshot = TIMER_INIT();
-                        last_recorded_tiers[title_id] = title->current_title_tier_index;
+                        recorded_tier->second = title->current_title_tier_index;
                     }
                 }
             } break;

--- a/GWToolboxdll/Modules/ResignLogModule.cpp
+++ b/GWToolboxdll/Modules/ResignLogModule.cpp
@@ -62,18 +62,14 @@ namespace {
 
     Status GetResignStatus(const uint32_t player_number)
     {
-        return party_member_statuses.contains(player_number) ? party_member_statuses[player_number].status : Status::Unknown;
+        const auto found = party_member_statuses.find(player_number);
+        return found != party_member_statuses.end() ? found->second.status : Status::Unknown;
     }
 
     void UpdatePlayerStates() {
         const auto players = GW::PartyMgr::GetPartyPlayers();
         if (!players) return;
         for (auto& p : *players) {
-            if (!party_member_statuses.contains(p.login_number)) {
-                party_member_statuses[p.login_number] = {
-                    Status::Unknown,0
-                };
-            }
             auto& st = party_member_statuses[p.login_number];
             if (!p.connected()) {
                 if (st.status != Status::NotInParty) {
@@ -204,9 +200,8 @@ bool ResignLogModule::PrintResignStatus(const uint32_t player_number, std::wstri
     if (!player_name) {
         return false;
     }
-    const auto status = party_member_statuses.contains(player_number) ? party_member_statuses[player_number] : PartyMemberStatus({
-        Status::Unknown, 0
-    });
+    const auto found = party_member_statuses.find(player_number);
+    const auto status = found != party_member_statuses.end() ? found->second : PartyMemberStatus{};
     out = std::format(L"{}. {} - {}", idx, player_name, TextUtils::StringToWString(GetStatusStr(status.status)));
     if (include_timestamp && status.timestamp) {
         out += std::format(L" [{}:{:02}:{:02}:{:03}]", status.timestamp / (60 * 60 * 1000), status.timestamp / (60 * 1000) % 60, status.timestamp / 1000 % 60, status.timestamp % 1000);

--- a/GWToolboxdll/Widgets/EffectsMonitorWidget.cpp
+++ b/GWToolboxdll/Widgets/EffectsMonitorWidget.cpp
@@ -225,8 +225,7 @@ namespace {
             case GW::Constants::SkillID::Aspect_of_Exhaustion:
             case GW::Constants::SkillID::Aspect_of_Depletion_energy_loss:
             case GW::Constants::SkillID::Scorpion_Aspect:
-                if (!effect_timestamps.contains((uint32_t)packet->effect->skill_id))
-                    effect_timestamps[(uint32_t)packet->effect->skill_id] = GW::MemoryMgr::GetSkillTimer();
+                effect_timestamps.try_emplace((uint32_t)packet->effect->skill_id, GW::MemoryMgr::GetSkillTimer());
                 break;
             }
         } break;

--- a/GWToolboxdll/Widgets/SkillMonitorWidget.cpp
+++ b/GWToolboxdll/Widgets/SkillMonitorWidget.cpp
@@ -90,8 +90,8 @@ namespace {
             return skill_activation.status == CASTING && skill_activation.id == skill_id;
         });
         float casttime = 0.f;
-        if (casttime_map.contains(agent_id)) {
-            casttime = casttime_map[agent_id];
+        if (const auto found_casttime = casttime_map.find(agent_id); found_casttime != casttime_map.end()) {
+            casttime = found_casttime->second;
         }
         else {
             const auto skill = GW::SkillbarMgr::GetSkillConstantData(skill_id);
@@ -121,8 +121,8 @@ namespace {
             return skill_activation.status == CASTING && skill_activation.id == skill_id;
         });
         float casttime = 0.f;
-        if (casttime_map.contains(agent_id)) {
-            casttime = casttime_map[agent_id];
+        if (const auto found_casttime = casttime_map.find(agent_id); found_casttime != casttime_map.end()) {
+            casttime = found_casttime->second;
         }
         else {
             const auto skill = GW::SkillbarMgr::GetSkillConstantData(skill_id);

--- a/GWToolboxdll/Widgets/TimerWidget.cpp
+++ b/GWToolboxdll/Widgets/TimerWidget.cpp
@@ -391,9 +391,7 @@ void TimerWidget::Initialize()
     ToolboxWidget::Initialize();
     SettingsRegistry::Register(this, settings);
     for (const auto& skill_id : spirit_effects | std::views::keys) {
-        if (!spirit_effects_enabled.contains(skill_id)) {
-            spirit_effects_enabled[skill_id] = false;
-        }
+        spirit_effects_enabled.try_emplace(skill_id, false);
     }
 
     GW::StoC::RegisterPacketCallback<GW::Packet::StoC::DisplayDialogue>(

--- a/GWToolboxdll/Windows/EnemyWindow.cpp
+++ b/GWToolboxdll/Windows/EnemyWindow.cpp
@@ -29,10 +29,11 @@ namespace {
     std::string& GetAgentName(uint32_t agent_id)
     {
         const auto enc_name = GW::Agents::GetAgentEncName(agent_id);
-        if (!agent_names_by_id.contains(agent_id)) {
-            agent_names_by_id[agent_id] = std::make_unique<GuiUtils::EncString>();
+        auto& entry = agent_names_by_id[agent_id];
+        if (!entry) {
+            entry = std::make_unique<GuiUtils::EncString>();
         }
-        auto* enc_string = agent_names_by_id[agent_id].get();
+        auto* enc_string = entry.get();
         enc_string->reset(enc_name);
         return enc_string->string();
     }

--- a/GWToolboxdll/Windows/Pathfinding/Pathing.cpp
+++ b/GWToolboxdll/Windows/Pathfinding/Pathing.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 
+#include <algorithm>
 #include <array>
 #include <map>
 
@@ -512,10 +513,8 @@ namespace Pathing {
         GW::Constants::InstanceType portal_cache_instance = GW::Constants::InstanceType::Loading;
 
         struct PortalDoorway {
-            GW::Vec2f left{}, right{}; // gate line, when the prop has a facing
             GW::Vec2f pos{};
-            float radius_sq = 0.f; // footprint fallback when it does not
-            bool has_facing = false;
+            float radius_sq = 0.f;
         };
         std::vector<PortalDoorway> doorway_cache;
 
@@ -532,52 +531,46 @@ namespace Pathing {
                 doorway_cache.reserve(portal_cache.size());
                 for (const auto& portal : portal_cache) {
                     const float half_width = PortalHalfWidth(portal);
-                    PortalDoorway d{};
-                    d.pos = {portal.pos.x, portal.pos.y};
-                    d.radius_sq = half_width * half_width;
-                    d.has_facing = portal.has_facing;
-                    if (portal.has_facing) {
-                        const float cos_f = cosf(portal.facing_radians);
-                        const float sin_f = sinf(portal.facing_radians);
-                        // The doorway spans across the facing, so the gate line runs along the perpendicular.
-                        d.left = {portal.pos.x - sin_f * half_width, portal.pos.y + cos_f * half_width};
-                        d.right = {portal.pos.x + sin_f * half_width, portal.pos.y - cos_f * half_width};
-                    }
-                    doorway_cache.push_back(d);
+                    doorway_cache.push_back({{portal.pos.x, portal.pos.y}, half_width * half_width});
                 }
             }
             return doorway_cache;
         }
 
-        float SideOfLine(const GW::Vec2f& a, const GW::Vec2f& b, const GW::Vec2f& p)
+        float DistanceToSegmentSq(const GW::Vec2f& p, const GW::Vec2f& a, const GW::Vec2f& b)
         {
-            return (b.x - a.x) * (p.y - a.y) - (b.y - a.y) * (p.x - a.x);
+            const float dx = b.x - a.x;
+            const float dy = b.y - a.y;
+            const float len_sq = dx * dx + dy * dy;
+            float t = 0.f;
+            if (len_sq > 0.f)
+                t = std::clamp(((p.x - a.x) * dx + (p.y - a.y) * dy) / len_sq, 0.f, 1.f);
+            const float ox = a.x + dx * t - p.x;
+            const float oy = a.y + dy * t - p.y;
+            return ox * ox + oy * oy;
         }
 
-        bool SegmentsCross(const GW::Vec2f& a, const GW::Vec2f& b, const GW::Vec2f& c, const GW::Vec2f& d)
+        // The doorway blocks as a disc the width of the prop, not as a line drawn across it. A
+        // walk that only clips the opening, or that creeps over it in steps too short to straddle
+        // a line, is still going through the gate.
+        bool SegmentHitsDoorway(const GW::Vec2f& a, const GW::Vec2f& b, const PortalDoorway& doorway)
         {
-            const float d1 = SideOfLine(a, b, c);
-            const float d2 = SideOfLine(a, b, d);
-            const float d3 = SideOfLine(c, d, a);
-            const float d4 = SideOfLine(c, d, b);
-            return ((d1 > 0) != (d2 > 0)) && ((d3 > 0) != (d4 > 0));
+            return DistanceToSegmentSq(doorway.pos, a, b) < doorway.radius_sq;
+        }
+
+        bool DoorwayContains(const PortalDoorway& doorway, const GW::Vec2f& p)
+        {
+            const float dx = p.x - doorway.pos.x;
+            const float dy = p.y - doorway.pos.y;
+            return dx * dx + dy * dy < doorway.radius_sq;
         }
     } // namespace
 
     bool CrossesTravelPortal(const GW::Vec2f& a, const GW::Vec2f& b)
     {
-        for (const auto& doorway : CurrentMapDoorways()) {
-            if (!doorway.has_facing) {
-                // No facing to build a doorway from, so fall back to the prop's footprint: block
-                // when the step ends up inside it.
-                const float dx = b.x - doorway.pos.x;
-                const float dy = b.y - doorway.pos.y;
-                if (dx * dx + dy * dy < doorway.radius_sq) return true;
-                continue;
-            }
-            if (SegmentsCross(a, b, doorway.left, doorway.right)) return true;
-        }
-        return false;
+        return std::ranges::any_of(CurrentMapDoorways(), [&](const PortalDoorway& doorway) {
+            return SegmentHitsDoorway(a, b, doorway);
+        });
     }
 
     bool CopyBlockedPlanes(std::vector<uint32_t>& out)
@@ -623,6 +616,17 @@ namespace Pathing {
             return GW::Vec2f{(t->XTL + t->XTR + t->XBL + t->XBR) * .25f, (t->YT + t->YB) * .5f};
         };
 
+        // A gate the player is standing in cannot be what separates them from anywhere, and you
+        // arrive on top of one every time you zone in through it. Testing against it would block
+        // the very first step and leave the whole map looking unreachable.
+        std::vector<const PortalDoorway*> gates;
+        for (const auto& doorway : CurrentMapDoorways()) {
+            if (!DoorwayContains(doorway, {player->pos.x, player->pos.y})) gates.push_back(&doorway);
+        }
+        const auto crosses_gate = [&](const GW::Vec2f& from, const GW::Vec2f& to) {
+            return std::ranges::any_of(gates, [&](const PortalDoorway* g) { return SegmentHitsDoorway(from, to, *g); });
+        };
+
         for (size_t head = 0; head < queue.size(); head++) {
             const auto [trap, plane_idx] = queue[head];
             const GW::Vec2f from = centre(trap);
@@ -630,7 +634,7 @@ namespace Pathing {
                 if (!adj || reachable.contains(adj)) continue;
                 // Stepping into a travel portal changes map, so the ground past one is not
                 // somewhere walking gets you - it belongs to the map on the other side.
-                if (CrossesTravelPortal(from, centre(adj))) continue;
+                if (crosses_gate(from, centre(adj))) continue;
                 reachable.insert(adj);
                 queue.push_back({adj, plane_idx});
             }
@@ -647,7 +651,7 @@ namespace Pathing {
                 for (uint32_t i = 0; i < pair->count; i++) {
                     const auto* t = pair->trapezoids[i];
                     if (!t || reachable.contains(t)) continue;
-                    if (CrossesTravelPortal(from, centre(t))) continue;
+                    if (crosses_gate(from, centre(t))) continue;
                     reachable.insert(t);
                     queue.push_back({t, target_plane});
                 }

--- a/GWToolboxdll/Windows/Pathfinding/PathingMapDataLoader.h
+++ b/GWToolboxdll/Windows/Pathfinding/PathingMapDataLoader.h
@@ -29,8 +29,8 @@ namespace Pathing {
     // Lightweight: load only portal props from DAT (no pathfinding data)
     bool LoadPortalPropsFromDAT(uint32_t map_file_id, std::vector<PortalProp>& out);
 
-    // Travel-portal props of the live map, with facing. Shared so the reachability check and the
-    // loaders agree on what counts as a portal.
+    // Travel-portal props of the live map. Shared so the reachability check and the loaders agree
+    // on what counts as a portal.
     bool IsPortalModelFileId(uint32_t model_file_id);
     void ParsePortalPropsFromMapContext(const GW::MapContext* map_context, std::vector<PortalProp>& out);
 


### PR DESCRIPTION
Two commits. **Both CI builds (MSVC and clang-cl) are green.**

## 1. `fix(pathing): restore the disc doorway test so dev builds again`

dev did not compile, so this PR - and every other branch off dev - failed CI with:

```
Pathing.cpp(538,43): error: no member named 'has_facing' in 'Pathing::PortalProp'
Pathing.cpp(540,57): error: no member named 'facing_radians' in 'Pathing::PortalProp'
```

`3d23ad84 perf fix` reintroduced the pre-`d966db48` body of `CrossesTravelPortal` - the gate-line version reading `PortalProp::has_facing` / `::facing_radians`. `d966db48 Pathing: block travel portals as a disc, not a line across the doorway` had deleted those fields three days earlier, so the merge landed code referencing members that no longer exist.

Restoring the fields would undo a deliberate behavioural fix, so this goes the other way - disc semantics back, on top of the per-map doorway cache `3d23ad84` added:

- `PortalDoorway` holds `pos` + `radius_sq` only.
- The test is `DistanceToSegmentSq` against that radius, so a walk that only clips the opening (or creeps over it in steps too short to straddle a line) still counts as going through the gate - `d966db48`'s original reason for the change.
- The reachability walk again skips gates the player is standing inside; without it, zoning in through a gate blocks the first step and the whole map reads as unreachable.

The perf intent of `3d23ad84` survives: the radius is squared once per map when the cache is built, not per test, and the per-adjacency `PortalHalfWidth` call is gone.

## 2. `perf: resolve hot container lookups once instead of contains()-then-[]`

Part of #2521, scoped to per-frame / per-packet paths: `SkillMonitorWidget` (×2), `EffectsMonitorWidget`, `TimerWidget`, `EnemyWindow`, `ResignLogModule` (×3), `GameSettings` (×2). Each tested for a key and then looked it up again; one `find()` / `try_emplace` does both. Node lookups are also where `_ITERATOR_DEBUG_LEVEL=2` hurts most, and Debug is the build we play in.

Two were latent bugs:

- `ResignLogModule::GetResignStatus` / `PrintResignStatus` read through `operator[]`, so asking about an unknown player **inserted a default entry** and grew the map. `find()` removes that.
- `GameSettings`' reinvite path did `const auto aliases = ...GetAliasedPlayerNames();` - the getter returns `const&`, `auto` dropped it, copying the whole alias map per reinvite. Now a reference.

`UpdatePlayerStates` did `contains()` + insert + `operator[]` where `PartyMemberStatus` already defaults to `{Unknown, 0}`, so one `operator[]` is equivalent.

Rebased on current dev; the BondsWidget and SnapsToPartyWindow hunks were dropped because `da21ca5e` already covered them. Remaining #2521 sites are listed in a comment on that issue.