### PR TITLE
perf(friendlist): cache the sorted online friends view

### DIFF
--- a/GWToolboxdll/Windows/FriendListWindow.cpp
+++ b/GWToolboxdll/Windows/FriendListWindow.cpp
@@ -79,6 +79,7 @@ namespace {
     bool friends_changed = false;
     bool friend_list_ready = false; // Allow processing when this is true.
     bool need_to_reorder_friends = true;
+    std::vector<FriendListWindow::Friend*> friends_online_sorted{};
 
     constexpr const char* alias_types[] = {
         "None",
@@ -832,6 +833,9 @@ bool FriendListWindow::RemoveFriend(const Friend* f)
         uuid_by_name.erase(char_key);
     }
     uuid_by_name.erase(f->GetAliasW());
+    // Cached view may hold the pointer we're about to free.
+    friends_online_sorted.clear();
+    need_to_reorder_friends = true;
     delete f;
     return true;
 }
@@ -1101,26 +1105,29 @@ void FriendListWindow::Draw(IDirect3DDevice9*)
             GW::FriendListMgr::SetFriendListStatus(static_cast<GW::FriendStatus>(status));
         }
     }
-    std::vector<Friend*> friends_online;
-    for (const auto& it : friends) {
-        Friend* lfp = it.second;
-        if (lfp->type != GW::FriendType::Friend) {
-            continue;
+    if (need_to_reorder_friends) {
+        friends_online_sorted.clear();
+        friends_online_sorted.reserve(friends.size());
+        for (const auto& it : friends) {
+            Friend* lfp = it.second;
+            if (lfp->type != GW::FriendType::Friend) {
+                continue;
+            }
+            if (lfp->IsOffline()) {
+                continue;
+            }
+            if (lfp->GetAliasW().empty()) {
+                continue;
+            }
+            friends_online_sorted.push_back(lfp);
         }
-        // Get actual object instead of pointer just in case it becomes invalid half way through the draw.
-        if (lfp->IsOffline()) {
-            continue;
-        }
-        if (lfp->GetAliasW().empty()) {
-            continue;
-        }
-        friends_online.push_back(lfp);
+        std::ranges::sort(friends_online_sorted, [](const Friend* lhs, const Friend* rhs) {
+            return lhs->GetAliasW().compare(rhs->GetAliasW()) < 0;
+        });
+        need_to_reorder_friends = false;
     }
-    std::ranges::sort(friends_online, [](const Friend* lhs, const Friend* rhs) {
-        return lhs->GetAliasW().compare(rhs->GetAliasW()) < 0;
-    });
     char tmpbuf[32];
-    for (Friend* lfp : friends_online) {
+    for (Friend* lfp : friends_online_sorted) {
         colIdx = 0;
         ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0, 0, 0, 0));
         ImGui::PushStyleColor(ImGuiCol_ButtonHovered, settings.hover_background_color.value);
@@ -1352,6 +1359,7 @@ void FriendListWindow::LoadFromFile()
                 uuid_by_name[it.first] = lf;
             }
             uuid_by_name[lf->GetAliasW()] = lf;
+            need_to_reorder_friends = true;
         }
         Log::Log("%s: Loaded friends from disk\n", Name());
         friends_list_checked = false;

--- a/GWToolboxdll/Windows/FriendListWindow.cpp
+++ b/GWToolboxdll/Windows/FriendListWindow.cpp
@@ -1109,7 +1109,7 @@ void FriendListWindow::Draw(IDirect3DDevice9*)
         friends_online_sorted.clear();
         friends_online_sorted.reserve(friends.size());
         for (const auto& it : friends) {
-            Friend* lfp = it.second;
+            const auto lfp = it.second;
             if (lfp->type != GW::FriendType::Friend) {
                 continue;
             }
@@ -1127,7 +1127,7 @@ void FriendListWindow::Draw(IDirect3DDevice9*)
         need_to_reorder_friends = false;
     }
     char tmpbuf[32];
-    for (Friend* lfp : friends_online_sorted) {
+    for (const auto lfp : friends_online_sorted) {
         colIdx = 0;
         ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0, 0, 0, 0));
         ImGui::PushStyleColor(ImGuiCol_ButtonHovered, settings.hover_background_color.value);


### PR DESCRIPTION
Closes #2519.

`FriendListWindow::Draw` allocated a fresh `std::vector<Friend*>`, filtered the whole friend map into it, and `std::ranges::sort`ed it by wstring alias **every frame** — while the friend list only actually changes when a friend-status packet arrives.

The file already had a `need_to_reorder_friends` flag that `SetFriend` maintained (status / alias / uuid / type change) but which nothing ever read. This wires it up:

- `friends_online_sorted` is a file-scope vector rebuilt (with `clear()` + `reserve()`) only when `need_to_reorder_friends` is set.
- `RemoveFriend` clears the cache and re-flags, since it frees a `Friend*` the cache may hold.
- `LoadFromFile` re-flags after repopulating `friends` from disk.

Steady-state cost per frame goes from `O(n log n)` wstring comparisons + a heap allocation to a plain vector walk.

Not measured — same static-pass caveat as the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)