### PR TITLE
perf(settings): cache the settings section lists instead of rebuilding them every frame

### DIFF
--- a/GWToolboxdll/ToolboxModule.cpp
+++ b/GWToolboxdll/ToolboxModule.cpp
@@ -20,9 +20,12 @@ namespace {
     std::unordered_map<std::string, ToolboxModule*> modules_loaded{};
 
     std::unordered_map<ToolboxModule*, std::vector<SectionDrawCallback>> module_setting_draw_callbacks;
+
+    uint32_t settings_draw_callbacks_revision = 0;
 } // namespace
 
 const std::unordered_map<std::string, SectionDrawCallbackList>& ToolboxModule::GetSettingsCallbacks() { return settings_draw_callbacks; }
+uint32_t ToolboxModule::GetSettingsCallbacksRevision() { return settings_draw_callbacks_revision; }
 const std::unordered_map<std::string, const char*>& ToolboxModule::GetSettingsIcons() { return settings_icons; }
 const std::unordered_map<std::string, ToolboxModule*>& ToolboxModule::GetModulesLoaded() { return modules_loaded; }
 
@@ -53,6 +56,7 @@ void ToolboxModule::Terminate()
         while (modules_it != callbacks_it->second.end()) {
             if (modules_it->module == this) {
                 callbacks_it->second.erase(modules_it);
+                settings_draw_callbacks_revision++;
                 modules_it = callbacks_it->second.begin();
                 continue;
             }
@@ -129,4 +133,5 @@ void ToolboxModule::RegisterSettingsContent(const char* section, const char* ico
         return pair.weighting > weighting;
     });
     callbacks.insert(it, {weighting, callback, this});
+    settings_draw_callbacks_revision++;
 }

--- a/GWToolboxdll/ToolboxModule.h
+++ b/GWToolboxdll/ToolboxModule.h
@@ -45,6 +45,9 @@ public:
     static const std::unordered_map<std::string, SectionDrawCallbackList>& GetSettingsCallbacks();
     static const std::unordered_map<std::string, const char*>& GetSettingsIcons();
 
+    // Bumped on every settings callback add/remove, so callers can cache anything derived from them.
+    static uint32_t GetSettingsCallbacksRevision();
+
     static const std::unordered_map<std::string, ToolboxModule*>& GetModulesLoaded();
 
     virtual void Initialize();

--- a/GWToolboxdll/Windows/SettingsWindow.cpp
+++ b/GWToolboxdll/Windows/SettingsWindow.cpp
@@ -502,72 +502,68 @@ void SettingsWindow::Draw(IDirect3DDevice9*)
 
         const auto& settings_sections = GetSettingsCallbacks();
 
-        std::vector<std::string> sections_to_draw;
-
         DrawSettingsSection(ToolboxTheme::Instance().SettingsName());
         DrawSettingsSection(ToolboxSettings::Instance().SettingsName());
 
-        const auto sort = [](const ToolboxModule* a, const ToolboxModule* b) {
-            return strcmp(a->Name(), b->Name()) < 0;
+        // Section names only change when a module is toggled or (un)registers settings content, not per frame.
+        struct CachedSections {
+            std::vector<ToolboxModule*> source;
+            std::vector<std::string> sections;
         };
-        const auto queue_settings_for_module = [&](ToolboxModule* m) {
-            for (const auto& [section, cb] : settings_sections) {
-                for (const auto& cbs : cb) {
-                    if (cbs.module == m) {
-                        sections_to_draw.push_back(section);
-                        break;
-                    }
-                }
-            }
-            sections_to_draw.emplace_back(m->SettingsName());
-        };
-        const auto sort_and_draw_settings = [&] {
-            std::ranges::sort(sections_to_draw);
-            for (auto& s : sections_to_draw) {
-                DrawSettingsSection(s.c_str());
-            }
-            sections_to_draw.clear();
-        };
+        static CachedSections modules, windows, widgets;
+        static uint32_t cached_callbacks_revision = static_cast<uint32_t>(-1);
 
+        const auto callbacks_revision = ToolboxModule::GetSettingsCallbacksRevision();
+        const bool callbacks_changed = cached_callbacks_revision != callbacks_revision;
+        cached_callbacks_revision = callbacks_revision;
 
-        static std::vector<ToolboxModule*> modules, windows, widgets;
-        const auto sync_sorted = [&](std::vector<ToolboxModule*>& dst, const auto& src) {
-            if (dst.size() == src.size() && std::ranges::equal(dst, src)) {
+        const auto sync_sections = [&](CachedSections& cache, const auto& src) {
+            if (!callbacks_changed && std::ranges::equal(cache.source, src)) {
                 return;
             }
-            dst.assign(src.begin(), src.end());
-            std::ranges::sort(dst, sort);
+            cache.source.assign(src.begin(), src.end());
+            std::vector<ToolboxModule*> sorted(cache.source);
+            std::ranges::sort(sorted, [](const ToolboxModule* a, const ToolboxModule* b) {
+                return strcmp(a->Name(), b->Name()) < 0;
+            });
+
+            cache.sections.clear();
+            for (const auto m : sorted) {
+                if (!m->HasSettings()) {
+                    continue;
+                }
+                for (const auto& [section, cb] : settings_sections) {
+                    for (const auto& cbs : cb) {
+                        if (cbs.module == m) {
+                            cache.sections.push_back(section);
+                            break;
+                        }
+                    }
+                }
+                cache.sections.emplace_back(m->SettingsName());
+            }
+            std::ranges::sort(cache.sections);
+        };
+        const auto draw_sections = [&](const CachedSections& cache) {
+            for (const auto& s : cache.sections) {
+                DrawSettingsSection(s.c_str());
+            }
         };
 
-        sync_sorted(modules, GWToolbox::GetModules());
-        for (const auto m : modules) {
-            if (m->HasSettings()) {
-                queue_settings_for_module(m);
-            }
-        }
-        sort_and_draw_settings();
+        sync_sections(modules, GWToolbox::GetModules());
+        draw_sections(modules);
 
-        sync_sorted(windows, GWToolbox::GetWindows());
-        if (!windows.empty()) {
+        sync_sections(windows, GWToolbox::GetWindows());
+        if (!windows.source.empty()) {
             ImGui::Text("Windows:");
         }
-        for (const auto m : windows) {
-            if (m->HasSettings()) {
-                queue_settings_for_module(m);
-            }
-        }
-        sort_and_draw_settings();
+        draw_sections(windows);
 
-        sync_sorted(widgets, GWToolbox::GetWidgets());
-        if (!widgets.empty()) {
+        sync_sections(widgets, GWToolbox::GetWidgets());
+        if (!widgets.source.empty()) {
             ImGui::Text("Widgets:");
         }
-        for (const auto m : widgets) {
-            if (m->HasSettings()) {
-                queue_settings_for_module(m);
-            }
-        }
-        sort_and_draw_settings();
+        draw_sections(widgets);
 
         if (ImGui::Button("Save Now", ImVec2(w, 0))) {
             GWToolbox::SaveSettings();


### PR DESCRIPTION
Fixes #2518.

`SettingsWindow::Draw` rebuilt the settings section list for modules, windows and widgets **every frame** the settings window was open:

- a copy of each of the three module lists,
- a sort of each by `strcmp(Name(), ...)`,
- an O(modules x sections x callbacks) scan of `GetSettingsCallbacks()` to find which sections each module contributes to,
- a `std::ranges::sort` over a freshly built `std::vector<std::string>` per group.

The existing guard compared the *sorted* cache against the *unsorted* source with `std::ranges::equal`, so it only hit when the source happened to already be in name order - in practice the copy + sort ran every frame regardless.

## Change

- `SettingsWindow::Draw` now caches, per group, the source module list *in its original order* plus the computed sorted section names. Per-frame cost is one pointer-sequence compare per group; everything else runs only when the list actually changes.
- `ToolboxModule::GetSettingsCallbacksRevision()` - a counter bumped whenever a settings callback is registered or removed (`RegisterSettingsContent` / `Terminate`) - so the cache also rebuilds when a module changes what sections it draws into, not just when it's enabled/disabled.

Draw order is unchanged, as are the group headers ("Windows:", "Widgets:") and the `drawn_settings` dedup.

## Testing

Not compiled or measured - this container has no MSVC/cmake toolchain, and the issue itself came from a static pass. Worth a build plus an eyeball of the Settings window (toggle a module on/off, confirm its section appears/disappears) before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)