### PR TITLE
feat(alcohol): recognise Juniberry Gin, Vabbian Wine, Zehtuka's Jug and Battle Isle Iced Tea

### DIFF
--- a/GWToolboxdll/Utils/ToolboxUtils.cpp
+++ b/GWToolboxdll/Utils/ToolboxUtils.cpp
@@ -769,6 +769,10 @@ namespace GW {
                 case GW::Constants::ItemID::Ricewine:
                 case GW::Constants::ItemID::ShamrockAle:
                 case GW::Constants::ItemID::Cider:
+                case GW::Constants::ItemID::BottleOfJuniberryGin:
+                case GW::Constants::ItemID::BottleOfVabbianWine:
+                case GW::Constants::ItemID::ZehtukasJug:
+                case GW::Constants::ItemID::BattleIsleIcedTea:
                     return 1;
                 case GW::Constants::ItemID::Grog:
                 case GW::Constants::ItemID::SpikedEggnog:


### PR DESCRIPTION
Toolbox didn't treat these four drinks as alcohol, so they were skipped by drunk-point tracking and by the alcohol pcon.

Added to `GW::Items::GetAlcoholPointsPerUse` as 1-point drinks:
- Bottle of Juniberry Gin (19172)
- Bottle of Vabbian Wine (19173)
- Zehtuka's Jug (19171)
- Battle Isle Iced Tea (36682)

The item IDs already existed in GWCA's `ItemIDs.h`; they just were never wired into the alcohol switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)