### PR TITLE
fix(alcohol): don't treat Battle Isle Iced Tea as alcohol

### DIFF
--- a/GWToolboxdll/Utils/ToolboxUtils.cpp
+++ b/GWToolboxdll/Utils/ToolboxUtils.cpp
@@ -772,7 +772,6 @@ namespace GW {
                 case GW::Constants::ItemID::BottleOfJuniberryGin:
                 case GW::Constants::ItemID::BottleOfVabbianWine:
                 case GW::Constants::ItemID::ZehtukasJug:
-                case GW::Constants::ItemID::BattleIsleIcedTea:
                     return 1;
                 case GW::Constants::ItemID::Grog:
                 case GW::Constants::ItemID::SpikedEggnog:


### PR DESCRIPTION
Follow-up to #2528. Battle Isle Iced Tea was included with the three Nightfall drinks in `GW::Items::GetAlcoholPointsPerUse`; removing it as requested. Juniberry Gin, Vabbian Wine and Zehtuka's Jug stay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)