### PR TITLE
Fix Identify All and Salvage All with infinite kits

### DIFF
--- a/GWToolboxdll/Modules/InventoryManager.cpp
+++ b/GWToolboxdll/Modules/InventoryManager.cpp
@@ -1423,15 +1423,8 @@ namespace {
         if (!pending_salvage_kit.item_id || !pending_salvage_item.item_id) {
             return false;
         }
-        const auto current_kit = pending_salvage_kit.item();
-        if (current_kit && current_kit->GetUses() == pending_salvage_kit.uses) {
-            return true;
-        }
         const auto current_item = pending_salvage_item.item();
-        if (current_item && current_item->quantity == pending_salvage_item.quantity) {
-            return true;
-        }
-        return false;
+        return current_item && current_item->quantity == pending_salvage_item.quantity;
     }
 
     void ContinueSalvage()
@@ -1552,15 +1545,8 @@ namespace {
         if (!pending_identify_kit.item_id || !pending_identify_item.item_id) {
             return false;
         }
-        const auto current_kit = pending_identify_kit.item();
-        if (current_kit && current_kit->GetUses() == pending_identify_kit.uses) {
-            return true;
-        }
         const auto current_item = pending_identify_item.item();
-        if (current_item && !current_item->GetIsIdentified()) {
-            return true;
-        }
-        return false;
+        return current_item && !current_item->GetIsIdentified();
     }
 
 } // namespace
@@ -2753,4 +2739,3 @@ bool PendingTransaction::selling()
 {
     return type == GW::Merchant::TransactionType::MerchantSell || type == GW::Merchant::TransactionType::TraderSell;
 }
-


### PR DESCRIPTION
Fixes #2544

## What changed
- detect identification completion from the target item's identified flag
- detect salvage completion from the target item's quantity/removal
- stop requiring the kit use count to change, since infinite kits do not deplete

## Reverse engineering
The current Guild Wars client inventory-slot callback at `0x008ea920` dispatches identify action `0xd` and salvage action `0xe` against the target item. The target identified/quantity state is therefore the completion signal; kit depletion is a separate item update and is not guaranteed for infinite kits.

## Verification
- `git diff --check`
- MSVC and clang-cl builds will run in PR CI (the local checkout has no CMake/compiler toolchain)