### PR TITLE
Use Lightbringer title in Turai's Procession and Jennur's Horde

### DIFF
--- a/GWToolboxdll/Utils/ToolboxUtils.cpp
+++ b/GWToolboxdll/Utils/ToolboxUtils.cpp
@@ -137,6 +137,12 @@ namespace GW {
                     return {TitleID::Deldrimor};
                 case MapID::Turais_Procession:
                 case MapID::Jennurs_Horde:
+                case MapID::Nundu_Bay:
+                case MapID::Dzagonur_Bastion:
+                case MapID::Yatendi_Canyons:
+                case MapID::Vehtendi_Valley:
+                case MapID::Forum_Highlands:
+                case MapID::The_Mirror_of_Lyss:
                 case MapID::Grand_Court_of_Sebelkeh:
                     return {TitleID::Lightbringer};
                 // Vanguard: DepthsOfTyria dungeons in Charr territory

--- a/GWToolboxdll/Utils/ToolboxUtils.cpp
+++ b/GWToolboxdll/Utils/ToolboxUtils.cpp
@@ -135,7 +135,8 @@ namespace GW {
                 case MapID::The_Elusive_Golemancer_mission:
                 case MapID::Genius_Operated_Living_Enchanted_Manifestation_mission:
                     return {TitleID::Deldrimor};
-                // Lightbringer: Grand Court of Sebelkeh mission has Margonites (would otherwise show Sunspear by continent)
+                case MapID::Turais_Procession:
+                case MapID::Jennurs_Horde:
                 case MapID::Grand_Court_of_Sebelkeh:
                     return {TitleID::Lightbringer};
                 // Vanguard: DepthsOfTyria dungeons in Charr territory


### PR DESCRIPTION
## Summary
- select Lightbringer for Turai's Procession and Jennur's Horde
- select Lightbringer for Nundu Bay and Dzagonur Bastion
- select Lightbringer for Yatendi Canyons, Vehtendi Valley, Forum Highlands, and The Mirror of Lyss
- retain the existing Grand Court of Sebelkeh override

## Verification
- `git diff --check`
- confirmed all map names use existing `MapID` constants