### PR TITLE
Make in-game name tag color overrides optional

### DIFF
--- a/GWToolboxdll/Modules/GameSettings.cpp
+++ b/GWToolboxdll/Modules/GameSettings.cpp
@@ -2001,8 +2001,11 @@ void GameSettings::DrawSettingsInternal()
     ImGui::Unindent();
     ImGui::NewLine();
     ImGui::Checkbox("Show 'You have N Lockpicks' on Locked Chest name tags", &settings.show_amount_of_lockpicks_under_locked_chest_nametag);
-    ImGui::Text("In-game name tag colors:");
+    if (ImGui::Checkbox("In-game name tag colors", &settings.override_name_tag_colors)) {
+        nametag_color_cache.clear();
+    }
     ImGui::ShowHelp("These set global name tag colors by category.\nTo set a custom color for a specific agent, see Minimap > Custom Agents > Text Color.");
+    ImGui::BeginDisabled(!settings.override_name_tag_colors);
     ImGui::Indent();
     ImGui::StartSpacedElements(checkbox_w);
     constexpr uint32_t flags = ImGuiColorEditFlags_NoInputs;
@@ -2011,6 +2014,7 @@ void GameSettings::DrawSettingsInternal()
         Colors::DrawSettingHueWheel(c.label, c.ptr, flags);
     }
     ImGui::Unindent();
+    ImGui::EndDisabled();
 
     ImGui::NewLine();
     ImGui::Text("Hide skill descriptions in:");
@@ -2495,46 +2499,44 @@ void GameSettings::OnUpdateSkillCount(GW::HookStatus*, void* packet)
     }
 }
 
-// Default colour for agent name tags
 void GameSettings::OnAgentNameTag(GW::HookStatus*, const GW::UI::UIMessage msgid, void* wParam, void*)
 {
     if (msgid != GW::UI::UIMessage::kShowAgentNameTag && msgid != GW::UI::UIMessage::kSetAgentNameTagAttribs) {
         return;
     }
     const auto tag = static_cast<GW::UI::AgentNameTagInfo*>(wParam);
-    // Apply default colors for nametags
-    for (const auto& c : nametag_color_settings) {
-        if (c.player_override) {
-            continue;
-        }
-        if (tag->text_color == static_cast<Color>(c.default_val)) {
-            tag->text_color = *c.ptr;
-            break;
-        }
-    }
-    // Override colors for friends, guildies and party members
-    if (tag->name_enc) {
-        const auto player_name = TextUtils::GetPlayerNameFromEncodedString(tag->name_enc);
-        if (!player_name.empty() && player_name != GetPlayerName()) {
-            const auto cached = nametag_color_cache.find(player_name);
-            if (cached != nametag_color_cache.end()) {
-                tag->text_color = cached->second;
+    if (settings.override_name_tag_colors) {
+        for (const auto& c : nametag_color_settings) {
+            if (c.player_override) {
+                continue;
             }
-            else {
-                if (GW::FriendListMgr::GetFriend(nullptr, player_name.c_str(), GW::FriendType::Friend)) {
-                    tag->text_color = settings.nametag_color_friends;
-                }
-                else if (IsGuildMemberPlayer(player_name.c_str())) {
-                    tag->text_color = settings.nametag_color_guild_members;
-                }
-                else if (IsAgentInMyParty(tag->agent_id)) {
-                    tag->text_color = settings.nametag_color_player_in_my_party;
-                }
-                nametag_color_cache[player_name] = tag->text_color;
+            if (tag->text_color == static_cast<Color>(c.default_val)) {
+                tag->text_color = *c.ptr;
+                break;
             }
         }
+        if (tag->name_enc) {
+            const auto player_name = TextUtils::GetPlayerNameFromEncodedString(tag->name_enc);
+            if (!player_name.empty() && player_name != GetPlayerName()) {
+                const auto cached = nametag_color_cache.find(player_name);
+                if (cached != nametag_color_cache.end()) {
+                    tag->text_color = cached->second;
+                }
+                else {
+                    if (GW::FriendListMgr::GetFriend(nullptr, player_name.c_str(), GW::FriendType::Friend)) {
+                        tag->text_color = settings.nametag_color_friends;
+                    }
+                    else if (IsGuildMemberPlayer(player_name.c_str())) {
+                        tag->text_color = settings.nametag_color_guild_members;
+                    }
+                    else if (IsAgentInMyParty(tag->agent_id)) {
+                        tag->text_color = settings.nametag_color_player_in_my_party;
+                    }
+                    nametag_color_cache[player_name] = tag->text_color;
+                }
+            }
+        }
     }
-    // Show amount of lockpicks under locked chest nametag
     if (settings.show_amount_of_lockpicks_under_locked_chest_nametag && tag->name_enc && wcseq(tag->name_enc, GW::EncStrings::LockedChest) && !tag->underline) {
         static wchar_t you_have_n_lockpicks[12];
         const auto count = GW::Items::CountItemByModelId(GW::Constants::ItemID::Lockpick, (int)GW::Constants::Bag::Backpack, (int)GW::Constants::Bag::Bag_2);

--- a/GWToolboxdll/Modules/GameSettings.h
+++ b/GWToolboxdll/Modules/GameSettings.h
@@ -157,7 +157,7 @@ public:
         bool useful_level_progress_label = true;
         bool hide_store_page_on_char_select = false;
 
-        bool override_name_tag_colors = true;
+        bool override_name_tag_colors = false;
         Colors::SettingColor nametag_color_npc = static_cast<Color>(DEFAULT_NAMETAG_COLOR::NPC);
         Colors::SettingColor nametag_color_player_self = static_cast<Color>(DEFAULT_NAMETAG_COLOR::PLAYER_SELF);
         Colors::SettingColor nametag_color_player_other = static_cast<Color>(DEFAULT_NAMETAG_COLOR::PLAYER_OTHER);

--- a/GWToolboxdll/Modules/GameSettings.h
+++ b/GWToolboxdll/Modules/GameSettings.h
@@ -157,6 +157,7 @@ public:
         bool useful_level_progress_label = true;
         bool hide_store_page_on_char_select = false;
 
+        bool override_name_tag_colors = true;
         Colors::SettingColor nametag_color_npc = static_cast<Color>(DEFAULT_NAMETAG_COLOR::NPC);
         Colors::SettingColor nametag_color_player_self = static_cast<Color>(DEFAULT_NAMETAG_COLOR::PLAYER_SELF);
         Colors::SettingColor nametag_color_player_other = static_cast<Color>(DEFAULT_NAMETAG_COLOR::PLAYER_OTHER);

--- a/site/src/content/docs/history.md
+++ b/site/src/content/docs/history.md
@@ -9,6 +9,7 @@ the latest version, go to the [Home Page](./) instead.
 
 ## Version 8.34
 * [Fix] Automatic title selection (`/title` and the Reapply Title hotkey) now uses Lightbringer instead of Sunspear in Turai's Procession, Jennur's Horde, Nundu Bay, Dzagonur Bastion, Yatendi Canyons, Vehtendi Valley, Forum Highlands and The Mirror of Lyss, where Margonites make Lightbringer the useful title.
+* [Fix] Game Settings: in-game name tag colour overrides can now be disabled so the colours configured in Guild Wars are used instead. The overrides are off by default.
 * [Minor] Mouse Settings: disabled the "Enable cursor fix" camera-glitch workaround because an August 2026 Guild Wars update changed lookaround speed. Cursor-size scaling remains available.
 
 ## Version 8.33

--- a/site/src/content/docs/settings.mdx
+++ b/site/src/content/docs/settings.mdx
@@ -120,7 +120,7 @@ Note that you will not see status changes on your own friend list, but your stat
 * **Block full screen message when entering a new area**
 * **Block full screen popup that shows when completing a vanquish**
 * **Block full screen popup that shows when opening a dungeon chest**
-* **In-game name tag colors** sets the colour the floating name tag above each agent is drawn in, by category. Click a colour wheel to change a category's colour. These are global overrides — to recolour a single specific agent instead of a whole category, use [Minimap → Custom Agents](/docs/windows/minimap#custom-agents)' **Text color** field:
+* **In-game name tag colors** overrides the colour the floating name tag above each agent is drawn in, by category. Uncheck it to use Guild Wars' name tag colours instead. Click a colour wheel to change a category's colour. These are global overrides — to recolour a single specific agent instead of a whole category, use [Minimap → Custom Agents](/docs/windows/minimap#custom-agents)' **Text color** field:
     * **NPC** — non-player characters such as allies, vendors and signposts.
     * **Myself** — your own character.
     * **Other Player** — players not currently in your party.


### PR DESCRIPTION
## Summary
- turn the in-game name tag colors heading into a persisted checkbox
- disable color pickers and skip all Toolbox name tag recoloring when unchecked
- document how to fall back to Guild Wars' configured colors

## Verification
- `git diff --check origin/dev...HEAD`
- builds/tests not run (workspace policy prohibits project builds)