### PR TITLE
Fix stale map data and periodic cartographer hitches

### DIFF
--- a/GWToolboxdll/Widgets/CartographerWidget.cpp
+++ b/GWToolboxdll/Widgets/CartographerWidget.cpp
@@ -1805,16 +1805,22 @@ void CartographerWidget::Update(float)
     }
     if (!changed.empty()) Log::FlushFile();
 #endif
-    if (coverage_stale || sweeping) {
-        // Rebuilding from scratch supersedes any pending diff, so re-baseline the snapshot.
+    const bool sweep_finished = sweeping && probe->complete;
+    const bool rebuild_all = coverage_stale || sweep_finished;
+    if (rebuild_all) {
         if (grid.bits && grid.dword_count) carto_snapshot.assign(grid.bits, grid.bits + grid.dword_count);
         RecomputeCoverage(grid, map_info);
     }
-    else if (!changed.empty()) {
-        RescoreAround(grid, changed);
-        RebuildFog(grid, map_info);
+    else {
+        if (sweeping) {
+            for (auto& [cell, sc] : probe->cells) ScoreStandCell(grid, cell, sc);
+        }
+        else if (!changed.empty()) {
+            RescoreAround(grid, changed);
+        }
+        if (!changed.empty()) RebuildFog(grid, map_info);
     }
-    if (coverage_stale || sweeping || !changed.empty()) RecountExploration(grid);
+    if (rebuild_all || !changed.empty()) RecountExploration(grid);
     carto_dirty = false;
     coverage_stale = false;
     PruneUncoveredPoints(grid);

--- a/GWToolboxdll/Widgets/CartographerWidget.cpp
+++ b/GWToolboxdll/Widgets/CartographerWidget.cpp
@@ -86,6 +86,7 @@ namespace Carto {
     bool show_grid = false;
     bool using_bec = false;
     bool set_quest_marker = true;
+    bool fog_covers_continent = false;
 #ifndef _DEBUG
     constexpr auto kBirdsEyeView = static_cast<GW::Constants::SkillID>(3439);
 #endif
@@ -719,6 +720,11 @@ namespace Carto {
         }
     }
 
+    bool ShouldBuildContinentFog()
+    {
+        return show_whole_continent && !continent_mask.Empty() && GW::UI::GetIsWorldMapShowing();
+    }
+
     void RebuildFog(const CartoGrid& grid, GW::AreaInfo* map_info)
     {
         unreachable_fog_cells = 0;
@@ -733,8 +739,8 @@ namespace Carto {
         int y1 = static_cast<int>(ceilf(bounds.Max.y / kWorldMapUnitsPerCell));
         map_cell_min = {x0, y0};
         map_cell_max = {x1, y1};
-        // The bake answers for the whole continent, so the world map shows everything worth walking to.
-        if (show_whole_continent && !continent_mask.Empty()) {
+        fog_covers_continent = ShouldBuildContinentFog();
+        if (fog_covers_continent) {
             x0 = continent_mask.x0;
             y0 = continent_mask.y0;
             x1 = continent_mask.x0 + continent_mask.w;
@@ -1770,7 +1776,10 @@ void CartographerWidget::Update(float)
     }
 #endif
 
-    if (TIMER_DIFF(last_scan) < 1000) return;
+    BuildContinentMask(static_cast<int>(map_info->continent));
+    const bool fog_scope_changed = fog_covers_continent != ShouldBuildContinentFog();
+    if (fog_scope_changed) coverage_stale = true;
+    if (!fog_scope_changed && TIMER_DIFF(last_scan) < 1000) return;
     last_scan = TIMER_INIT();
 
     CartoGrid grid;
@@ -1785,7 +1794,6 @@ void CartographerWidget::Update(float)
     GW::Vec2f player_wm;
     if (!WorldMapWidget::GamePosToWorldMap(player->pos, player_wm)) return;
     player_wm_cached = player_wm;
-    BuildContinentMask(static_cast<int>(map_info->continent));
     // A completing sweep still needs one last full pass, so the flag is read before the sweep.
     DropProbeIfGatesMoved();
     const bool sweeping = !probe->complete;

--- a/GWToolboxdll/Widgets/CartographerWidget.cpp
+++ b/GWToolboxdll/Widgets/CartographerWidget.cpp
@@ -1769,7 +1769,7 @@ void CartographerWidget::Update(float)
     const auto has_birds_eye_view = GW::Effects::GetPlayerEffectBySkillId(kBirdsEyeView) != nullptr;
     if (using_bec != has_birds_eye_view) {
         using_bec = has_birds_eye_view;
-        for (auto& [map_id, cached] : probe_cache) cached.complete = false;
+        for (auto& entry : probe_cache) entry.second.complete = false;
         owner_cache.clear();
         owner_query = {};
         coverage_stale = true;

--- a/GWToolboxdll/Windows/Pathfinding/PathfindingWindow.cpp
+++ b/GWToolboxdll/Windows/Pathfinding/PathfindingWindow.cpp
@@ -430,30 +430,37 @@ namespace {
             return nullptr;
         }
 
-        // Fast path: file already resident. readFromDat routes into the game's serialized file subsystem, so re-reading it every recompute stalls the game thread; file_id alone keys the map within a session (mirrors GetMilepathForMap).
+        const auto live_map_context = map_id == GW::Map::GetMapID() ? GW::GetMapContext() : nullptr;
+        const auto matches_live_bounds = [live_map_context](const Pathing::PathingMapData* data) {
+            return !live_map_context || (data
+                && data->bounds_min.x == live_map_context->start_pos.x
+                && data->bounds_min.y == live_map_context->start_pos.y
+                && data->bounds_max.x == live_map_context->end_pos.x
+                && data->bounds_max.y == live_map_context->end_pos.y);
+        };
+
         for (const auto& [hash, mp] : mile_paths_by_coords) {
             if (static_cast<uint32_t>(hash & 0xFFFFFFFF) == fid) {
+                if (!matches_live_bounds(mp->GetMapData())) continue;
                 TouchLru(hash);
                 return mp;
             }
         }
 
-        // A ctx-fallback entry (bounds mismatch below) is keyed by map_id + live node count, not fid — probe for it
-        // or the resident-only path never sees it and the prewarm loop re-reads the DAT forever.
         if (map_id == GW::Map::GetMapID()) {
             if (const auto mc = GW::GetMapContext(); mc && mc->path && mc->path->staticData) {
                 const auto ctx_hash = static_cast<uint64_t>(map_id) | (static_cast<uint64_t>(mc->path->pathNodes.size()) << 32);
                 if (const auto it = mile_paths_by_coords.find(ctx_hash); it != mile_paths_by_coords.end()) {
-                    TouchLru(ctx_hash);
-                    return it->second;
+                    if (matches_live_bounds(it->second->GetMapData())) {
+                        TouchLru(ctx_hash);
+                        return it->second;
+                    }
                 }
             }
         }
 
-        // Not resident: the DAT read + parse below blocks the caller. Refuse on the game thread.
         if (!allow_load) return nullptr;
 
-        // Already known unreadable this session — skip the blocking re-read and the repeat log.
         if (dat_load_failed_fids.contains(fid)) return nullptr;
 
         PATH_LOG_INFO("LoadMapFromDAT: map=%d file_id=%u (0x%X)", (int)map_id, fid, fid);
@@ -465,15 +472,14 @@ namespace {
             return nullptr;
         }
 
-        // For the current map, cross-check DAT against live memory: a bounds mismatch means a stale file_id, so use the MapContext copy.
         Pathing::PathingMapData ctx_data;
         Pathing::PathingMapData* chosen = &dat_data;
         if (map_id == GW::Map::GetMapID()) {
             if (!Pathing::LoadFromMapContext(GW::GetMapContext(), fid, &ctx_data)) {
                 PATH_LOG_ERROR("LoadMapFromDAT: Context parse failed for map %d file_id=%u", (int)map_id, fid);
             }
-            else if (ctx_data.bounds_max.x != dat_data.bounds_max.x || ctx_data.bounds_max.y != dat_data.bounds_max.y) {
-                PATH_LOG_ERROR("LoadMapFromDAT: Context bounds_max dont match DAT portals for the current map, file_id=%u - check InfoWindow to update the map file id for this map! Using map context data for now.", fid);
+            else if (!matches_live_bounds(&dat_data)) {
+                PATH_LOG_ERROR("LoadMapFromDAT: Context bounds dont match DAT portals for the current map, file_id=%u - check InfoWindow to update the map file id for this map! Using map context data for now.", fid);
                 chosen = &ctx_data;
             }
         }


### PR DESCRIPTION
## Summary
- validate resident pathing data against all live current-map bounds
- fall back to current MapContext data after mission/outpost geometry changes
- avoid rebuilding fog on every one-second probe step
- limit mission-map fog generation to the current map rectangle
- generate continent-wide fog only while the whole-continent world map is displayed

## Verification
- `git diff --check origin/dev...HEAD`
- build/tests not run per workspace policy