### PR TITLE
Fix synthetic spirit durations on the skillbar

### DIFF
--- a/GWToolboxdll/Utils/ToolboxUtils.cpp
+++ b/GWToolboxdll/Utils/ToolboxUtils.cpp
@@ -866,6 +866,11 @@ namespace GW {
         // The full ID is 0x0f000000 | skill_id, making it deterministic and recyclable per skill.
         static constexpr uint32_t custom_effect_id_base = 0x0f000000;
 
+        bool IsCustomEffect(const uint32_t effect_id)
+        {
+            return (effect_id & 0xff000000) == custom_effect_id_base;
+        }
+
         uint32_t AddCustomEffect(const GW::Constants::SkillID skill_id, const float duration_seconds)
         {
             const auto player_effects = GW::Effects::GetPlayerEffectsArray();
@@ -893,7 +898,7 @@ namespace GW {
 
         bool RemoveCustomEffect(const uint32_t effect_id)
         {
-            if ((effect_id & 0xff000000) != custom_effect_id_base) return false;
+            if (!IsCustomEffect(effect_id)) return false;
             const auto player_effects = GW::Effects::GetPlayerEffectsArray();
             if (!player_effects) return false;
             auto& arr = player_effects->effects;

--- a/GWToolboxdll/Utils/ToolboxUtils.h
+++ b/GWToolboxdll/Utils/ToolboxUtils.h
@@ -237,6 +237,8 @@ namespace GW {
         bool IsAlcohol(const GW::Item* item);
     }
     namespace Effects {
+        bool IsCustomEffect(uint32_t effect_id);
+
         uint32_t AddCustomEffect(GW::Constants::SkillID skill_id, float duration_seconds);
 
         bool RemoveCustomEffect(uint32_t effect_id);

--- a/GWToolboxdll/Widgets/SkillbarWidget.cpp
+++ b/GWToolboxdll/Widgets/SkillbarWidget.cpp
@@ -16,6 +16,7 @@
 #include <Defines.h>
 #include <ImGuiAddons.h>
 #include <Utils/FontLoader.h>
+#include <Utils/ToolboxUtils.h>
 #include "SkillbarWidget.h"
 #include <Modules/ChatCommands.h>
 
@@ -181,6 +182,8 @@ void SkillbarWidget::Update(float)
     }
     if (const auto* effects = want_effects ? GW::Effects::GetPlayerEffects() : nullptr) {
         for (const GW::Effect& effect : *effects) {
+            if (GW::Effects::IsCustomEffect(effect.effect_id))
+                continue;
             for (auto i = 0; i < _countof(skillbar->skills); i++) {
                 if (effect.skill_id != skillbar->skills[i].skill_id)
                     continue;


### PR DESCRIPTION
## Summary
- identify Toolbox-created synthetic effects by their reserved effect ID range
- ignore synthetic spirit timers when coloring or annotating skillbar slots
- keep the spirit timers available on the effects bar

## Verification
- `git diff --check`
- build/tests not run because compilation is prohibited in this workspace