### PR TITLE
Fix animation speed label in Info window

### DIFF
--- a/GWToolboxdll/Windows/InfoWindow.cpp
+++ b/GWToolboxdll/Windows/InfoWindow.cpp
@@ -461,7 +461,7 @@ namespace {
                 InfoField("Animation code", "0x%X", living->animation_code);
                 InfoField("Animation id", "0x%X", living->animation_id);
                 InfoField("Animation type", "0x%X", living->animation_type);
-                InfoField("Animation code", "%.3f", living->animation_speed);
+                InfoField("Animation speed", "%.3f", living->animation_speed);
             }
             if (npc) {
                 ImGui::PushID("npc_info");


### PR DESCRIPTION
## Summary
- label the target animation speed field correctly
- avoid the duplicate ImGui label that triggers a warning in the Advanced target info

## Verification
- `git diff --check`
- confirmed the field reads `AgentLiving::animation_speed`

No build or tests run per workspace policy.