### PR TITLE
Fix spirit effect skillbar tracking

### DIFF
--- a/GWToolboxdll/Utils/ToolboxUtils.cpp
+++ b/GWToolboxdll/Utils/ToolboxUtils.cpp
@@ -866,11 +866,6 @@ namespace GW {
         // The full ID is 0x0f000000 | skill_id, making it deterministic and recyclable per skill.
         static constexpr uint32_t custom_effect_id_base = 0x0f000000;
 
-        bool IsCustomEffect(const uint32_t effect_id)
-        {
-            return (effect_id & 0xff000000) == custom_effect_id_base;
-        }
-
         uint32_t AddCustomEffect(const GW::Constants::SkillID skill_id, const float duration_seconds)
         {
             const auto player_effects = GW::Effects::GetPlayerEffectsArray();
@@ -898,7 +893,7 @@ namespace GW {
 
         bool RemoveCustomEffect(const uint32_t effect_id)
         {
-            if (!IsCustomEffect(effect_id)) return false;
+            if ((effect_id & 0xff000000) != custom_effect_id_base) return false;
             const auto player_effects = GW::Effects::GetPlayerEffectsArray();
             if (!player_effects) return false;
             auto& arr = player_effects->effects;

--- a/GWToolboxdll/Utils/ToolboxUtils.h
+++ b/GWToolboxdll/Utils/ToolboxUtils.h
@@ -237,8 +237,6 @@ namespace GW {
         bool IsAlcohol(const GW::Item* item);
     }
     namespace Effects {
-        bool IsCustomEffect(uint32_t effect_id);
-
         uint32_t AddCustomEffect(GW::Constants::SkillID skill_id, float duration_seconds);
 
         bool RemoveCustomEffect(uint32_t effect_id);

--- a/GWToolboxdll/Widgets/EffectsMonitorWidget.cpp
+++ b/GWToolboxdll/Widgets/EffectsMonitorWidget.cpp
@@ -31,13 +31,17 @@ namespace {
     ImGuiViewport* viewport = nullptr;
     ImDrawList* draw_list = nullptr;
 
-    // Maps an agent's encoded name to the skill_id of the spirit it represents.
-    // TODO: @3vcloud - populate with actual encoded names for all desired tracked spirits.
-    const std::unordered_map<std::wstring, GW::Constants::SkillID> spirit_enc_name_to_skill_id = {
-        {L"\x416F\xD141\x9F0B\x5276", GW::Constants::SkillID::Disenchantment},
-        {L"\x4164\x825C\xA2F2\x1235", GW::Constants::SkillID::Pain},
-        {L"\x4171\xCD7A\xD7A6\x386D", GW::Constants::SkillID::Bloodsong},
-        {L"\x8102\x5F66\xBE02\xB9AB\x1073", GW::Constants::SkillID::Signet_of_Spirits}
+    const std::unordered_map<uint32_t, GW::Constants::SkillID> spirit_name_id_to_skill_id = {
+        {0x4063, GW::Constants::SkillID::Shadowsong},
+        {0x4064, GW::Constants::SkillID::Pain},
+        {0x406b, GW::Constants::SkillID::Dissonance},
+        {0x406f, GW::Constants::SkillID::Disenchantment},
+        {0x4071, GW::Constants::SkillID::Bloodsong},
+        {0x4072, GW::Constants::SkillID::Wanderlust},
+        {0xc537, GW::Constants::SkillID::Anguish},
+        {0xc53a, GW::Constants::SkillID::Gaze_of_Fury},
+        {0x11196, GW::Constants::SkillID::Vampirism},
+        {0x15c66, GW::Constants::SkillID::Signet_of_Spirits},
     };
 
     // Deterministic effect ID per spirit skill: high byte 0x0f avoids collision with real effects.
@@ -107,7 +111,7 @@ namespace {
             const auto* packet = static_cast<GW::UI::UIPacket::kAgentSkillPacket*>(wparam);
             if (packet->agent_id != GW::Agents::GetControlledCharacterId()) break;
             const bool is_spirit = std::any_of(
-                spirit_enc_name_to_skill_id.begin(), spirit_enc_name_to_skill_id.end(),
+                spirit_name_id_to_skill_id.begin(), spirit_name_id_to_skill_id.end(),
                 [&](const auto& kv) { return kv.second == packet->skill_id; });
             if (!is_spirit) break;
             // Agent may have already spawned before this activation message arrived.
@@ -129,8 +133,8 @@ namespace {
             if (!IsAlliedSpirit(agent)) break;
             const auto* enc_name = GW::Agents::GetAgentEncName(agent);
             if (!enc_name) break;
-            const auto name_it = spirit_enc_name_to_skill_id.find(enc_name);
-            if (name_it == spirit_enc_name_to_skill_id.end()) break;
+            const auto name_it = spirit_name_id_to_skill_id.find(GW::UI::EncStrToUInt32(enc_name));
+            if (name_it == spirit_name_id_to_skill_id.end()) break;
             if (pending_spirit_spawn.skill_id != GW::Constants::SkillID::No_Skill) {
                 // Skill activation arrived first: resolve now.
                 if (GW::MemoryMgr::GetSkillTimer() - pending_spirit_spawn.timestamp_ms > 500) {

--- a/GWToolboxdll/Widgets/SkillbarWidget.cpp
+++ b/GWToolboxdll/Widgets/SkillbarWidget.cpp
@@ -16,7 +16,6 @@
 #include <Defines.h>
 #include <ImGuiAddons.h>
 #include <Utils/FontLoader.h>
-#include <Utils/ToolboxUtils.h>
 #include "SkillbarWidget.h"
 #include <Modules/ChatCommands.h>
 
@@ -182,8 +181,6 @@ void SkillbarWidget::Update(float)
     }
     if (const auto* effects = want_effects ? GW::Effects::GetPlayerEffects() : nullptr) {
         for (const GW::Effect& effect : *effects) {
-            if (GW::Effects::IsCustomEffect(effect.effect_id))
-                continue;
             for (auto i = 0; i < _countof(skillbar->skills); i++) {
                 if (effect.skill_id != skillbar->skills[i].skill_id)
                     continue;

--- a/site/src/content/docs/history.md
+++ b/site/src/content/docs/history.md
@@ -9,6 +9,7 @@ the latest version, go to the [Home Page](./) instead.
 
 ## Version 8.34
 * [Fix] Hero Builds now applies saved disabled skill states at a controlled rate, so loading teams with more than 16 disabled hero skills no longer leaves later skills enabled.
+* [Fix] Effects Monitor now tracks Shadowsong, Dissonance, Wanderlust, Anguish, Gaze of Fury and Vampirism after you summon them. These spirit timers also highlight their matching skill and appear in the Skillbar widget's effect monitor.
 * [Fix] Cartographer now detects the Bird's Eye View effect automatically and adjusts its reveal range while the effect is active, replacing the manual Bird's Eye Compass setting.
 * [Fix] Cartographer now uses the current map's pathing data after transitions between missions and outposts, and no longer periodically rebuilds continent-wide fog while the mission map is open.
 * [Fix] Automatic title selection (`/title` and the Reapply Title hotkey) now uses Lightbringer instead of Sunspear in Turai's Procession, Jennur's Horde, Nundu Bay, Dzagonur Bastion, Yatendi Canyons, Vehtendi Valley, Forum Highlands and The Mirror of Lyss, where Margonites make Lightbringer the useful title.
@@ -220,7 +221,7 @@ the latest version, go to the [Home Page](./) instead.
 * [New] `/transmo` NPC list is now fully user-configurable in settings — add your current target as a named entry, edit or remove existing entries, and reset to built-in defaults; also added `/transmo model NPC_ID MODEL_FILE_ID MODEL_FILE FLAGS [SCALE]` subcommand for direct model specification
 * [New] Inventory Sorting: new `/sortinventory` and `/sortstorage` chat commands to sort character or storage inventory from chat; sorting now automatically deprioritises Nicholas The Traveller collectibles until the week they are needed
 * [New] Notifications: added Team Chat as an option for toast notifications and window flash; new "Change window title on notification" option — the GW window title changes to show pending unread notifications when the game is minimised or running in the background
-* [New] Effects Monitor widget: new option to track nearby spirit effect timers (Bloodsong, Vampirism, etc.) and display their remaining duration alongside your own effects
+* [New] Effects Monitor widget: new option to track spirit effect timers for spirits you summon and display their remaining duration alongside your own effects
 * [New] Item Drops: new "Always hide items for player" and "Always hide items for party" lists — items on these lists are always hidden from the drop overlay regardless of rarity or other filter settings
 * [New] Added `/disableheroskill <hero_number> <slot_number> [0|1]` chat command to enable or disable a specific hero's skill slot from chat
 * [New] Added `/custommarker <x> <y>` chat command to place a custom quest marker at exact world coordinates; `/custommarker clear` removes it


### PR DESCRIPTION
## Summary
- identify tracked spirits by their language-independent encoded string IDs
- add Shadowsong, Dissonance, Wanderlust, Gaze of Fury, Anguish, and Vampirism
- allow synthetic spirit effects to drive skillbar highlighting and duration overlays
- remove the now-unused public custom-effect classifier
- correct the original spirit-timer release note and document the expanded support for 8.34

## Verification
- `git diff --check`
- `clang-format --dry-run --Werror GWToolboxdll/Widgets/EffectsMonitorWidget.cpp GWToolboxdll/Widgets/SkillbarWidget.cpp GWToolboxdll/Utils/ToolboxUtils.cpp GWToolboxdll/Utils/ToolboxUtils.h`
- build/tests not run because compilation is prohibited in this workspace