### PR TITLE
fix: guard stale audio handles and bounty frames

### DIFF
--- a/GWToolboxdll/Modules/AudioSettings.cpp
+++ b/GWToolboxdll/Modules/AudioSettings.cpp
@@ -126,11 +126,21 @@ struct MusicData {
         return handle;
     }
 
-    // Avoids assertion issues when handle->h0000 is freed already e.g. by toolbox
+    int OnCloseHandleException(const DWORD code)
+    {
+        return code == EXCEPTION_ACCESS_VIOLATION || code == EXCEPTION_BREAKPOINT
+            ? EXCEPTION_EXECUTE_HANDLER
+            : EXCEPTION_CONTINUE_SEARCH;
+    }
+
     void OnCloseHandle(GW::RecObject* handle)
     {
         GW::Hook::EnterHook();
-        if (handle && handle->vtable) CloseHandle_Ret(handle);
+        __try {
+            if (handle && handle->vtable) CloseHandle_Ret(handle);
+        }
+        __except (OnCloseHandleException(GetExceptionCode())) {
+        }
         GW::Hook::LeaveHook();
     }
 

--- a/GWToolboxdll/Widgets/BountyKillTrackerWidget.cpp
+++ b/GWToolboxdll/Widgets/BountyKillTrackerWidget.cpp
@@ -332,8 +332,7 @@ void BountyKillTrackerWidget::Draw(IDirect3DDevice9*)
     if (!visible) return;
     if (active_bounties.empty()) return;
 
-    if (!effects_frame)
-        effects_frame = GW::UI::GetFrameByLabel(L"Effects");
+    effects_frame = GW::UI::GetFrameByLabel(L"Effects");
     if (!effects_frame) return;
 
     DummyWindow();


### PR DESCRIPTION
## Summary

- guard the audio close hook against stale game handles while preserving hook bookkeeping
- reacquire the Effects UI frame before traversing its children
- address the two crash signatures found across seven 8.33 minidumps

## Validation

- `cmake --build build --config Debug --target GWToolboxdll`
- `git diff --check`