### PR TITLE
Document corrected spirit durations

### DIFF
--- a/site/src/content/docs/history.md
+++ b/site/src/content/docs/history.md
@@ -9,7 +9,7 @@ the latest version, go to the [Home Page](./) instead.
 
 ## Version 8.34
 * [Fix] Hero Builds now applies saved disabled skill states at a controlled rate, so loading teams with more than 16 disabled hero skills no longer leaves later skills enabled.
-* [Fix] Effects Monitor now tracks Shadowsong, Dissonance, Wanderlust, Anguish, Gaze of Fury and Vampirism after you summon them. These spirit timers also highlight their matching skill and appear in the Skillbar widget's effect monitor.
+* [Fix] Effects Monitor now tracks Shadowsong, Dissonance, Wanderlust, Anguish, Gaze of Fury and Vampirism after you summon them. These spirit timers also highlight their matching skill and appear in the Skillbar widget's effect monitor. Timers use each spirit's actual lifespan, including Shadowsong's fixed 30 seconds and Vampirism's Sunspear-rank scaling.
 * [Fix] Cartographer now detects the Bird's Eye View effect automatically and adjusts its reveal range while the effect is active, replacing the manual Bird's Eye Compass setting.
 * [Fix] Cartographer now uses the current map's pathing data after transitions between missions and outposts, and no longer periodically rebuilds continent-wide fog while the mission map is open.
 * [Fix] Automatic title selection (`/title` and the Reapply Title hotkey) now uses Lightbringer instead of Sunspear in Turai's Procession, Jennur's Horde, Nundu Bay, Dzagonur Bastion, Yatendi Canyons, Vehtendi Valley, Forum Highlands and The Mirror of Lyss, where Margonites make Lightbringer the useful title.


### PR DESCRIPTION
## Summary
- clarify that tracked spirit timers use the spirit lifespan
- note Shadowsong's fixed 30-second lifespan and Vampirism's Sunspear-rank scaling

## Verification
- `git diff --check`
- site build not run because builds are prohibited in this workspace