### PR TITLE
docs: note audio handle crash fix

### DIFF
--- a/site/src/content/docs/history.md
+++ b/site/src/content/docs/history.md
@@ -14,6 +14,7 @@ the latest version, go to the [Home Page](./) instead.
 * [Fix] Cartographer now uses the current map's pathing data after transitions between missions and outposts, and no longer periodically rebuilds continent-wide fog while the mission map is open.
 * [Fix] Automatic title selection (`/title` and the Reapply Title hotkey) now uses Lightbringer instead of Sunspear in Turai's Procession, Jennur's Horde, Nundu Bay, Dzagonur Bastion, Yatendi Canyons, Vehtendi Valley, Forum Highlands and The Mirror of Lyss, where Margonites make Lightbringer the useful title.
 * [Fix] Fixed a crash while replacing the fallback font during Toolbox startup.
+* [Fix] Audio Settings no longer crashes Guild Wars when an audio handle has already been released.
 * [Fix] Game Settings: in-game name tag colour overrides can now be disabled so the colours configured in Guild Wars are used instead. The overrides are off by default.
 * [Minor] Mouse Settings: disabled the "Enable cursor fix" camera-glitch workaround because an August 2026 Guild Wars update changed lookaround speed. Cursor-size scaling remains available.
 


### PR DESCRIPTION
Adds the 8.34 release-note entry for the stale audio-handle crash fix.

Static verification: git diff --check (site build not run per workspace policy).