### PR TITLE
refactor: use ui messages for skill status

### DIFF
--- a/GWToolboxdll/Modules/GameSettings.cpp
+++ b/GWToolboxdll/Modules/GameSettings.cpp
@@ -2432,7 +2432,7 @@ void GameSettings::OnWriteChat(GW::HookStatus* status, GW::UI::UIMessage, void* 
 // Auto-drop UA when recasting
 void GameSettings::OnAgentStartCast(GW::HookStatus*, GW::UI::UIMessage, void* wParam, void*)
 {
-    const auto packet = static_cast<GW::UI::UIPacket::kAgentSkillPacket*>(wParam);
+    const auto packet = static_cast<GW::UI::UIPacket::kAgentSkillStartedCast*>(wParam);
     if (settings.drop_ua_on_cast && packet && packet->skill_id == GW::Constants::SkillID::Unyielding_Aura) {
         const auto buffs = GW::Effects::GetAgentBuffs(packet->agent_id);
         if (buffs) {

--- a/GWToolboxdll/Modules/ObserverModule.cpp
+++ b/GWToolboxdll/Modules/ObserverModule.cpp
@@ -221,6 +221,21 @@ void ObserverModule::Initialize()
         HandleGenericPacket(value_id, caster_id, target_id, value, no_target);
     });
 
+    const auto on_agent_skill_status = [this](GW::HookStatus*, const GW::UI::UIMessage message_id, void* wparam, void*) {
+        if (!wparam || !IsActive() || !InitializeObserverSession()) {
+            return;
+        }
+        const auto packet = static_cast<GW::UI::UIPacket::kAgentSkillPacket*>(wparam);
+        if (message_id == GW::UI::UIMessage::kAgentSkillCancelled) {
+            HandleSkillCancelled(packet->agent_id);
+        }
+        else {
+            HandleInterrupted(packet->agent_id);
+        }
+    };
+    RegisterUIMessageCallback(&AgentSkillStatus_Entry, GW::UI::UIMessage::kAgentSkillCancelled, on_agent_skill_status);
+    RegisterUIMessageCallback(&AgentSkillStatus_Entry, GW::UI::UIMessage::kAgentSkillInterrupted, on_agent_skill_status);
+
     if (IsActive() && !observer_session_initialized) {
         InitializeObserverSession();
     }
@@ -358,20 +373,12 @@ void ObserverModule::HandleGenericPacket(const uint32_t value_id, const uint32_t
             break;
         }
 
-        case GW::Packet::StoC::GenericValueID::interrupted:
-            HandleInterrupted(caster_id);
-            break;
-
         case GW::Packet::StoC::GenericValueID::attack_skill_finished:
             HandleAttackSkillFinished(caster_id);
             break;
 
         case GW::Packet::StoC::GenericValueID::instant_skill_activated:
             HandleInstantSkillActivated(caster_id, target_id, static_cast<GW::Constants::SkillID>(value));
-            break;
-
-        case GW::Packet::StoC::GenericValueID::attack_skill_stopped:
-            HandleAttackSkillStopped(caster_id);
             break;
 
         case GW::Packet::StoC::GenericValueID::attack_skill_activated: {
@@ -394,10 +401,6 @@ void ObserverModule::HandleGenericPacket(const uint32_t value_id, const uint32_t
 
         case GW::Packet::StoC::GenericValueID::skill_finished:
             HandleSkillFinished(caster_id);
-            break;
-
-        case GW::Packet::StoC::GenericValueID::skill_stopped:
-            HandleSkillStopped(caster_id);
             break;
 
         case GW::Packet::StoC::GenericValueID::skill_activated: {
@@ -793,12 +796,6 @@ void ObserverModule::HandleAttackSkillFinished(const uint32_t agent_id)
 }
 
 
-void ObserverModule::HandleAttackSkillStopped(const uint32_t agent_id)
-{
-    ReduceAction(GetObservableAgentById(agent_id), ActionStage::Stopped);
-}
-
-
 void ObserverModule::HandleInstantSkillActivated(const uint32_t caster_id, const uint32_t target_id, const GW::Constants::SkillID skill_id)
 {
     // assuming there are no instant attack skills...
@@ -824,7 +821,7 @@ void ObserverModule::HandleSkillFinished(const uint32_t agent_id)
 }
 
 
-void ObserverModule::HandleSkillStopped(const uint32_t agent_id)
+void ObserverModule::HandleSkillCancelled(const uint32_t agent_id)
 {
     ReduceAction(GetObservableAgentById(agent_id), ActionStage::Stopped);
 }

--- a/GWToolboxdll/Modules/ObserverModule.h
+++ b/GWToolboxdll/Modules/ObserverModule.h
@@ -657,11 +657,10 @@ private:
     void HandleInstantSkillActivated(uint32_t caster_id, uint32_t target_id, GW::Constants::SkillID skill_id);
 
     void HandleAttackSkillFinished(uint32_t agent_id);
-    void HandleAttackSkillStopped(uint32_t agent_id);
     void HandleAttackSkillStarted(uint32_t caster_id, uint32_t target_id, GW::Constants::SkillID skill_id);
 
     void HandleSkillFinished(uint32_t agent_id);
-    void HandleSkillStopped(uint32_t agent_id);
+    void HandleSkillCancelled(uint32_t agent_id);
     void HandleSkillActivated(uint32_t caster_id, uint32_t target_id, GW::Constants::SkillID skill_id);
 
     void HandleGenericPacket(uint32_t value_id, uint32_t caster_id,
@@ -724,4 +723,5 @@ private:
     GW::HookEntry GenericValueTarget_Entry;
     GW::HookEntry GenericValue_Entry;
     GW::HookEntry GenericFloat_Entry;
+    GW::HookEntry AgentSkillStatus_Entry;
 };

--- a/GWToolboxdll/Widgets/SkillMonitorWidget.cpp
+++ b/GWToolboxdll/Widgets/SkillMonitorWidget.cpp
@@ -8,7 +8,6 @@
 #include <GWCA/Managers/MapMgr.h>
 #include <GWCA/Managers/SkillbarMgr.h>
 
-#include <GWCA/Packets/StoC.h>
 #include <GWCA/Managers/UIMgr.h>
 #include <GWCA/Utilities/Hook.h>
 
@@ -53,15 +52,6 @@ namespace {
             return settings.status_color_interrupted;
         }
         return Colors::Empty();
-    }
-
-    void CasttimeCallback(const uint32_t value_id, const uint32_t caster_id, const float value)
-    {
-        if (value_id != GW::Packet::StoC::GenericValueID::casttime) {
-            return;
-        }
-
-        casttime_map[caster_id] = value;
     }
 
     GW::HookEntry PostUIMessage_Entry;
@@ -111,7 +101,7 @@ namespace {
             });
         }
     }
-    void OnSkillCancelledOrInterrupted(uint32_t agent_id, GW::Constants::SkillID skill_id)
+    void OnSkillStopped(uint32_t agent_id, GW::Constants::SkillID skill_id, const SkillActivationStatus status)
     {
         const auto skill_history = &history[agent_id];
         if (!skill_history) {
@@ -129,13 +119,13 @@ namespace {
             if (skill) casttime = skill->activation;
         }
         if (casting != skill_history->end()) {
-            casting->status = CANCELLED;
+            casting->status = status;
             casttime_map.erase(agent_id);
         }
         else {
             skill_history->push_back({
                 skill_id,
-                CANCELLED,
+                status,
                 TIMER_INIT(),
                 TIMER_INIT(),
                 casttime,
@@ -154,9 +144,10 @@ namespace {
                 const auto packet = (GW::UI::UIPacket::kAgentSkillPacket*)wparam;
                 OnSkillCompleted(packet->agent_id, packet->skill_id);
             } break;
-            case GW::UI::UIMessage::kAgentSkillCancelled: {
+            case GW::UI::UIMessage::kAgentSkillCancelled:
+            case GW::UI::UIMessage::kAgentSkillInterrupted: {
                 const auto packet = (GW::UI::UIPacket::kAgentSkillPacket*)wparam;
-                OnSkillCancelledOrInterrupted(packet->agent_id, packet->skill_id);
+                OnSkillStopped(packet->agent_id, packet->skill_id, message_id == GW::UI::UIMessage::kAgentSkillCancelled ? CANCELLED : INTERRUPTED);
             } break;
         }
     }
@@ -167,7 +158,7 @@ void SkillMonitorWidget::Initialize()
 {
     SnapsToPartyWindow::Initialize();
     SettingsRegistry::Register(this, settings);
-    GW::UI::UIMessage ui_messages[] = {GW::UI::UIMessage::kAgentSkillActivated, GW::UI::UIMessage::kAgentSkillActivatedInstantly, GW::UI::UIMessage::kAgentSkillCancelled, GW::UI::UIMessage::kAgentSkillStartedCast};
+    GW::UI::UIMessage ui_messages[] = {GW::UI::UIMessage::kAgentSkillActivated, GW::UI::UIMessage::kAgentSkillActivatedInstantly, GW::UI::UIMessage::kAgentSkillCancelled, GW::UI::UIMessage::kAgentSkillInterrupted, GW::UI::UIMessage::kAgentSkillStartedCast};
     for (auto message_id : ui_messages) {
         RegisterUIMessageCallback(&PostUIMessage_Entry, message_id, OnPostUIMessage, 0x4000);
     }
@@ -361,5 +352,4 @@ void SkillMonitorWidget::DrawSettingsInternal()
         settings.history_timeout = 0;
     }
 }
-
 

--- a/GWToolboxdll/Widgets/SkillMonitorWidget.h
+++ b/GWToolboxdll/Widgets/SkillMonitorWidget.h
@@ -3,9 +3,6 @@
 #include <Widgets/SnapsToPartyWindow.h>
 
 class SkillMonitorWidget : public SnapsToPartyWindow {
-protected:
-    static void OnStoCPacket(GW::HookStatus* status, GW::Packet::StoC::PacketBase* base);
-    static void SkillCallback(const uint32_t value_id, const uint32_t caster_id, const uint32_t value);
 public:
     static SkillMonitorWidget& Instance()
     {


### PR DESCRIPTION
Replace StoC terminal skill-state handling with the client UI broadcasts introduced in GWCA 4.8.6.0.

- Track cancelled skills through kAgentSkillCancelled.
- Track interrupted skills through kAgentSkillInterrupted.
- Remove duplicate StoC stopped/interrupted handling from Observer.
- Render cancelled and interrupted Skill Monitor entries separately.