### PR TITLE
Chat Log message as a trigger for DisplayDialogue

### DIFF
--- a/GWToolboxdll/Windows/ObjectiveTimerWindow.cpp
+++ b/GWToolboxdll/Windows/ObjectiveTimerWindow.cpp
@@ -22,6 +22,7 @@
 #include <GWCA/Managers/GameThreadMgr.h>
 #include <GWCA/Managers/MapMgr.h>
 #include <GWCA/Managers/StoCMgr.h>
+#include <GWCA/Managers/UIMgr.h>
 
 #include <GWToolbox.h>
 #include <Utils/GuiUtils.h>
@@ -286,6 +287,7 @@ void ObjectiveTimerWindow::Initialize()
     static GW::HookEntry AgentUpdateAllegiance_Entry;
     static GW::HookEntry DoACompleteZone_Entry;
     static GW::HookEntry DisplayDialogue_Entry;
+    static GW::HookEntry WriteToChatLog_Entry;
     static GW::HookEntry MessageServer_Entry;
     static GW::HookEntry InstanceLoadInfo_Entry;
     static GW::HookEntry ManipulateMapObject_Entry;
@@ -373,6 +375,12 @@ void ObjectiveTimerWindow::Initialize()
             // NB: All GW strings are null terminated, use wcslen to avoid having to check all 122 chars
             Event(EventType::DisplayDialogue, wcslen(packet->message), packet->message);
         });
+    GW::UI::RegisterUIMessageCallback(
+        &WriteToChatLog_Entry, GW::UI::UIMessage::kWriteToChatLogWithSender,
+        [this](GW::HookStatus*, GW::UI::UIMessage, void* wparam, void*) {
+            const auto packet = (GW::UI::UIPacket::kWriteToChatLogWithSender*)wparam;
+            Event(EventType::DisplayDialogue, wcslen(packet->message), packet->message);
+        }, 0x4000);
     GW::StoC::RegisterPacketCallback<GW::Packet::StoC::ManipulateMapObject>(
         &ManipulateMapObject_Entry, [this](GW::HookStatus*, const GW::Packet::StoC::ManipulateMapObject* packet) {
             if (GW::Map::GetInstanceType() == GW::Constants::InstanceType::Explorable) {


### PR DESCRIPTION
This fixes the long standing issue of the DoA "Tendrils" objective not starting, leaving the objective in a broken state even for a completed run.

I believe dialogs are also always shown in chat so the UIMessage trigger could just replace the StoC::DisplayDialogue trigger entirely but I don't feel like testing them all and triggering the event twice is fine enough.