### PR TITLE
fix: clarify compositor status messages

### DIFF
--- a/GWToolboxdll/Modules/DangerRingsModule.cpp
+++ b/GWToolboxdll/Modules/DangerRingsModule.cpp
@@ -226,8 +226,12 @@ void DangerRingsModule::LoadSettings(SettingsDoc& doc, ToolboxIni* legacy)
 void DangerRingsModule::DrawSettingsInternal()
 {
     const auto red = ImGui::ColorConvertU32ToFloat4(Colors::Red());
-    if (!GameWorldCompositor::IsActive())
-        ImGui::TextColored(red, GameWorldCompositor::HasFailed() ? "In-world compositor FAILED to install." : "In-world compositor: not installed yet.");
+    if (GameWorldCompositor::HasFailed())
+        ImGui::TextColored(red, "In-world compositor FAILED to install.");
+    else if (GameWorldCompositor::IsActive())
+        ImGui::TextColored(ImGui::ColorConvertU32ToFloat4(Colors::Green()), "In-world compositor active.");
+    else
+        ImGui::TextDisabled("In-world compositor: not installed yet.");
 
     ImGui::TextDisabled("Occlusion behind terrain follows the \"In-game rendering\" module's setting.");
     ImGui::DragFloat("Maximum render distance", &render_max_distance, 5.f, 10.f, 100000.f, "%.0f", ImGuiSliderFlags_AlwaysClamp);

--- a/GWToolboxdll/Modules/LootBeaconsModule.cpp
+++ b/GWToolboxdll/Modules/LootBeaconsModule.cpp
@@ -566,8 +566,12 @@ void LootBeaconsModule::SaveSettings(SettingsDoc& doc)
 void LootBeaconsModule::DrawSettingsInternal()
 {
     const auto red = ImGui::ColorConvertU32ToFloat4(Colors::Red());
-    if (!GameWorldCompositor::IsActive())
-        ImGui::TextColored(red, GameWorldCompositor::HasFailed() ? "In-world compositor FAILED to install." : "In-world compositor: not installed yet.");
+    if (GameWorldCompositor::HasFailed())
+        ImGui::TextColored(red, "In-world compositor FAILED to install.");
+    else if (GameWorldCompositor::IsActive())
+        ImGui::TextColored(ImGui::ColorConvertU32ToFloat4(Colors::Green()), "In-world compositor active.");
+    else
+        ImGui::TextDisabled("In-world compositor: not installed yet.");
 
     ImGui::TextUnformatted("Beacon by gold value");
     ImGui::ShowHelp("Any drop whose trader price (Kamadan, or presearing.com's price sheet while pre-searing) meets a threshold gets a beacon,\nregardless of rarity - catches ectos, gemstones, dyes and other white-rarity valuables.\nAn item that clears both thresholds uses the higher tier's colour.");

--- a/GWToolboxdll/Modules/RiverModule.cpp
+++ b/GWToolboxdll/Modules/RiverModule.cpp
@@ -513,8 +513,12 @@ void RiverModule::DrawSettings()
     const auto red = ImGui::ColorConvertU32ToFloat4(Colors::Red());
     const auto green = ImGui::ColorConvertU32ToFloat4(Colors::Green());
     ImGui::TextColored(red, "Warning: This is a beta feature.");
-    if (!GameWorldCompositor::IsActive())
-        ImGui::TextColored(red, GameWorldCompositor::HasFailed() ? "  in-world compositor FAILED to install." : "  in-world compositor: not installed yet.");
+    if (GameWorldCompositor::HasFailed())
+        ImGui::TextColored(red, "  in-world compositor FAILED to install.");
+    else if (GameWorldCompositor::IsActive())
+        ImGui::TextColored(green, "  in-world compositor active.");
+    else
+        ImGui::TextDisabled("  in-world compositor: not installed yet.");
 
     ImGui::TextUnformatted("Textures");
     ImGui::ShowHelp("The in-game lava textures (plus the water sheet). Pick one for a uniform surface, or several\nto mix them across the map in ~1024-unit patches. Nothing selected = nothing drawn.");

--- a/GWToolboxdll/Modules/SkillRangeRingsModule.cpp
+++ b/GWToolboxdll/Modules/SkillRangeRingsModule.cpp
@@ -280,8 +280,12 @@ void SkillRangeRingsModule::LoadSettings(SettingsDoc& doc, ToolboxIni* legacy)
 void SkillRangeRingsModule::DrawSettingsInternal()
 {
     const auto red = ImGui::ColorConvertU32ToFloat4(Colors::Red());
-    if (!GameWorldCompositor::IsActive())
-        ImGui::TextColored(red, GameWorldCompositor::HasFailed() ? "In-world compositor FAILED to install." : "In-world compositor: not installed yet.");
+    if (GameWorldCompositor::HasFailed())
+        ImGui::TextColored(red, "In-world compositor FAILED to install.");
+    else if (GameWorldCompositor::IsActive())
+        ImGui::TextColored(ImGui::ColorConvertU32ToFloat4(Colors::Green()), "In-world compositor active.");
+    else
+        ImGui::TextDisabled("In-world compositor: not installed yet.");
 
     ImGui::TextUnformatted("Hover any skill (skillbar, skills window...) to see its ranges on the ground.");
     if (ImGui::Checkbox("Show AoE ring at your current target", &aoe_at_target)) rings_dirty = true;

--- a/GWToolboxdll/Modules/WeatherModule.cpp
+++ b/GWToolboxdll/Modules/WeatherModule.cpp
@@ -1364,7 +1364,12 @@ void WeatherModule::DrawSettings()
 {
     const auto red = ImGui::ColorConvertU32ToFloat4(Colors::Red());
     const auto green = ImGui::ColorConvertU32ToFloat4(Colors::Green());
-    if (!GameWorldCompositor::IsActive()) ImGui::TextColored(red, GameWorldCompositor::HasFailed() ? "  in-world compositor FAILED to install." : "  in-world compositor: not installed yet.");
+    if (GameWorldCompositor::HasFailed())
+        ImGui::TextColored(red, "  in-world compositor FAILED to install.");
+    else if (GameWorldCompositor::IsActive())
+        ImGui::TextColored(green, "  in-world compositor active.");
+    else
+        ImGui::TextDisabled("  in-world compositor: not installed yet.");
 
     // Info: the current map's climate, and which condition(s) are currently being shown.
     if (const GW::AreaInfo* info = GW::Map::GetCurrentMapInfo())


### PR DESCRIPTION
## Summary\n- show a red compositor message only after hook installation fails\n- show active compositor status in green\n- show pending installation status as disabled text\n\n## Verification\n- \n- not built, per workspace instructions