### PR TITLE
Add system ping forwarding

### DIFF
--- a/Dependencies/GWCA/include/GWCA/Constants/UIMessages.h
+++ b/Dependencies/GWCA/include/GWCA/Constants/UIMessages.h
@@ -34,7 +34,13 @@ namespace GW {
 		enum class StringPreference : uint32_t;
 		enum class EnumPreference : uint32_t;
 		enum class UiProfileSetting : uint32_t;
-		struct CompassPoint;
+		
+        struct CompassPoint {
+			CompassPoint() : x(0), y(0) {}
+			CompassPoint(int _x, int _y) : x(_x), y(_y) {}
+			int x;
+			int y;
+		};
 
 		enum class UIMessage : uint32_t {
 			kNone = 0x0,                             // 0x0
@@ -290,7 +296,7 @@ namespace GW {
 			kDialogueMessageUpdated,                 // 0x1000009c
 			kLogout,                                 // 0x1000009d, wparam = { bool unknown, bool character_select }
 			kCompassDraw,                            // 0x1000009e, wparam = UIPacket::kCompassDraw*
-			kMessage_0x1000009f,                     // 0x1000009f
+			kCompassPing,                            // 0x1000009f, wParam = UIPacket::kCompassPing*
 			kMessage_0x100000a0,                     // 0x100000a0
 			kMessage_0x100000a1,                     // 0x100000a1
 			kOnScreenMessage,                        // 0x100000a2, wparam = wchar_** encoded_string
@@ -977,6 +983,11 @@ namespace GW {
 				uint32_t number_of_points;
 				CompassPoint* points;
 			};
+            struct kCompassPing {
+                CompassPoint point;
+                uint32_t color; // ARGB
+                bool muted;
+            };
 			struct kObjectiveAdd {
 				uint32_t objective_id;
 				wchar_t* name;

--- a/Dependencies/GWCA/include/GWCA/Managers/UIMgr.h
+++ b/Dependencies/GWCA/include/GWCA/Managers/UIMgr.h
@@ -47,13 +47,6 @@ namespace GW {
 
 		enum class UIMessage : uint32_t;
 
-		struct CompassPoint {
-			CompassPoint() : x(0), y(0) {}
-			CompassPoint(int _x, int _y) : x(_x), y(_y) {}
-			int x;
-			int y;
-		};
-
 		typedef void(__cdecl* DecodeStr_Callback)(void* param, const wchar_t* s);
 
 		struct ChatTemplate {

--- a/GWToolboxdll/Widgets/Minimap/Minimap.cpp
+++ b/GWToolboxdll/Widgets/Minimap/Minimap.cpp
@@ -836,6 +836,7 @@ void Minimap::Initialize()
                                           GW::UI::UIMessage::kChangeTarget,
                                           GW::UI::UIMessage::kSkillActivated,
                                           GW::UI::UIMessage::kCompassDraw,
+                                          GW::UI::UIMessage::kCompassPing,
                                           GW::UI::UIMessage::kEnableUIPositionOverlay,
                                           GW::UI::UIMessage::kDestroyUIPositionOverlay};
     for (const auto message_id : hook_messages) {

--- a/GWToolboxdll/Widgets/Minimap/PingsLinesRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/PingsLinesRenderer.cpp
@@ -28,7 +28,7 @@ void PingsLinesRenderer::RegisterSettings(ToolboxModule* module)
         SettingsRegistry::RegisterField(module, key, reinterpret_cast<Colors::SettingColor*>(color));
     };
     register_color("color_drawings", &color_drawings);
-    register_color("color_pings", &ping_circle.color);
+    register_color("color_pings", &color_pings);
     register_color("color_shadowstep_mark", &marker.color);
     register_color("color_shadowstep_line", &color_shadowstep_line);
     register_color("color_shadowstep_line_maxrange", &color_shadowstep_line_maxrange);
@@ -43,7 +43,7 @@ void PingsLinesRenderer::DrawSettings()
     ImGui::SmallConfirmButton("Restore Defaults", "Are you sure?", [&](bool result, void*) {
         if (result) {
             color_drawings = Colors::ARGB(0xFF, 0xFF, 0xFF, 0xFF);
-            ping_circle.color = Colors::ARGB(128, 255, 0, 0);
+            color_pings = Colors::ARGB(128, 255, 0, 0);
             marker.color = Colors::ARGB(200, 128, 0, 128);
             color_shadowstep_line = Colors::ARGB(48, 128, 0, 128);
             color_shadowstep_line_maxrange = Colors::ARGB(48, 128, 0, 128);
@@ -52,7 +52,7 @@ void PingsLinesRenderer::DrawSettings()
         }
         });
     changed |= Colors::DrawSettingHueWheel("Drawings", &color_drawings);
-    changed |= Colors::DrawSettingHueWheel("Pings", &ping_circle.color);
+    changed |= Colors::DrawSettingHueWheel("Pings", &color_pings);
     changed |= Colors::DrawSettingHueWheel("Shadow Step Marker", &marker.color);
     changed |= Colors::DrawSettingHueWheel("Shadow Step Line", &color_shadowstep_line);
     changed |= Colors::DrawSettingHueWheel("Shadow Step Line (Max range)", &color_shadowstep_line_maxrange);
@@ -94,62 +94,73 @@ void PingsLinesRenderer::P046Callback(const GW::Packet::StoC::AgentPinged* pak)
 }
 
 void PingsLinesRenderer::OnUIMessage(GW::HookStatus*, GW::UI::UIMessage message_id, void* wparam, void*) {
-    if (message_id != GW::UI::UIMessage::kCompassDraw)
-        return;
+    switch (message_id) {
+    case GW::UI::UIMessage::kCompassDraw: {
+        const auto packet = (GW::UI::UIPacket::kCompassDraw*)wparam;
 
-    const auto packet = (GW::UI::UIPacket::kCompassDraw*)wparam;
+        bool new_session;
 
-    bool new_session;
-
-    if (is_minimap_compass_draw) {
-        return;
-    }
-    if (drawings[packet->player_number].player == packet->player_number) {
-        new_session = drawings[packet->player_number].session != packet->session_id;
-        drawings[packet->player_number].session = packet->session_id;
-    }
-    else {
-        drawings[packet->player_number].player = packet->player_number;
-        drawings[packet->player_number].session = packet->session_id;
-        new_session = true;
-    }
-
-    if (new_session && packet->number_of_points == 1) {
-        pings.push_front(new TerrainPing(
-            packet->points[0].x * drawing_scale,
-            packet->points[0].y * drawing_scale));
-        return;
-    }
-
-    if (new_session) {
-        for (auto i = 0u; i < packet->number_of_points - 1; i++) {
-            DrawingLine l;
-            l.x1 = packet->points[i + 0].x * drawing_scale;
-            l.y1 = packet->points[i + 0].y * drawing_scale;
-            l.x2 = packet->points[i + 1].x * drawing_scale;
-            l.y2 = packet->points[i + 1].y * drawing_scale;
-            drawings[packet->player_number].lines.push_back(l);
-        }
-    }
-    else {
-        if (drawings[packet->player_number].lines.empty()) {
+        if (is_minimap_compass_draw) {
             return;
         }
-        for (auto i = 0u; i < packet->number_of_points; i++) {
-            DrawingLine l;
-            if (i == 0) {
-                l.x1 = drawings[packet->player_number].lines.back().x2;
-                l.y1 = drawings[packet->player_number].lines.back().y2;
-            }
-            else {
-                l.x1 = packet->points[i - 1].x * drawing_scale;
-                l.y1 = packet->points[i - 1].y * drawing_scale;
-            }
-            l.x2 = packet->points[i].x * drawing_scale;
-            l.y2 = packet->points[i].y * drawing_scale;
-            drawings[packet->player_number].lines.push_back(l);
+        if (drawings[packet->player_number].player == packet->player_number) {
+            new_session = drawings[packet->player_number].session != packet->session_id;
+            drawings[packet->player_number].session = packet->session_id;
         }
+        else {
+            drawings[packet->player_number].player = packet->player_number;
+            drawings[packet->player_number].session = packet->session_id;
+            new_session = true;
+        }
+
+        if (new_session && packet->number_of_points == 1) {
+            pings.push_front(new TerrainPing(
+                packet->points[0].x * drawing_scale,
+                packet->points[0].y * drawing_scale));
+            return;
+        }
+
+        if (new_session) {
+            for (auto i = 0u; i < packet->number_of_points - 1; i++) {
+                DrawingLine l;
+                l.x1 = packet->points[i + 0].x * drawing_scale;
+                l.y1 = packet->points[i + 0].y * drawing_scale;
+                l.x2 = packet->points[i + 1].x * drawing_scale;
+                l.y2 = packet->points[i + 1].y * drawing_scale;
+                drawings[packet->player_number].lines.push_back(l);
+            }
+        }
+        else {
+            if (drawings[packet->player_number].lines.empty()) {
+                return;
+            }
+            for (auto i = 0u; i < packet->number_of_points; i++) {
+                DrawingLine l;
+                if (i == 0) {
+                    l.x1 = drawings[packet->player_number].lines.back().x2;
+                    l.y1 = drawings[packet->player_number].lines.back().y2;
+                }
+                else {
+                    l.x1 = packet->points[i - 1].x * drawing_scale;
+                    l.y1 = packet->points[i - 1].y * drawing_scale;
+                }
+                l.x2 = packet->points[i].x * drawing_scale;
+                l.y2 = packet->points[i].y * drawing_scale;
+                drawings[packet->player_number].lines.push_back(l);
+            }
+        }
+    } break;
+    case GW::UI::UIMessage::kCompassPing: {
+        const auto packet = (GW::UI::UIPacket::kCompassPing*)wparam;
+
+        pings.push_front(new TerrainPing(
+            packet->point.x * drawing_scale,
+            packet->point.y * drawing_scale,
+            packet->color
+        ));
+    } break;
     }
+
 
 }
 
@@ -253,6 +264,13 @@ void PingsLinesRenderer::DrawPings(IDirect3DDevice9* device)
         }
         if (TIMER_DIFF(ping->start) > ping->duration) {
             continue;
+        }
+
+        if (ping->GetColor() != Colors::Empty()) {
+            ping_circle.color = Colors::Sub(ping->GetColor(), Colors::ARGB(128, 0, 0, 0));
+        }
+        else {
+            ping_circle.color = color_pings;
         }
 
         DirectX::XMMATRIX scale, world;

--- a/GWToolboxdll/Widgets/Minimap/PingsLinesRenderer.h
+++ b/GWToolboxdll/Widgets/Minimap/PingsLinesRenderer.h
@@ -43,16 +43,21 @@ class PingsLinesRenderer : public D3DVertexBuffer {
         [[nodiscard]] virtual float GetScale() const { return 1.0f; }
         [[nodiscard]] virtual bool ShowInner() const { return true; }
         [[nodiscard]] virtual DWORD GetAgentID() const { return 0; }
+        [[nodiscard]] virtual Color GetColor() const { return 0; }
     };
 
     struct TerrainPing : Ping {
         TerrainPing(const float _x, const float _y)
-            : x(_x), y(_y) { }
+            : TerrainPing(_x, _y, Colors::Empty()) { }
+        TerrainPing(const float _x, const float _y, const Color _color)
+            : x(_x), y(_y), color(_color) { }
 
         const float x, y;
+        const Color color;
         [[nodiscard]] float GetX() const override { return x; }
         [[nodiscard]] float GetY() const override { return y; }
         [[nodiscard]] float GetScale() const override { return 2.0f; }
+        [[nodiscard]] Color GetColor() const override { return color; }
     };
 
     struct AgentPing : Ping {
@@ -174,6 +179,7 @@ private:
     std::vector<GW::UI::CompassPoint> queue{};
 
     Color color_drawings = Colors::ARGB(0xFF, 0xFF, 0xFF, 0xFF);
+    Color color_pings = Colors::ARGB(128, 255, 0, 0);
     Color color_shadowstep_line = Colors::ARGB(155, 128, 0, 128);
     Color color_shadowstep_line_maxrange = Colors::ARGB(255, 255, 0, 128);
     float maxrange_interp_begin = 0.85f;


### PR DESCRIPTION
Currently pings that are system issued are completely invisible if using the Toolbox Minimap.

Some of these pings are quite useful to the player though, maybe more so with the newly added items.

Side by side comparison using the Scepter of Orr (blue) and Stalker's Rations (yellow)

<img width="728" height="375" alt="image" src="https://github.com/user-attachments/assets/c50f07f9-3620-454b-a692-25ce5137091e" />

TODOs:
- [x] Find a better way to manage opacity, using one of the following options
  - Add a configurable opacity slider
  - Render pings using the same texture the ingame compass uses
- [x] Render far away pings, as seen in the game compass on the left
- [ ] Option to also play the ping sound
