### PR TITLE
feat: add hero professions to hero builds

### DIFF
--- a/GWToolboxdll/Modules/Resources.cpp
+++ b/GWToolboxdll/Modules/Resources.cpp
@@ -52,6 +52,42 @@
 
 namespace {
 
+    using GW::Constants::HeroID;
+    using GW::Constants::Profession;
+
+    constexpr std::array hero_professions = {
+        std::pair{HeroID::Norgu, Profession::Mesmer},
+        std::pair{HeroID::Goren, Profession::Warrior},
+        std::pair{HeroID::Tahlkora, Profession::Monk},
+        std::pair{HeroID::MasterOfWhispers, Profession::Necromancer},
+        std::pair{HeroID::AcolyteJin, Profession::Ranger},
+        std::pair{HeroID::Koss, Profession::Warrior},
+        std::pair{HeroID::Dunkoro, Profession::Monk},
+        std::pair{HeroID::AcolyteSousuke, Profession::Elementalist},
+        std::pair{HeroID::Melonni, Profession::Dervish},
+        std::pair{HeroID::ZhedShadowhoof, Profession::Elementalist},
+        std::pair{HeroID::GeneralMorgahn, Profession::Paragon},
+        std::pair{HeroID::MargridTheSly, Profession::Ranger},
+        std::pair{HeroID::Zenmai, Profession::Assassin},
+        std::pair{HeroID::Olias, Profession::Necromancer},
+        std::pair{HeroID::MOX, Profession::Dervish},
+        std::pair{HeroID::KeiranThackeray, Profession::Paragon},
+        std::pair{HeroID::Jora, Profession::Warrior},
+        std::pair{HeroID::PyreFierceshot, Profession::Ranger},
+        std::pair{HeroID::Anton, Profession::Assassin},
+        std::pair{HeroID::Livia, Profession::Necromancer},
+        std::pair{HeroID::Hayda, Profession::Paragon},
+        std::pair{HeroID::Kahmu, Profession::Dervish},
+        std::pair{HeroID::Gwen, Profession::Mesmer},
+        std::pair{HeroID::Xandra, Profession::Ritualist},
+        std::pair{HeroID::Vekk, Profession::Elementalist},
+        std::pair{HeroID::Ogden, Profession::Monk},
+        std::pair{HeroID::Miku, Profession::Assassin},
+        std::pair{HeroID::ZeiRi, Profession::Ritualist},
+        std::pair{HeroID::Devona, Profession::Warrior},
+        std::pair{HeroID::GhostOfAlthea, Profession::Mesmer}
+    };
+
     DXGI_FORMAT ConvertD3D9FormatToDXGI(D3DFORMAT d3d9Format)
     {
         switch (d3d9Format) {
@@ -1204,6 +1240,19 @@ GuiUtils::EncString* Resources::GetHeroName(const GW::Constants::HeroID hero_id)
     const auto hero_data = GW::PartyMgr::GetHeroConstData(hero_id);
     hero_names[hero_id] = DecodeStringId(hero_data ? hero_data->name_id : 0x3);
     return hero_names[hero_id];
+}
+
+GW::Constants::Profession Resources::GetHeroProfession(const GW::Constants::HeroID hero_id)
+{
+    for (const auto& [id, profession] : hero_professions) {
+        if (id == hero_id) return profession;
+    }
+    if (hero_id < GW::Constants::HeroID::Merc1 || hero_id > GW::Constants::HeroID::Merc8
+        || GW::Map::GetInstanceType() != GW::Constants::InstanceType::Outpost || !GW::Map::GetIsMapLoaded()) {
+        return GW::Constants::Profession::None;
+    }
+    const auto* hero = GW::PartyMgr::GetHeroInfo(hero_id);
+    return hero ? hero->primary : GW::Constants::Profession::None;
 }
 
 GuiUtils::EncString* Resources::GetMapName(const GW::Constants::MapID map_id)

--- a/GWToolboxdll/Modules/Resources.h
+++ b/GWToolboxdll/Modules/Resources.h
@@ -117,6 +117,7 @@ public:
 
     // Guaranteed to return a pointer, but may not yet be decoded.
     static GuiUtils::EncString* GetHeroName(GW::Constants::HeroID hero_id);
+    static GW::Constants::Profession GetHeroProfession(GW::Constants::HeroID hero_id);
 
     // Guaranteed to return a pointer, but may not yet be decoded. Does the region->name lookup.
     static GuiUtils::EncString* GetRegionName(GW::Region region);

--- a/GWToolboxdll/Utils/TeamBuild.cpp
+++ b/GWToolboxdll/Utils/TeamBuild.cpp
@@ -26,6 +26,7 @@
 #include <Utils/GuiUtils.h>
 #include <Utils/TextUtils.h>
 #include <Windows/BuildsWindow.h>
+#include <Windows/HeroBuildsWindow.h>
 #include <Windows/PconsWindow.h>
 #include <Windows/RerollWindow.h>
 #include "TeamBuildEncoder.h"
@@ -262,12 +263,33 @@ namespace {
         HeroID::GhostOfAlthea
     };
 
-    // Returns hero IDs sorted by name; re-sorts each frame until all names are decoded.
+    bool HeroSortByName(const HeroID left, const HeroID right)
+    {
+        return _stricmp(Resources::GetHeroName(left)->string().c_str(), Resources::GetHeroName(right)->string().c_str()) < 0;
+    }
+
+    bool HeroSortByProfession(const HeroID left, const HeroID right)
+    {
+        const auto left_profession = Resources::GetHeroProfession(left);
+        const auto right_profession = Resources::GetHeroProfession(right);
+        if (left_profession == right_profession) return HeroSortByName(left, right);
+        if (left_profession == GW::Constants::Profession::None) return false;
+        if (right_profession == GW::Constants::Profession::None) return true;
+        return left_profession < right_profession;
+    }
+
     const std::vector<HeroID>& SortedHeroIDs()
     {
         static std::vector<HeroID> sorted;
         static bool is_sorted = false;
-        if (!is_sorted) {
+        static bool sort_by_profession = false;
+        static std::array<GW::Constants::Profession, 8> mercenary_professions{};
+        const bool should_sort_by_profession = HeroBuildsWindow::SortByProfession();
+        std::array<GW::Constants::Profession, 8> current_mercenary_professions{};
+        for (size_t i = 0; i < current_mercenary_professions.size(); ++i) {
+            current_mercenary_professions[i] = Resources::GetHeroProfession(static_cast<HeroID>(HeroID::Merc1 + i));
+        }
+        if (!is_sorted || sort_by_profession != should_sort_by_profession || mercenary_professions != current_mercenary_professions) {
             sorted.clear();
             for (const auto id : HeroIndexToID) {
                 if (id != HeroID::NoHero) sorted.push_back(id);
@@ -279,10 +301,10 @@ namespace {
                     break;
                 }
             }
-            std::ranges::sort(sorted, [](const HeroID a, const HeroID b) {
-                return _stricmp(Resources::GetHeroName(a)->string().c_str(), Resources::GetHeroName(b)->string().c_str()) < 0;
-            });
+            std::ranges::sort(sorted, should_sort_by_profession ? &HeroSortByProfession : &HeroSortByName);
             is_sorted = all_decoded;
+            sort_by_profession = should_sort_by_profession;
+            mercenary_professions = current_mercenary_professions;
         }
         return sorted;
     }
@@ -1080,18 +1102,23 @@ void TeamBuild::DrawHeroBuildsContent(bool& builds_modified, bool editable)
                 const auto hero_it = std::ranges::find(sorted_heroes, build.hero_id);
                 int combo_idx = hero_it != sorted_heroes.end() ? static_cast<int>(std::distance(sorted_heroes.begin(), hero_it)) : -1;
                 ImGui::PushItemWidth(name_width);
-                if (ImGui::MyCombo(
-                        "###heroid", "Choose Hero", &combo_idx,
-                        [](void*, const int idx, const char** out_text) -> bool {
-                            const auto& heroes = SortedHeroIDs();
-                            if (idx < 0 || idx >= static_cast<int>(heroes.size())) return false;
-                            *out_text = Resources::GetHeroName(heroes[idx])->string().c_str();
-                            return true;
-                        },
-                        nullptr, static_cast<int>(sorted_heroes.size())
-                    )) {
-                    build.hero_id = (combo_idx >= 0 && combo_idx < static_cast<int>(sorted_heroes.size())) ? sorted_heroes[combo_idx] : HeroID::NoHero;
-                    ResetEncodedCache();
+                const char* preview = combo_idx >= 0 ? HeroBuildsWindow::GetMercDisplayName(sorted_heroes[combo_idx]) : "Choose Hero";
+                if (ImGui::BeginCombo("###heroid", preview)) {
+                    const ImVec2 profession_icon_size{ImGui::GetFrameHeight() * 0.8f, ImGui::GetFrameHeight() * 0.8f};
+                    for (int i = 0; i < static_cast<int>(sorted_heroes.size()); ++i) {
+                        const auto hero_id = sorted_heroes[i];
+                        const bool is_selected = i == combo_idx;
+                        if (const auto profession = Resources::GetHeroProfession(hero_id); profession != GW::Constants::Profession::None) {
+                            ImGui::Image(*Resources::GetProfessionIcon(profession), profession_icon_size);
+                            ImGui::SameLine();
+                        }
+                        if (ImGui::Selectable(HeroBuildsWindow::GetMercDisplayName(hero_id), is_selected)) {
+                            build.hero_id = hero_id;
+                            ResetEncodedCache();
+                        }
+                        if (is_selected) ImGui::SetItemDefaultFocus();
+                    }
+                    ImGui::EndCombo();
                 }
                 ImGui::PopItemWidth();
 

--- a/GWToolboxdll/Windows/HeroBuildsWindow.cpp
+++ b/GWToolboxdll/Windows/HeroBuildsWindow.cpp
@@ -87,6 +87,9 @@ namespace {
     // Bottom-left sprite (col 0, row 1) = semi-transparent cross = "disabled" overlay
     IDirect3DTexture9** skill_toggle_sprite = nullptr;
 
+    std::array<std::string, 8> merc_display_names{};
+    std::wstring merc_display_names_player_name{};
+
     using GW::Constants::HeroID;
 
     constexpr std::array HeroIndexToID = {
@@ -260,6 +263,41 @@ GW::HeroPartyMember* HeroBuildsWindow::GetPartyHeroByID(const GW::Constants::Her
     }
     return nullptr;
 }
+
+void HeroBuildsWindow::RefreshMercDisplayNames()
+{
+    if (!GW::Map::GetIsMapLoaded() || GW::Map::GetInstanceType() != GW::Constants::InstanceType::Outpost) return;
+    const auto player_name = GW::AccountMgr::GetCurrentPlayerName();
+    if (!(player_name && *player_name) || merc_display_names_player_name == player_name) return;
+    const auto* world = GW::GetWorldContext();
+    if (!(world && world->hero_info.size())) return;
+
+    for (size_t i = 0; i < merc_display_names.size(); ++i) {
+        const auto hero_id = static_cast<GW::Constants::HeroID>(GW::Constants::HeroID::Merc1 + i);
+        merc_display_names[i] = Resources::GetHeroName(hero_id)->string();
+        for (const auto& hero : world->hero_info) {
+            if (hero.hero_id == hero_id && hero.name[0]) {
+                merc_display_names[i] = TextUtils::WStringToString(hero.name);
+                break;
+            }
+        }
+    }
+    merc_display_names_player_name = player_name;
+}
+
+const char* HeroBuildsWindow::GetMercDisplayName(const GW::Constants::HeroID hero_id)
+{
+    if (hero_id >= GW::Constants::HeroID::Merc1 && hero_id <= GW::Constants::HeroID::Merc8) {
+        const auto index = static_cast<size_t>(hero_id - GW::Constants::HeroID::Merc1);
+        if (!merc_display_names[index].empty()) return merc_display_names[index].c_str();
+    }
+    return Resources::GetHeroName(hero_id)->string().c_str();
+}
+
+bool HeroBuildsWindow::SortByProfession()
+{
+    return settings.sort_by_profession;
+}
 void HeroBuildsWindow::Initialize()
 {
     ToolboxWindow::Initialize();
@@ -284,6 +322,7 @@ void HeroBuildsWindow::Terminate()
 
 void HeroBuildsWindow::Draw(IDirect3DDevice9*)
 {
+    RefreshMercDisplayNames();
     if (visible) {
         ImGui::SetNextWindowCenter(ImGuiCond_FirstUseEver);
         ImGui::SetNextWindowSize(ImVec2(300, 250), ImGuiCond_FirstUseEver);
@@ -612,6 +651,7 @@ void HeroBuildsWindow::DrawSettingsInternal()
 {
     ImGui::Checkbox("Hide Hero Build windows when entering explorable area", &settings.hide_when_entering_explorable);
     ImGui::CheckboxWithHelp("Only show one teambuild window at a time", &settings.one_teambuild_at_a_time, "Close other teambuild windows when you open a new one");
+    ImGui::CheckboxWithHelp("Sort heroes by profession", &settings.sort_by_profession, "Group heroes by profession in the hero selector dropdown.");
 }
 
 void HeroBuildsWindow::SaveSettings(SettingsDoc& doc)

--- a/GWToolboxdll/Windows/HeroBuildsWindow.h
+++ b/GWToolboxdll/Windows/HeroBuildsWindow.h
@@ -37,6 +37,7 @@ public:
         bool hide_when_entering_explorable = false;
         bool one_teambuild_at_a_time = false;
         bool filter_by_profession = false;
+        bool sort_by_profession = false;
     };
 
     // On-disk schema of herobuilds.json
@@ -92,8 +93,11 @@ public:
     // Returns ptr to party member of this hero, optionally fills out out_hero_index to be the index of this hero for the player.
 
     static GW::HeroPartyMember* GetPartyHeroByID(const GW::Constants::HeroID hero_id, size_t* out_hero_index);
+    static const char* GetMercDisplayName(GW::Constants::HeroID hero_id);
+    static bool SortByProfession();
 
 private:
+    static void RefreshMercDisplayNames();
     TeamBuild* GetTeambuildByName(const std::string& argBuildname);
 
     // Encode a teambuild into a Daybreak party loadout base64 string (header=15, type=1, version=1).

--- a/site/src/content/docs/herobuilds.mdx
+++ b/site/src/content/docs/herobuilds.mdx
@@ -36,10 +36,13 @@ The Hero Builds window allows you to create and edit teambuilds for your heroes,
 
 - **Add Current Team**: You can quickly create a new teambuild based on your current team setup.
 
+- **Hero Selector**: Shows hero profession icons and uses each mercenary hero's in-game name when available.
+
 ## Settings
 
 - **Hide when entering explorable**: Automatically hides the Hero Builds window when entering an explorable area.
 - **Only show one teambuild at a time**: Closes other teambuild windows when you open a new one.
+- **Sort heroes by profession**: Groups heroes by profession in the hero selector dropdown.
 
 ## Chat Commands
 


### PR DESCRIPTION
Carries the functional Hero Builds additions from #2601 without formatter churn.

- Display static hero and loaded mercenary profession icons in the selector.
- Add optional profession sorting with live mercenary re-sorting.
- Use in-game mercenary names, refreshing only for a changed character in a loaded outpost.
- Document the selector and setting.