### PR TITLE
Restrict breakout buttons to icon modules

### DIFF
--- a/GWToolboxdll/ToolboxUIElement.cpp
+++ b/GWToolboxdll/ToolboxUIElement.cpp
@@ -552,24 +552,26 @@ void ToolboxUIElement::DrawSizeAndPositionSettings()
         ImGui::SetTooltip("This %s cannot be shown in the main window", TypeName());
     }
 
-    ImGui::CheckboxWithHelp("Show breakout button", &show_breakout_button, "Shows a small floating button on screen that toggles this window.\nRight-click the button to remove it.");
-    if (show_breakout_button) {
-        ImGui::Indent();
-        ImGui::Checkbox("Lock breakout button position", &lock_breakout_button);
-        if (!lock_breakout_button) {
-            char breakout_window_id[256];
-            snprintf(breakout_window_id, sizeof(breakout_window_id), "%s##breakout_btn", Name());
-            const auto breakout_window = ImGui::FindWindowByName(breakout_window_id);
-            ImVec2 _breakout_pos(0, 0);
-            if (breakout_window) {
-                _breakout_pos = breakout_window->Pos;
+    if (const auto icon = Icon(); icon && *icon) {
+        ImGui::CheckboxWithHelp("Show breakout button", &show_breakout_button, "Shows a small floating button on screen that toggles this window.\nRight-click the button to remove it.");
+        if (show_breakout_button) {
+            ImGui::Indent();
+            ImGui::Checkbox("Lock breakout button position", &lock_breakout_button);
+            if (!lock_breakout_button) {
+                char breakout_window_id[256];
+                snprintf(breakout_window_id, sizeof(breakout_window_id), "%s##breakout_btn", Name());
+                const auto breakout_window = ImGui::FindWindowByName(breakout_window_id);
+                ImVec2 _breakout_pos(0, 0);
+                if (breakout_window) {
+                    _breakout_pos = breakout_window->Pos;
+                }
+                if (ImGui::DragFloat2("Breakout position", reinterpret_cast<float*>(&_breakout_pos), 1.0f, 0.0f, 0.0f, "%.0f")) {
+                    ImGui::SetWindowPos(breakout_window_id, _breakout_pos);
+                }
+                ImGui::ShowHelp("You need to show the breakout button for this control to work");
             }
-            if (ImGui::DragFloat2("Breakout position", reinterpret_cast<float*>(&_breakout_pos), 1.0f, 0.0f, 0.0f, "%.0f")) {
-                ImGui::SetWindowPos(breakout_window_id, _breakout_pos);
-            }
-            ImGui::ShowHelp("You need to show the breakout button for this control to work");
+            ImGui::Unindent();
         }
-        ImGui::Unindent();
     }
 }
 
@@ -647,8 +649,8 @@ namespace {
 
 void ToolboxUIElement::DrawBreakoutButton(IDirect3DDevice9*)
 {
-    // Runs for every enabled element every frame, so bail before building the window id.
-    if (!show_breakout_button) {
+    const auto icon = Icon();
+    if (!show_breakout_button || !icon || !*icon) {
         breakout_button_rects.erase(this);
         return;
     }
@@ -668,7 +670,6 @@ void ToolboxUIElement::DrawBreakoutButton(IDirect3DDevice9*)
         breakout_pos_set = true;
     }
     else if (!breakout_pos_set) {
-        // Brand-new button: default to the middle of the screen, nudged so it doesn't land on another button.
         const float est = ImGui::GetFrameHeight() + 16.f;
         const ImVec2 pos = GetDefaultBreakoutPos(this, {est, est});
         ImGui::SetNextWindowPos(pos, ImGuiCond_Always);
@@ -693,27 +694,15 @@ void ToolboxUIElement::DrawBreakoutButton(IDirect3DDevice9*)
     if (ImGui::Begin(window_id, nullptr, flags)) {
         ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, {6.f, 4.f});
         const float btn_size = ImGui::GetTextLineHeight() + ImGui::GetStyle().FramePadding.y * 2.f;
-        const char* icon = Icon();
 
         const auto active_col = ImGui::GetStyle().Colors[ImGuiCol_ButtonActive];
         const auto inactive_col = ImVec4(0.15f, 0.15f, 0.15f, 0.8f);
         ImGui::PushStyleColor(ImGuiCol_Button, visible ? active_col : inactive_col);
 
-        bool clicked;
-        if (icon && *icon) {
-            clicked = ImGui::Button(icon, {btn_size, btn_size});
-        }
-        else {
-            char label[4] = {};
-            const auto* name = Name();
-            for (size_t i = 0; i < 2 && name[i]; i++) {
-                label[i] = name[i];
-            }
-            clicked = ImGui::Button(label, {btn_size, btn_size});
-        }
+        const bool clicked = ImGui::Button(icon, {btn_size, btn_size});
 
         ImGui::PopStyleColor();
-        ImGui::PopStyleVar(); // FramePadding
+        ImGui::PopStyleVar();
 
         if (clicked) {
             ToggleVisible();
@@ -737,8 +726,6 @@ void ToolboxUIElement::DrawBreakoutButton(IDirect3DDevice9*)
     ImGui::End();
     ImGui::PopStyleVar(2);
 
-    // Keep breakout_pos current so SaveSettings captures the right position even without a live ImGui context.
-    // Also record the live rect so other breakout buttons can avoid overlapping this one.
     if (const auto bw = ImGui::FindWindowByName(window_id)) {
         breakout_pos[0] = bw->Pos.x;
         breakout_pos[1] = bw->Pos.y;

--- a/site/src/content/docs/history.md
+++ b/site/src/content/docs/history.md
@@ -17,6 +17,7 @@ the latest version, go to the [Home Page](./) instead.
 * [Fix] Audio Settings no longer crashes Guild Wars when an audio handle has already been released.
 * [Fix] Game Settings: in-game name tag colour overrides can now be disabled so the colours configured in Guild Wars are used instead. The overrides are off by default.
 * [Minor] Mouse Settings: disabled the "Enable cursor fix" camera-glitch workaround because an August 2026 Guild Wars update changed lookaround speed. Cursor-size scaling remains available.
+* [Minor] Breakout buttons are now available only for modules with an icon, preventing ambiguous text-only buttons.
 
 ## Version 8.33
 * [New] Cartographer widget: helps you finish the Cartographer titles. It shades the parts of the world map you still have to uncover, and — using the game's own cartography rules — marks the exact squares you need to *stand in* to clear them, rather than just the fog itself. Reachability is derived from real pathing (travel portals count as walls, so it won't suggest a square you can only reach by zoning), the whole continent is shown rather than just your current map, and hovering a fog patch names the map you have to travel to in order to uncover it. Squares you can get close to but still can't uncover are drawn in grey.


### PR DESCRIPTION
Fixes #2600.

Instead of adding a text fallback to breakout buttons, only modules with an icon expose and render a breakout button. Existing saved breakout settings for iconless modules are ignored.