### PR TITLE
Avoid Armory search allocations

### DIFF
--- a/GWToolboxdll/Utils/TextUtils.cpp
+++ b/GWToolboxdll/Utils/TextUtils.cpp
@@ -10,18 +10,6 @@ bool wcseq(const wchar_t* a, const wchar_t* b)
 }
 
 namespace {
-    int portable_stricmp(const char* a, const char* b)
-    {
-        while (*a && *b) {
-            char c1 = static_cast<char>(std::tolower(static_cast<unsigned char>(*a)));
-            char c2 = static_cast<char>(std::tolower(static_cast<unsigned char>(*b)));
-            if (c1 != c2) return c1 - c2;
-            ++a;
-            ++b;
-        }
-        return static_cast<char>(std::tolower(static_cast<unsigned char>(*a))) - static_cast<char>(std::tolower(static_cast<unsigned char>(*b)));
-    }
-
     constexpr auto diacritics = std::to_array<const wchar_t*>({
         L"A\x0041\x0410\x24B6\xFF21\x00C0\x00C1\x00C2\x1EA6\x1EA4\x1EAA\x1EA8\x00C3\x0100\x0102\x1EB0\x1EAE\x1EB4\x1EB2\x0226\x01E0\x00C4\x01DE\x1EA2\x00C5\x01FA\x01CD\x0200\x0202\x1EA0\x1EAC\x1EB6\x1E00\x0104\x023A\x2C6F",
         L"B\x00DF\x0412\x0042\x24B7\xFF22\x1E02\x1E04\x1E06\x0243\x0182\x0181",
@@ -341,8 +329,19 @@ namespace TextUtils {
         return Encoding::WideToUtf8(str);
     }
 
-    // Makes sure the file name doesn't have chars that won't be allowed on disk
-    // https://docs.microsoft.com/en-gb/windows/win32/fileio/naming-a-file
+    int Stricmp(const std::string_view a, const std::string_view b)
+    {
+        const auto& locale = std::locale();
+        const auto length = std::min(a.size(), b.size());
+        for (size_t i = 0; i < length; i++) {
+            const auto lower_a = std::tolower(a[i], locale);
+            const auto lower_b = std::tolower(b[i], locale);
+            if (lower_a != lower_b) return lower_a < lower_b ? -1 : 1;
+        }
+        if (a.size() == b.size()) return 0;
+        return a.size() < b.size() ? -1 : 1;
+    }
+
     std::string SanitiseFilename(const std::string_view str)
     {
         const auto invalid_chars = "<>:\"/\\|?*";
@@ -353,15 +352,13 @@ namespace TextUtils {
             out += c;
         }
 
-        // Reserved device names (case-insensitive, with or without extension)
         static constexpr std::array reserved = {"CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"};
         for (const auto& name : reserved) {
-            if (portable_stricmp(out.c_str(), name) == 0) {
+            if (Stricmp(out, name) == 0) {
                 out += "_";
                 break;
             }
         }
-        // Trim trailing spaces and dots (Windows silently strips them)
         while (!out.empty() && (out.back() == ' ' || out.back() == '.'))
             out.pop_back();
 

--- a/GWToolboxdll/Utils/TextUtils.h
+++ b/GWToolboxdll/Utils/TextUtils.h
@@ -30,6 +30,7 @@ namespace TextUtils {
     std::wstring SanitiseFilename(std::wstring_view str);
     std::string PrintFilename(std::string path);
     std::wstring PrintFilename(std::wstring path);
+    int Stricmp(std::string_view a, std::string_view b);
     std::wstring Replace(const std::wstring_view subject, const std::wstring& pattern, const std::wstring& replacement);
     std::string Replace(const std::string_view subject, const std::string& pattern, const std::string& replacement);
 

--- a/GWToolboxdll/Windows/ArmoryWindow.cpp
+++ b/GWToolboxdll/Windows/ArmoryWindow.cpp
@@ -453,11 +453,6 @@ namespace GWArmory {
         return true;
     }
 
-    bool MatchesSearch(const Armor* armor)
-    {
-        return search_term.empty() || TextUtils::ToLower(armor->label).find(search_term) != std::string::npos;
-    }
-
     uint32_t CreateColor(GW::DyeColor col1, GW::DyeColor col2 = GW::DyeColor::None, GW::DyeColor col3 = GW::DyeColor::None, GW::DyeColor col4 = GW::DyeColor::None)
     {
         if (col1 == GW::DyeColor::None && col2 == GW::DyeColor::None && col3 == GW::DyeColor::None && col4 == GW::DyeColor::None) {
@@ -485,26 +480,25 @@ namespace GWArmory {
         if (!me) return nullptr;
         size_t armor_cnt = 0;
         const auto armors = GetArmorsPerProfession((GW::Constants::Profession)me->primary, &armor_cnt);
-        const auto lower_name = TextUtils::ToLower(item_name.data());
         for (size_t i = 0; i < armor_cnt && armors; i++) {
             const auto& armor = armors[i];
-            if (TextUtils::ToLower(armor.label) == lower_name) return &armor;
+            if (TextUtils::Stricmp(armor.label, item_name) == 0) return &armor;
         }
         for (size_t i = 0; i < _countof(costumes); i++) {
             const auto& armor = costumes[i];
-            if (TextUtils::ToLower(armor.label) == lower_name) return &armor;
+            if (TextUtils::Stricmp(armor.label, item_name) == 0) return &armor;
         }
         for (size_t i = 0; i < _countof(costume_heads); i++) {
             const auto& armor = costume_heads[i];
-            if (TextUtils::ToLower(armor.label) == lower_name) return &armor;
+            if (TextUtils::Stricmp(armor.label, item_name) == 0) return &armor;
         }
         for (size_t i = 0; i < _countof(weapons); i++) {
             const auto& weapon = weapons[i];
-            if (TextUtils::ToLower(weapon.label) == lower_name) return &weapon;
+            if (TextUtils::Stricmp(weapon.label, item_name) == 0) return &weapon;
         }
         for (size_t i = 0; i < _countof(unequipped_armors); i++) {
             const auto& armor = unequipped_armors[i];
-            if (TextUtils::ToLower(armor.label) == lower_name) return &armor;
+            if (TextUtils::Stricmp(armor.label, item_name) == 0) return &armor;
         }
         return nullptr;
     }
@@ -531,6 +525,8 @@ namespace GWArmory {
                 if (!IsEquipmentSlotSupportedByArmory(slot))
                     continue;
                 if (c != Campaign::BonusMissionPack && armor.campaign != c)
+                    continue;
+                if (!search_term.empty() && TextUtils::ToLower(armor.label).find(search_term) == std::string::npos)
                     continue;
                 ASSERT(slot != ItemSlot::Unknown);
                 const auto piece = &drawn_pieces[slot];
@@ -766,9 +762,7 @@ namespace GWArmory {
         const auto player_piece = &imgui_armor_pieces[slot];
         bool value_changed = false;
 
-        if (!search_term.empty() && std::ranges::none_of(state->pieces, [](const auto* piece) {
-            return MatchesSearch(piece);
-        })) {
+        if (!search_term.empty() && state->pieces.empty()) {
             ImGui::PopID();
             return false;
         }
@@ -866,9 +860,6 @@ namespace GWArmory {
 #else
         for (const auto& piece : state->pieces) {
 #endif
-            if (!MatchesSearch(piece)) {
-                continue;
-            }
             ImGui::PushID(piece->label);
 
             if (0 <= state->current_piece_index && static_cast<size_t>(state->current_piece_index) < state->pieces.size()) {
@@ -938,7 +929,7 @@ namespace GWArmory {
 
         std::vector<Armor*> type_pieces;
         for (auto* piece : state->pieces) {
-            if (piece->type == type && MatchesSearch(piece))
+            if (piece->type == type)
                 type_pieces.push_back(piece);
         }
         if (type_pieces.empty())
@@ -1445,6 +1436,7 @@ void ArmoryWindow::Draw(IDirect3DDevice9*)
         }
         if (ImGui::InputTextWithHint("##search", "Search armour and weapons...", search_buffer, sizeof(search_buffer))) {
             search_term = TextUtils::ToLower(search_buffer);
+            UpdateArmorsFilter();
         }
         const auto armor_order = {Headpiece, Chestpiece, Gloves, Leggings, Boots, CostumeHead, CostumeBody};
         for (const auto slot : armor_order) {


### PR DESCRIPTION
Adds portable `TextUtils::Stricmp` for case-insensitive exact comparisons and filters Armory search results when the query changes rather than during every render frame.