### PR TITLE
fix(damage): restore width resizing

### DIFF
--- a/GWToolboxdll/ToolboxUIElement.cpp
+++ b/GWToolboxdll/ToolboxUIElement.cpp
@@ -322,6 +322,7 @@ void ToolboxUIElement::DrawSizeAndPositionSettings()
 {
     const bool is_mobile = ToolboxSettings::is_in_mobile_mode;
 
+    // Auto-select tab based on current mode on first open
     if (settings_active_tab < 0) {
         settings_active_tab = is_mobile ? 1 : 0;
     }
@@ -357,7 +358,7 @@ void ToolboxUIElement::DrawSizeAndPositionSettings()
     char need_show_buf[128];
     snprintf(need_show_buf, sizeof(need_show_buf), "You need to show the %s for this control to work", TypeName());
 
-    if (is_movable) {
+    {
         static const char* frame_label_options[_countof(available_frame_labels) + 1];
         for (size_t i = 0; i < _countof(available_frame_labels); i++) {
             frame_label_options[i] = available_frame_labels[i].label;
@@ -373,7 +374,7 @@ void ToolboxUIElement::DrawSizeAndPositionSettings()
         }
         const char* preview = current_idx >= 0 ? frame_label_options[current_idx] : "None";
 
-        const bool snap_disabled = lm;
+        const bool snap_disabled = !is_movable || lm;
         ImGui::BeginDisabled(snap_disabled);
         const std::string prev_snap = snap;
         if (ImGui::BeginCombo("Snap to Frame", preview)) {
@@ -392,31 +393,49 @@ void ToolboxUIElement::DrawSizeAndPositionSettings()
             ImGui::EndCombo();
         }
         ImGui::EndDisabled();
+        // When snap target changes to a new frame, schedule snap_offset initialization from current window position
         if (snap != prev_snap && !snap.empty()) {
             needs_init_ref = true;
             snap_off[0] = 0.f;
             snap_off[1] = 0.f;
         }
         if (snap_disabled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
-            ImGui::SetTooltip("Uncheck 'Lock Position' to enable snap-to-frame");
+            if (!is_movable) {
+                ImGui::SetTooltip("This %s cannot be moved", TypeName());
+            }
+            else {
+                ImGui::SetTooltip("Uncheck 'Lock Position' to enable snap-to-frame");
+            }
         }
         else {
             ImGui::ShowHelp(need_show_buf);
         }
+    }
 
-        const bool pos_disabled = lm;
+    // Position / Snap Offset — mutually exclusive
+    {
+        const bool pos_disabled = !is_movable || lm;
         ImGui::BeginDisabled(pos_disabled);
         if (!snap.empty()) {
             if (ImGui::DragFloat2("Snap Offset", snap_off, 1.0f, 0.0f, 0.0f, "%.0f")) {
-                needs_init_ref = false;
+                needs_init_ref = false; // user explicitly set offset; cancel pending init
             }
         }
-        else if (ImGui::DragFloat2("Position", cur_pos, 1.0f, 0.0f, 0.0f, "%.0f") && window) {
-            ImGui::SetWindowPos(window, {cur_pos[0], cur_pos[1]});
+        else {
+            if (ImGui::DragFloat2("Position", cur_pos, 1.0f, 0.0f, 0.0f, "%.0f")) {
+                if (window) {
+                    ImGui::SetWindowPos(window, {cur_pos[0], cur_pos[1]});
+                }
+            }
         }
         ImGui::EndDisabled();
         if (pos_disabled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
-            ImGui::SetTooltip("Uncheck 'Lock Position' to adjust position");
+            if (!is_movable) {
+                ImGui::SetTooltip("This %s cannot be moved", TypeName());
+            }
+            else {
+                ImGui::SetTooltip("Uncheck 'Lock Position' to adjust position");
+            }
         }
         else if (!snap.empty()) {
             ImGui::ShowHelp("Pixel offset from the snapped GW frame's top-left corner");
@@ -426,8 +445,8 @@ void ToolboxUIElement::DrawSizeAndPositionSettings()
         }
     }
 
-    if (is_resizable) {
-        const bool size_disabled = ls || as_;
+    {
+        const bool size_disabled = !is_resizable || ls || as_;
         ImGui::BeginDisabled(size_disabled);
         if (ImGui::DragFloat2("Size", cur_size, 1.0f, 0.0f, 0.0f, "%.0f")) {
             if (window) {
@@ -436,7 +455,10 @@ void ToolboxUIElement::DrawSizeAndPositionSettings()
         }
         ImGui::EndDisabled();
         if (size_disabled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
-            if (as_) {
+            if (!is_resizable) {
+                ImGui::SetTooltip("This %s cannot be resized", TypeName());
+            }
+            else if (as_) {
                 ImGui::SetTooltip("Uncheck 'Auto Size' to adjust size");
             }
             else {
@@ -448,39 +470,58 @@ void ToolboxUIElement::DrawSizeAndPositionSettings()
         }
     }
 
-    if (is_movable || is_resizable) {
-        ImGui::StartSpacedElements(180.f);
-        if (is_movable) {
-            ImGui::NextSpacedElement();
-            ImGui::Checkbox("Lock Position", &lm);
-        }
-        if (is_resizable) {
-            ImGui::NextSpacedElement();
-            ImGui::Checkbox("Lock Size", &ls);
-            ImGui::NextSpacedElement();
-            ImGui::Checkbox("Auto Size", &as_);
-        }
+    ImGui::StartSpacedElements(180.f);
+
+    ImGui::NextSpacedElement();
+    ImGui::BeginDisabled(!is_movable);
+    ImGui::Checkbox("Lock Position", &lm);
+    ImGui::EndDisabled();
+    if (!is_movable && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+        ImGui::SetTooltip("This %s cannot be moved", TypeName());
     }
 
-    if (is_resizable && has_titlebar) {
-        if (ImGui::Checkbox("Auto-resize on collapse/expand", &auto_resize_on_collapse)) {
-            collapse_size_initialized = false;
-        }
+    ImGui::NextSpacedElement();
+    ImGui::BeginDisabled(!is_resizable);
+    ImGui::Checkbox("Lock Size", &ls);
+    ImGui::EndDisabled();
+    if (!is_resizable && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+        ImGui::SetTooltip("This %s cannot be resized", TypeName());
+    }
+
+    ImGui::NextSpacedElement();
+    ImGui::BeginDisabled(!is_resizable);
+    ImGui::Checkbox("Auto Size", &as_);
+    ImGui::EndDisabled();
+    if (!is_resizable && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+        ImGui::SetTooltip("This %s cannot be resized", TypeName());
+    }
+
+    // Auto-resize on collapse/expand (only relevant when the window has a title bar)
+    ImGui::BeginDisabled(!has_titlebar);
+    if (ImGui::Checkbox("Auto-resize on collapse/expand", &auto_resize_on_collapse)) {
+        collapse_size_initialized = false;
+    }
+    ImGui::EndDisabled();
+    if (!has_titlebar && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+        ImGui::SetTooltip("This %s has no titlebar", TypeName());
+    }
+    else {
         ImGui::ShowHelp("Automatically resize this window when it is collapsed or expanded");
-        ImGui::Indent();
-        ImGui::BeginDisabled(!auto_resize_on_collapse);
-        if (ImGui::DragFloat2("Collapsed size", collapsed_size.data(), 1.f, 0.f, 0.f, "%.0f")) {
-            collapse_size_initialized = false;
-        }
-        ImGui::ShowHelp("Width and height when the title bar is collapsed; 0 = keep current");
-        if (ImGui::DragFloat2("Expanded size", expanded_size.data(), 1.f, 0.f, 0.f, "%.0f")) {
-            collapse_size_initialized = false;
-        }
-        ImGui::ShowHelp("Width and height when the window is expanded; 0 = keep current");
-        ImGui::EndDisabled();
-        ImGui::Unindent();
     }
+    ImGui::Indent();
+    ImGui::BeginDisabled(!auto_resize_on_collapse || !has_titlebar);
+    if (ImGui::DragFloat2("Collapsed size", collapsed_size.data(), 1.f, 0.f, 0.f, "%.0f")) {
+        collapse_size_initialized = false;
+    }
+    ImGui::ShowHelp("Width and height when the title bar is collapsed; 0 = keep current");
+    if (ImGui::DragFloat2("Expanded size", expanded_size.data(), 1.f, 0.f, 0.f, "%.0f")) {
+        collapse_size_initialized = false;
+    }
+    ImGui::ShowHelp("Width and height when the window is expanded; 0 = keep current");
+    ImGui::EndDisabled();
+    ImGui::Unindent();
 
+    // Shared settings (not per-mode) drawn below the two-column layout
     ImGui::StartSpacedElements(180.f);
 
     ImGui::NextSpacedElement();

--- a/GWToolboxdll/ToolboxUIElement.cpp
+++ b/GWToolboxdll/ToolboxUIElement.cpp
@@ -322,7 +322,6 @@ void ToolboxUIElement::DrawSizeAndPositionSettings()
 {
     const bool is_mobile = ToolboxSettings::is_in_mobile_mode;
 
-    // Auto-select tab based on current mode on first open
     if (settings_active_tab < 0) {
         settings_active_tab = is_mobile ? 1 : 0;
     }
@@ -358,7 +357,7 @@ void ToolboxUIElement::DrawSizeAndPositionSettings()
     char need_show_buf[128];
     snprintf(need_show_buf, sizeof(need_show_buf), "You need to show the %s for this control to work", TypeName());
 
-    {
+    if (is_movable) {
         static const char* frame_label_options[_countof(available_frame_labels) + 1];
         for (size_t i = 0; i < _countof(available_frame_labels); i++) {
             frame_label_options[i] = available_frame_labels[i].label;
@@ -374,7 +373,7 @@ void ToolboxUIElement::DrawSizeAndPositionSettings()
         }
         const char* preview = current_idx >= 0 ? frame_label_options[current_idx] : "None";
 
-        const bool snap_disabled = !is_movable || lm;
+        const bool snap_disabled = lm;
         ImGui::BeginDisabled(snap_disabled);
         const std::string prev_snap = snap;
         if (ImGui::BeginCombo("Snap to Frame", preview)) {
@@ -393,49 +392,31 @@ void ToolboxUIElement::DrawSizeAndPositionSettings()
             ImGui::EndCombo();
         }
         ImGui::EndDisabled();
-        // When snap target changes to a new frame, schedule snap_offset initialization from current window position
         if (snap != prev_snap && !snap.empty()) {
             needs_init_ref = true;
             snap_off[0] = 0.f;
             snap_off[1] = 0.f;
         }
         if (snap_disabled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
-            if (!is_movable) {
-                ImGui::SetTooltip("This %s cannot be moved", TypeName());
-            }
-            else {
-                ImGui::SetTooltip("Uncheck 'Lock Position' to enable snap-to-frame");
-            }
+            ImGui::SetTooltip("Uncheck 'Lock Position' to enable snap-to-frame");
         }
         else {
             ImGui::ShowHelp(need_show_buf);
         }
-    }
 
-    // Position / Snap Offset — mutually exclusive
-    {
-        const bool pos_disabled = !is_movable || lm;
+        const bool pos_disabled = lm;
         ImGui::BeginDisabled(pos_disabled);
         if (!snap.empty()) {
             if (ImGui::DragFloat2("Snap Offset", snap_off, 1.0f, 0.0f, 0.0f, "%.0f")) {
-                needs_init_ref = false; // user explicitly set offset; cancel pending init
+                needs_init_ref = false;
             }
         }
-        else {
-            if (ImGui::DragFloat2("Position", cur_pos, 1.0f, 0.0f, 0.0f, "%.0f")) {
-                if (window) {
-                    ImGui::SetWindowPos(window, {cur_pos[0], cur_pos[1]});
-                }
-            }
+        else if (ImGui::DragFloat2("Position", cur_pos, 1.0f, 0.0f, 0.0f, "%.0f") && window) {
+            ImGui::SetWindowPos(window, {cur_pos[0], cur_pos[1]});
         }
         ImGui::EndDisabled();
         if (pos_disabled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
-            if (!is_movable) {
-                ImGui::SetTooltip("This %s cannot be moved", TypeName());
-            }
-            else {
-                ImGui::SetTooltip("Uncheck 'Lock Position' to adjust position");
-            }
+            ImGui::SetTooltip("Uncheck 'Lock Position' to adjust position");
         }
         else if (!snap.empty()) {
             ImGui::ShowHelp("Pixel offset from the snapped GW frame's top-left corner");
@@ -445,8 +426,8 @@ void ToolboxUIElement::DrawSizeAndPositionSettings()
         }
     }
 
-    {
-        const bool size_disabled = !is_resizable || ls || as_;
+    if (is_resizable) {
+        const bool size_disabled = ls || as_;
         ImGui::BeginDisabled(size_disabled);
         if (ImGui::DragFloat2("Size", cur_size, 1.0f, 0.0f, 0.0f, "%.0f")) {
             if (window) {
@@ -455,10 +436,7 @@ void ToolboxUIElement::DrawSizeAndPositionSettings()
         }
         ImGui::EndDisabled();
         if (size_disabled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
-            if (!is_resizable) {
-                ImGui::SetTooltip("This %s cannot be resized", TypeName());
-            }
-            else if (as_) {
+            if (as_) {
                 ImGui::SetTooltip("Uncheck 'Auto Size' to adjust size");
             }
             else {
@@ -470,58 +448,39 @@ void ToolboxUIElement::DrawSizeAndPositionSettings()
         }
     }
 
-    ImGui::StartSpacedElements(180.f);
-
-    ImGui::NextSpacedElement();
-    ImGui::BeginDisabled(!is_movable);
-    ImGui::Checkbox("Lock Position", &lm);
-    ImGui::EndDisabled();
-    if (!is_movable && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
-        ImGui::SetTooltip("This %s cannot be moved", TypeName());
+    if (is_movable || is_resizable) {
+        ImGui::StartSpacedElements(180.f);
+        if (is_movable) {
+            ImGui::NextSpacedElement();
+            ImGui::Checkbox("Lock Position", &lm);
+        }
+        if (is_resizable) {
+            ImGui::NextSpacedElement();
+            ImGui::Checkbox("Lock Size", &ls);
+            ImGui::NextSpacedElement();
+            ImGui::Checkbox("Auto Size", &as_);
+        }
     }
 
-    ImGui::NextSpacedElement();
-    ImGui::BeginDisabled(!is_resizable);
-    ImGui::Checkbox("Lock Size", &ls);
-    ImGui::EndDisabled();
-    if (!is_resizable && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
-        ImGui::SetTooltip("This %s cannot be resized", TypeName());
-    }
-
-    ImGui::NextSpacedElement();
-    ImGui::BeginDisabled(!is_resizable);
-    ImGui::Checkbox("Auto Size", &as_);
-    ImGui::EndDisabled();
-    if (!is_resizable && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
-        ImGui::SetTooltip("This %s cannot be resized", TypeName());
-    }
-
-    // Auto-resize on collapse/expand (only relevant when the window has a title bar)
-    ImGui::BeginDisabled(!has_titlebar);
-    if (ImGui::Checkbox("Auto-resize on collapse/expand", &auto_resize_on_collapse)) {
-        collapse_size_initialized = false;
-    }
-    ImGui::EndDisabled();
-    if (!has_titlebar && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
-        ImGui::SetTooltip("This %s has no titlebar", TypeName());
-    }
-    else {
+    if (is_resizable && has_titlebar) {
+        if (ImGui::Checkbox("Auto-resize on collapse/expand", &auto_resize_on_collapse)) {
+            collapse_size_initialized = false;
+        }
         ImGui::ShowHelp("Automatically resize this window when it is collapsed or expanded");
+        ImGui::Indent();
+        ImGui::BeginDisabled(!auto_resize_on_collapse);
+        if (ImGui::DragFloat2("Collapsed size", collapsed_size.data(), 1.f, 0.f, 0.f, "%.0f")) {
+            collapse_size_initialized = false;
+        }
+        ImGui::ShowHelp("Width and height when the title bar is collapsed; 0 = keep current");
+        if (ImGui::DragFloat2("Expanded size", expanded_size.data(), 1.f, 0.f, 0.f, "%.0f")) {
+            collapse_size_initialized = false;
+        }
+        ImGui::ShowHelp("Width and height when the window is expanded; 0 = keep current");
+        ImGui::EndDisabled();
+        ImGui::Unindent();
     }
-    ImGui::Indent();
-    ImGui::BeginDisabled(!auto_resize_on_collapse || !has_titlebar);
-    if (ImGui::DragFloat2("Collapsed size", collapsed_size.data(), 1.f, 0.f, 0.f, "%.0f")) {
-        collapse_size_initialized = false;
-    }
-    ImGui::ShowHelp("Width and height when the title bar is collapsed; 0 = keep current");
-    if (ImGui::DragFloat2("Expanded size", expanded_size.data(), 1.f, 0.f, 0.f, "%.0f")) {
-        collapse_size_initialized = false;
-    }
-    ImGui::ShowHelp("Width and height when the window is expanded; 0 = keep current");
-    ImGui::EndDisabled();
-    ImGui::Unindent();
 
-    // Shared settings (not per-mode) drawn below the two-column layout
     ImGui::StartSpacedElements(180.f);
 
     ImGui::NextSpacedElement();

--- a/GWToolboxdll/Widgets/PartyDamage.cpp
+++ b/GWToolboxdll/Widgets/PartyDamage.cpp
@@ -541,6 +541,7 @@ PartyDamage::PlayerDamage* PartyDamage::GetDamageByAgentId(uint32_t agent_id, ui
 void PartyDamage::Initialize()
 {
     SnapsToPartyWindow::Initialize();
+    is_resizable = true;
     SettingsRegistry::Register(this, settings);
 
     total = 0;
@@ -568,6 +569,11 @@ void PartyDamage::Terminate()
     GW::Chat::DeleteCommand(&ChatCmd_HookEntry);
 
     party_names_by_index.clear();
+}
+
+ImGuiWindowFlags PartyDamage::GetWinFlags(const ImGuiWindowFlags flags, const bool noinput_if_frozen) const
+{
+    return ToolboxWidget::GetWinFlags(flags, noinput_if_frozen) | ImGuiWindowFlags_NoMove;
 }
 
 void PartyDamage::Update(const float)
@@ -654,7 +660,6 @@ void PartyDamage::Draw(IDirect3DDevice9*)
         return;
     }
 
-    // @Cleanup: Only call when the party window has been moved or updated
     const clock_t combat_time = GetEffectiveCombatTime();
 
     if (party_agent_ids_by_index.empty() || !RecalculatePartyPositions()) {
@@ -682,7 +687,11 @@ void PartyDamage::Draw(IDirect3DDevice9*)
     const Color healing_from = Colors::Add(settings.color_healing, Colors::ARGB(0, 20, 20, 20));
     const Color healing_to = Colors::Sub(settings.color_healing, Colors::ARGB(0, 20, 20, 20));
 
-    const auto width = settings.width;
+    const auto minimum_width = settings.width;
+    auto width = minimum_width;
+    if (const auto window = ImGui::FindWindowByName(Name())) {
+        width = std::max(width, window->SizeFull.x);
+    }
     const auto user_offset_x = abs(static_cast<float>(settings.user_offset));
     float window_x = .0f;
     if (settings.overlay_party_window) {
@@ -694,22 +703,23 @@ void PartyDamage::Draw(IDirect3DDevice9*)
     else {
         window_x = party_health_bars_position.top_left.x - user_offset_x - width;
         if (window_x < 0 || settings.user_offset < 0) {
-            // Right placement
             window_x = party_health_bars_position.bottom_right.x + user_offset_x;
         }
     }
 
     const float cond_h = settings.show_condition_dps ? ImGui::GetTextLineHeight() + 6.0f : 0.0f;
 
-    // Add a window to capture mouse clicks.
     ImGui::SetNextWindowPos({window_x, party_health_bars_position.top_left.y - cond_h});
-    ImGui::SetNextWindowSize({width, party_health_bars_position.bottom_right.y - party_health_bars_position.top_left.y + cond_h});
+    const float height = party_health_bars_position.bottom_right.y - party_health_bars_position.top_left.y + cond_h;
+    ImGui::SetNextWindowSizeConstraints({minimum_width, height}, {FLT_MAX, height});
     ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 0);
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
     ImGui::PushStyleVar(ImGuiStyleVar_WindowMinSize, ImVec2(10.0f, 10.0f));
     ImGui::PushStyleColor(ImGuiCol_WindowBg, 0);
     if (ImGui::Begin(Name(), nullptr, GetWinFlags())) {
         const auto draw_list = ImGui::GetWindowDrawList();
+        window_x = ImGui::GetWindowPos().x;
+        width = ImGui::GetWindowWidth();
         constexpr size_t buffer_size = 16;
         char buffer[buffer_size];
 
@@ -730,7 +740,7 @@ void PartyDamage::Draw(IDirect3DDevice9*)
                 ImGui::Text("%d/s", dps);
                 ImGui::SameLine();
             }
-            ImGui::NewLine(); // flush last SameLine
+            ImGui::NewLine();
         }
 
         for (auto& [agent_id, party_slot] : party_indeces_by_agent_id) {
@@ -899,7 +909,7 @@ void PartyDamage::DrawSettingsInternal()
     ImGui::PopItemWidth();
     ImGui::ShowHelp("Distance away from the party window");
 
-    ImGui::DragFloat("Width", &settings.width, 1.0f, 50.0f, 0.0f, "%.0f");
+    ImGui::DragFloat("Minimum width", &settings.width, 1.0f, 50.0f, 0.0f, "%.0f");
     if (settings.width <= 0) {
         settings.width = 1.0f;
     }

--- a/GWToolboxdll/Widgets/PartyDamage.h
+++ b/GWToolboxdll/Widgets/PartyDamage.h
@@ -69,6 +69,8 @@ public:
     void Initialize() override;
     void Terminate() override;
 
+    ImGuiWindowFlags GetWinFlags(ImGuiWindowFlags flags = 0, bool noinput_if_frozen = true) const override;
+
     void Draw(IDirect3DDevice9* pDevice) override;
 
     void Update(float delta) override;


### PR DESCRIPTION
## Summary\n- retain the existing shared behavior that hides unavailable move and resize controls\n- allow only the Damage widget to be horizontally resized while retaining party anchoring\n- use the configured Damage width as a minimum instead of resetting its width every draw\n\n## Validation\n- git diff --check\n- not run: build or tests (workspace policy)\n- not run: clang-format (not installed)