### PR TITLE
More minimap ping improvements

### DIFF
--- a/GWToolboxdll/D3DContainers.h
+++ b/GWToolboxdll/D3DContainers.h
@@ -8,6 +8,7 @@ struct IDirect3DVertexBuffer9;
 typedef unsigned long DWORD;
 
 #define D3DFVF_CUSTOMVERTEX D3DFVF_XYZ | D3DFVF_DIFFUSE
+#define D3DFVF_TEXTUREDVERTEX D3DFVF_XYZ | D3DFVF_DIFFUSE | D3DFVF_TEX1
 
 typedef GW::Vec2f D3DVec2f;
 
@@ -19,6 +20,15 @@ struct D3DVertex {
     D3DVertex() = default;
     D3DVertex(float x, float y, float z, DWORD color);
     D3DVertex(float x, float y, DWORD color);
+};
+
+struct D3DVertexTextured {
+    float x;
+    float y;
+    float z;
+    DWORD color;
+    float u;
+    float v;
 };
 
 struct D3DTriangle {

--- a/GWToolboxdll/Widgets/Minimap/PingsLinesRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/PingsLinesRenderer.cpp
@@ -290,7 +290,7 @@ void PingsLinesRenderer::DrawPings(IDirect3DDevice9* device)
                 const GW::Agent* me = GW::Agents::GetObservingAgent();
 
                 if (me) {
-                    const auto center = me->pos - context.translation / context.zoom_scale;
+                    const auto center = me->pos - GW::Rotate(context.translation, context.rotation - DirectX::XM_PIDIV2) / context.zoom_scale;
 
                     float dx = px - center.x;
                     float dy = py - center.y;

--- a/GWToolboxdll/Widgets/Minimap/PingsLinesRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/PingsLinesRenderer.cpp
@@ -283,42 +283,40 @@ void PingsLinesRenderer::DrawPings(IDirect3DDevice9* device)
             if (inner_texture_ptr == nullptr) {
                 inner_texture_ptr = GwDatModule::LoadGreyscaleTextureFromFileId(PING_INNER_FILE_ID);
             }
+            
+            const auto context = Minimap::GetRenderContext();
+            const GW::Agent* me = inner_texture_ptr ? GW::Agents::GetObservingAgent() : nullptr;
 
-            if(inner_texture_ptr) {
-                const auto context = Minimap::GetRenderContext();
-                const GW::Agent* me = GW::Agents::GetObservingAgent();
+            if (me) {
+                const float rotation = context.rotation - DirectX::XM_PIDIV2;
+                const auto center = me->pos - GW::Rotate(context.translation, rotation) / context.zoom_scale;
 
-                if (me) {
-                    const float rotation = context.rotation - DirectX::XM_PIDIV2;
-                    const auto center = me->pos - GW::Rotate(context.translation, rotation) / context.zoom_scale;
+                const auto p = GW::Vec2f(px, py);
+                const auto delta = p - center;
 
-                    const auto p = GW::Vec2f(px, py);
-                    const auto delta = p - center;
+                const float max_distance = (GW::Constants::Range::Compass - drawing_scale) / context.zoom_scale;
+                const float distance_sq = GW::GetSquareDistance(p, center);
 
-                    const float max_distance = (GW::Constants::Range::Compass - drawing_scale) / context.zoom_scale;
-                    const float distance_sq = GW::GetSquareDistance(p, center);
+                auto inner_translate = translate;
 
-                    auto inner_translate = translate;
+                if (distance_sq > max_distance * max_distance) {
+                    const float distance = GW::GetDistance(p, center);
+                    const float factor = max_distance / distance;
+                    const auto clamped = delta * factor;
 
-                    if (distance_sq > max_distance * max_distance) {
-                        const float distance = GW::GetDistance(p, center);
-                        const float factor = max_distance / distance;
-                        const auto clamped = delta * factor;
-
-                        inner_translate = DirectX::XMMatrixTranslation(
-                            center.x + clamped.x,
-                            center.y + clamped.y,
-                            0.0f
-                        );
-                    }
-
-                    scale = DirectX::XMMatrixScaling(drawing_scale * 2, drawing_scale * 2, 1.0f);
-                    world = scale * inner_translate;
-                    device->SetTransform(D3DTS_WORLD, reinterpret_cast<const D3DMATRIX*>(&world));
-
-                    ping_circle.texture = *inner_texture_ptr;
-                    ping_circle.Render(device);
+                    inner_translate = DirectX::XMMatrixTranslation(
+                        center.x + clamped.x,
+                        center.y + clamped.y,
+                        0.0f
+                    );
                 }
+
+                scale = DirectX::XMMatrixScaling(drawing_scale * 2, drawing_scale * 2, 1.0f);
+                world = scale * inner_translate;
+                device->SetTransform(D3DTS_WORLD, reinterpret_cast<const D3DMATRIX*>(&world));
+
+                ping_circle.texture = *inner_texture_ptr;
+                ping_circle.Render(device);
             }
         }
 

--- a/GWToolboxdll/Widgets/Minimap/PingsLinesRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/PingsLinesRenderer.cpp
@@ -297,8 +297,16 @@ void PingsLinesRenderer::DrawPings(IDirect3DDevice9* device)
                     float dx = px - center.x;
                     float dy = py - center.y;
 
+                    const float angle = DirectX::XM_PIDIV2 - context.rotation;
+                    const float cos_a = std::cos(angle);
+                    const float sin_a = std::sin(angle);
+
+                    const float view_dx = dx * cos_a - dy * sin_a;
+                    const float view_dy = dx * sin_a + dy * cos_a;
+
                     const float max_distance = (GW::Constants::Range::Compass - drawing_scale) / context.zoom_scale;
-                    const float distance_sq = dx * dx + dy * dy;
+
+                    const float distance_sq = view_dx * view_dx + view_dy * view_dy;
 
                     auto inner_translate = translate;
 
@@ -306,9 +314,15 @@ void PingsLinesRenderer::DrawPings(IDirect3DDevice9* device)
                         const float distance = std::sqrt(distance_sq);
                         const float factor = max_distance / distance;
 
+                        const float clamped_x = view_dx * factor;
+                        const float clamped_y = view_dy * factor;
+
+                        const float world_dx = clamped_x * cos_a + clamped_y * sin_a;
+                        const float world_dy = -clamped_x * sin_a + clamped_y * cos_a;
+
                         inner_translate = DirectX::XMMatrixTranslation(
-                            center.x + dx * factor,
-                            center.y + dy * factor,
+                            center.x + world_dx,
+                            center.y + world_dy,
                             0.0f
                         );
                     }

--- a/GWToolboxdll/Widgets/Minimap/PingsLinesRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/PingsLinesRenderer.cpp
@@ -43,7 +43,7 @@ void PingsLinesRenderer::DrawSettings()
     ImGui::SmallConfirmButton("Restore Defaults", "Are you sure?", [&](bool result, void*) {
         if (result) {
             color_drawings = Colors::ARGB(0xFF, 0xFF, 0xFF, 0xFF);
-            color_pings = Colors::ARGB(128, 255, 0, 0);
+            color_pings = Colors::ARGB(104, 255, 0, 0);
             marker.color = Colors::ARGB(200, 128, 0, 128);
             color_shadowstep_line = Colors::ARGB(48, 128, 0, 128);
             color_shadowstep_line_maxrange = Colors::ARGB(48, 128, 0, 128);
@@ -52,7 +52,8 @@ void PingsLinesRenderer::DrawSettings()
         }
         });
     changed |= Colors::DrawSettingHueWheel("Drawings", &color_drawings);
-    changed |= Colors::DrawSettingHueWheel("Pings", &color_pings);
+    changed |= Colors::DrawSettingHueWheel("Player Pings", &color_pings);
+    ImGui::ShowHelp("The alpha level is also used for the game's pings");
     changed |= Colors::DrawSettingHueWheel("Shadow Step Marker", &marker.color);
     changed |= Colors::DrawSettingHueWheel("Shadow Step Line", &color_shadowstep_line);
     changed |= Colors::DrawSettingHueWheel("Shadow Step Line (Max range)", &color_shadowstep_line_maxrange);
@@ -267,7 +268,7 @@ void PingsLinesRenderer::DrawPings(IDirect3DDevice9* device)
         }
 
         if (ping->GetColor() != Colors::Empty()) {
-            ping_circle.color = Colors::Sub(ping->GetColor(), Colors::ARGB(128, 0, 0, 0));
+            ping_circle.color = (ping->GetColor() & ~IM_COL32_A_MASK) | (color_pings & IM_COL32_A_MASK);
         }
         else {
             ping_circle.color = color_pings;
@@ -277,21 +278,72 @@ void PingsLinesRenderer::DrawPings(IDirect3DDevice9* device)
         const auto translate = DirectX::XMMatrixTranslation(px, py, 0.0f);
 
         if (ping->ShowInner()) {
-            scale = DirectX::XMMatrixScaling(drawing_scale, drawing_scale, 1.0f);
-            world = scale * translate;
-            device->SetTransform(D3DTS_WORLD, reinterpret_cast<const D3DMATRIX*>(&world));
-            ping_circle.Render(device);
+            static bool requested_inner_texture = false;
+            static IDirect3DTexture9** inner_texture_ptr = nullptr;
+
+            if (!requested_inner_texture) {
+                inner_texture_ptr = GwDatModule::LoadGreyscaleTextureFromFileId(PING_INNER_FILE_ID);
+                requested_inner_texture = true;
+            }
+
+            if(inner_texture_ptr) {
+                const auto context = Minimap::GetRenderContext();
+
+                const GW::Agent* me = GW::Agents::GetObservingAgent();
+
+                if (me) {
+                    const auto center = me->pos - context.translation / context.zoom_scale;
+
+                    float dx = px - center.x;
+                    float dy = py - center.y;
+
+                    const float max_distance = (GW::Constants::Range::Compass - drawing_scale) / context.zoom_scale;
+                    const float distance_sq = dx * dx + dy * dy;
+
+                    auto inner_translate = translate;
+
+                    if (distance_sq > max_distance * max_distance) {
+                        const float distance = std::sqrt(distance_sq);
+                        const float factor = max_distance / distance;
+
+                        inner_translate = DirectX::XMMatrixTranslation(
+                            center.x + dx * factor,
+                            center.y + dy * factor,
+                            0.0f
+                        );
+                    }
+
+                    scale = DirectX::XMMatrixScaling(drawing_scale * 2, drawing_scale * 2, 1.0f);
+                    world = scale * inner_translate;
+                    device->SetTransform(D3DTS_WORLD, reinterpret_cast<const D3DMATRIX*>(&world));
+
+                    ping_circle.texture = *inner_texture_ptr;
+                    ping_circle.Render(device);
+                }
+            }
         }
 
-        int diff = TIMER_DIFF(ping->start);
-        const bool first_loop = diff < 1000;
-        diff = diff % 1000;
-        diff *= first_loop ? 2 : 1;
+        static bool requested_outer_texture = false;
+        static IDirect3DTexture9** outer_texture_ptr = nullptr;
 
-        scale = DirectX::XMMatrixScaling(diff * ping_scale, diff * ping_scale, 1.0f);
-        world = scale * translate;
-        device->SetTransform(D3DTS_WORLD, reinterpret_cast<const D3DMATRIX*>(&world));
-        ping_circle.Render(device);
+        if (!requested_outer_texture) {
+            outer_texture_ptr = GwDatModule::LoadGreyscaleTextureFromFileId(PING_OUTER_FILE_ID);
+            requested_outer_texture = true;
+        }
+
+        if (outer_texture_ptr) {
+            int diff = TIMER_DIFF(ping->start);
+            const bool first_loop = diff < 1000;
+            diff = diff % 1000;
+            diff *= first_loop ? 2 : 1;
+
+            scale = DirectX::XMMatrixScaling(diff * ping_scale, diff * ping_scale, 1.0f);
+            world = scale * translate;
+            device->SetTransform(D3DTS_WORLD, reinterpret_cast<const D3DMATRIX*>(&world));
+
+            ping_circle.texture = *outer_texture_ptr;
+            ping_circle.Render(device);
+        }
     }
     if (!pings.empty()) {
         const Ping* last = pings.back();
@@ -426,31 +478,67 @@ void PingsLinesRenderer::DrawRecallLine(IDirect3DDevice9*)
 void PingsLinesRenderer::PingCircle::Initialize(IDirect3DDevice9* device)
 {
     type = D3DPT_TRIANGLESTRIP;
-    count = 96; // polycount
-    const auto vertex_count = count + 2;
-    D3DVertex* _vertices = nullptr;
+    count = 2;
 
-    if (buffer) {
+    constexpr size_t vertex_count = 4;
+
+    D3DVertexTextured* _vertices = nullptr;
+
+    if (buffer)
+    {
         buffer->Release();
+        buffer = nullptr;
     }
-    device->CreateVertexBuffer(sizeof(D3DVertex) * vertex_count, 0,
-                               D3DFVF_CUSTOMVERTEX, D3DPOOL_MANAGED, &buffer, nullptr);
-    buffer->Lock(0, sizeof(D3DVertex) * vertex_count, reinterpret_cast<void**>(&_vertices),
-                 D3DLOCK_DISCARD);
 
-    for (size_t i = 0; i < count; i++) {
-        const float angle = i * (2 * DirectX::XM_PI / count);
-        const bool outer = i % 2 == 0;
-        const float radius = outer ? 1.0f : 0.8f;
-        _vertices[i].x = radius * std::cos(angle);
-        _vertices[i].y = radius * std::sin(angle);
-        _vertices[i].z = 0.0f;
-        _vertices[i].color = outer ? color : Colors::Sub(color, 0xFF000000);
-    }
-    _vertices[count] = _vertices[0];
-    _vertices[count + 1] = _vertices[1];
+    device->CreateVertexBuffer(
+        sizeof(D3DVertexTextured) * vertex_count,
+        0,
+        D3DFVF_TEXTUREDVERTEX,
+        D3DPOOL_MANAGED,
+        &buffer,
+        nullptr);
+
+    buffer->Lock(
+        0,
+        sizeof(D3DVertexTextured) * vertex_count,
+        reinterpret_cast<void**>(&_vertices),
+        D3DLOCK_DISCARD);
+
+    _vertices[0] = { -1.0f, -1.0f, 0.0f, color, 0.0f, 1.0f };
+    _vertices[1] = { -1.0f,  1.0f, 0.0f, color, 0.0f, 0.0f };
+    _vertices[2] = {  1.0f, -1.0f, 0.0f, color, 1.0f, 1.0f };
+    _vertices[3] = {  1.0f,  1.0f, 0.0f, color, 1.0f, 0.0f };
 
     buffer->Unlock();
+
+    device->SetTextureStageState(0, D3DTSS_COLOROP, D3DTOP_SELECTARG2);
+    device->SetTextureStageState(0, D3DTSS_COLORARG2, D3DTA_DIFFUSE);
+
+    device->SetTextureStageState(0, D3DTSS_ALPHAOP, D3DTOP_MODULATE);
+    device->SetTextureStageState(0, D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
+    device->SetTextureStageState(0, D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
+
+    device->SetRenderState(D3DRS_ALPHABLENDENABLE, TRUE);
+    device->SetRenderState(D3DRS_SRCBLEND,  D3DBLEND_SRCALPHA);
+    device->SetRenderState(D3DRS_DESTBLEND, D3DBLEND_ONE);
+}
+
+void PingsLinesRenderer::PingCircle::Render(IDirect3DDevice9* device)
+{
+    if (dirty) Invalidate();
+    if (!initialized) {
+        initialized = true;
+        Initialize(device);
+    }
+    if (!buffer || !count || !texture) return;
+
+    device->SetTexture(0, texture);
+
+    device->SetFVF(D3DFVF_TEXTUREDVERTEX);
+    device->SetStreamSource(0, buffer, 0, sizeof(D3DVertexTextured));
+    device->DrawPrimitive(type, 0, count);
+
+    device->SetTexture(0, nullptr);
 }
 
 void PingsLinesRenderer::Marker::Initialize(IDirect3DDevice9* device)

--- a/GWToolboxdll/Widgets/Minimap/PingsLinesRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/PingsLinesRenderer.cpp
@@ -286,41 +286,28 @@ void PingsLinesRenderer::DrawPings(IDirect3DDevice9* device)
 
             if(inner_texture_ptr) {
                 const auto context = Minimap::GetRenderContext();
-
                 const GW::Agent* me = GW::Agents::GetObservingAgent();
 
                 if (me) {
-                    const auto center = me->pos - GW::Rotate(context.translation, context.rotation - DirectX::XM_PIDIV2) / context.zoom_scale;
+                    const float rotation = context.rotation - DirectX::XM_PIDIV2;
+                    const auto center = me->pos - GW::Rotate(context.translation, rotation) / context.zoom_scale;
 
-                    float dx = px - center.x;
-                    float dy = py - center.y;
-
-                    const float angle = DirectX::XM_PIDIV2 - context.rotation;
-                    const float cos_a = std::cos(angle);
-                    const float sin_a = std::sin(angle);
-
-                    const float view_dx = dx * cos_a - dy * sin_a;
-                    const float view_dy = dx * sin_a + dy * cos_a;
+                    const auto p = GW::Vec2f(px, py);
+                    const auto delta = p - center;
 
                     const float max_distance = (GW::Constants::Range::Compass - drawing_scale) / context.zoom_scale;
-
-                    const float distance_sq = view_dx * view_dx + view_dy * view_dy;
+                    const float distance_sq = GW::GetSquareDistance(p, center);
 
                     auto inner_translate = translate;
 
                     if (distance_sq > max_distance * max_distance) {
-                        const float distance = std::sqrt(distance_sq);
+                        const float distance = GW::GetDistance(p, center);
                         const float factor = max_distance / distance;
-
-                        const float clamped_x = view_dx * factor;
-                        const float clamped_y = view_dy * factor;
-
-                        const float world_dx = clamped_x * cos_a + clamped_y * sin_a;
-                        const float world_dy = -clamped_x * sin_a + clamped_y * cos_a;
+                        const auto clamped = delta * factor;
 
                         inner_translate = DirectX::XMMatrixTranslation(
-                            center.x + world_dx,
-                            center.y + world_dy,
+                            center.x + clamped.x,
+                            center.y + clamped.y,
                             0.0f
                         );
                     }

--- a/GWToolboxdll/Widgets/Minimap/PingsLinesRenderer.cpp
+++ b/GWToolboxdll/Widgets/Minimap/PingsLinesRenderer.cpp
@@ -278,12 +278,10 @@ void PingsLinesRenderer::DrawPings(IDirect3DDevice9* device)
         const auto translate = DirectX::XMMatrixTranslation(px, py, 0.0f);
 
         if (ping->ShowInner()) {
-            static bool requested_inner_texture = false;
             static IDirect3DTexture9** inner_texture_ptr = nullptr;
 
-            if (!requested_inner_texture) {
+            if (inner_texture_ptr == nullptr) {
                 inner_texture_ptr = GwDatModule::LoadGreyscaleTextureFromFileId(PING_INNER_FILE_ID);
-                requested_inner_texture = true;
             }
 
             if(inner_texture_ptr) {
@@ -337,12 +335,10 @@ void PingsLinesRenderer::DrawPings(IDirect3DDevice9* device)
             }
         }
 
-        static bool requested_outer_texture = false;
         static IDirect3DTexture9** outer_texture_ptr = nullptr;
 
-        if (!requested_outer_texture) {
+        if (outer_texture_ptr == nullptr) {
             outer_texture_ptr = GwDatModule::LoadGreyscaleTextureFromFileId(PING_OUTER_FILE_ID);
-            requested_outer_texture = true;
         }
 
         if (outer_texture_ptr) {

--- a/GWToolboxdll/Widgets/Minimap/PingsLinesRenderer.h
+++ b/GWToolboxdll/Widgets/Minimap/PingsLinesRenderer.h
@@ -4,6 +4,8 @@
 #include <GWCA/Managers/UIMgr.h>
 #include <GWCA/Packets/StoC.h>
 
+#include <Modules/GwDatModule.h>
+
 #include <Color.h>
 #include <Timer.h>
 
@@ -15,6 +17,9 @@ class PingsLinesRenderer : public D3DVertexBuffer {
     friend class Minimap;
     const float drawing_scale = 96.0f;
     const clock_t drawing_timeout = 5000;
+
+    const uint32_t PING_INNER_FILE_ID = 50468;
+    const uint32_t PING_OUTER_FILE_ID = 49225;
 
     struct DrawingLine {
         DrawingLine()
@@ -91,6 +96,9 @@ class PingsLinesRenderer : public D3DVertexBuffer {
 
     public:
         Color color = Colors::ARGB(128, 255, 0, 0);
+        IDirect3DTexture9* texture = nullptr;
+
+        void Render(IDirect3DDevice9* device) override;
     };
 
     class Marker : public D3DVertexBuffer {
@@ -179,7 +187,7 @@ private:
     std::vector<GW::UI::CompassPoint> queue{};
 
     Color color_drawings = Colors::ARGB(0xFF, 0xFF, 0xFF, 0xFF);
-    Color color_pings = Colors::ARGB(128, 255, 0, 0);
+    Color color_pings = Colors::ARGB(104, 255, 0, 0);
     Color color_shadowstep_line = Colors::ARGB(155, 128, 0, 128);
     Color color_shadowstep_line_maxrange = Colors::ARGB(255, 255, 0, 128);
     float maxrange_interp_begin = 0.85f;


### PR DESCRIPTION
Continuation of #2598

- Use ping texture for rendering
- Clamp inner ping to minimap edge
- Use sensible default for ping opacity

As mentioned in #2598 playing sounds with the game's compass disable would also be nice but using the sound file id didn't seem to play anything for me and I don't care enough to investigate further right now.

Example:
<img width="727" height="376" alt="image" src="https://github.com/user-attachments/assets/44f2669d-972e-47f3-ba27-c57f03b48ab2" />
