### PR TITLE
Add option to hide compass pings

### DIFF
--- a/GWToolboxdll/Widgets/Minimap/Minimap.cpp
+++ b/GWToolboxdll/Widgets/Minimap/Minimap.cpp
@@ -124,6 +124,7 @@ namespace {
 
     bool hide_compass_agents = false;
     bool hide_compass_drawings = false;
+    bool hide_compass_pings = false;
     bool hide_compass_quest_marker = false;
     bool render_all_quests = false;
 
@@ -787,6 +788,7 @@ void Minimap::Initialize()
     SettingsRegistry::RegisterField(this, "render_all_quests", &render_all_quests);
     SettingsRegistry::RegisterField(this, "hide_compass_quest_marker", &hide_compass_quest_marker);
     SettingsRegistry::RegisterField(this, "hide_compass_drawings", &hide_compass_drawings);
+    SettingsRegistry::RegisterField(this, "hide_compass_pings", &hide_compass_pings);
     SettingsRegistry::RegisterField(this, "hide_flagging_controls", &hide_flagging_controls);
     SettingsRegistry::RegisterField(this, "hide_compass_when_minimap_draws", &hide_compass_when_minimap_draws);
     register_color("color_map", &color_map);
@@ -870,6 +872,9 @@ void Minimap::OnUIMessage(GW::HookStatus* status, const GW::UI::UIMessage msgid,
             ASSERT(wParam);
             if (hide_compass_drawings) status->blocked = true;
         } break;
+        case GW::UI::UIMessage::kCompassPing:
+            if (hide_compass_pings) status->blocked = true;
+            break;
         case GW::UI::UIMessage::kMapLoaded: {
             in_interface_settings = false;
             EnsureCompassIsLoaded();
@@ -1032,6 +1037,7 @@ void Minimap::DrawSettingsInternal()
     ImGui::CheckboxWithHelp("Draw all quest markers", &render_all_quests, "Draw quest markers for all quests in your quest log, not just the active quest");
 
     ImGui::CheckboxWithHelp("Hide GW compass drawings", &hide_compass_drawings, "Drawings made by other players will be visible on the minimap, but not the compass");
+    ImGui::CheckboxWithHelp("Hide GW compass pings", &hide_compass_pings, "Pings made by other players will be visible on the minimap, but not the compass");
     if (ImGui::Checkbox("Hide GW compass when minimap is visible", &hide_compass_when_minimap_draws)) {
         GW::GameThread::Enqueue(OverrideCompassVisibility);
     }


### PR DESCRIPTION
## Summary
- add a persisted minimap setting to hide native Guild Wars compass pings
- retain ping rendering on the Toolbox minimap

## Verification
- 
- not run: project builds/tests are prohibited in this workspace