### PR TITLE
release: prepare 8.34 beta 1

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,8 +1,8 @@
 name: CMake
 
 on:
-  # push covers dev (post-merge validation) and master (release builds, gated
-  # below on should_release). pull_request covers PRs against dev - including
+  # push covers dev (post-merge validation and beta releases) and master
+  # (release builds). pull_request covers PRs against dev - including
   # from forks, where CERTUM_OTP_URI is unset and signing/release is skipped -
   # so branches only build once a PR is open instead of on every push.
   push:
@@ -137,7 +137,7 @@ jobs:
 
     - name: Determine release version
       id: version
-      if: github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev'
       shell: bash
       run: |
         VERSION=$(sed -n 's/.*set(GWTOOLBOXDLL_VERSION "\(.*\)").*/\1/p' CMakeLists.txt | tr -d '\r')
@@ -146,6 +146,12 @@ jobs:
         if [ -z "$VERSION" ]; then
           echo "Could not find version in CMakeLists.txt"
           exit 1
+        fi
+
+        if [ "$GITHUB_REF" = 'refs/heads/dev' ] && [ -z "$BETA" ]; then
+          echo "Dev builds require a beta version. Skipping release."
+          echo "should_release=false" >> "$GITHUB_OUTPUT"
+          exit 0
         fi
 
         if [ -z "$BETA" ]; then
@@ -159,6 +165,11 @@ jobs:
         echo "Target tag: $TAG_NAME"
         echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
         echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        if [ -n "$BETA" ]; then
+          echo "prerelease=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "prerelease=false" >> "$GITHUB_OUTPUT"
+        fi
 
         if git ls-remote --tags origin "refs/tags/$TAG_NAME" | grep -q .; then
           echo "Tag $TAG_NAME already exists. Skipping release."
@@ -206,6 +217,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAG_NAME: ${{ steps.version.outputs.tag_name }}
         VERSION: ${{ steps.version.outputs.version }}
+        PRERELEASE: ${{ steps.version.outputs.prerelease }}
         BIN_DIR: ${{ runner.workspace }}/GWToolboxpp/bin/RelWithDebInfo
       run: |
         # Already built by compress.ps1 (GWToolboxdll/CMakeLists.txt POST_BUILD) - no need to re-gzip.
@@ -229,7 +241,13 @@ jobs:
         git tag "$TAG_NAME"
         git push origin "$TAG_NAME"
 
+        release_args=()
+        if [ "$PRERELEASE" = 'true' ]; then
+          release_args+=(--prerelease)
+        fi
+
         gh release create "$TAG_NAME" \
           --title "$TAG_NAME" \
           --notes-file release_notes.md \
+          "${release_args[@]}" \
           "$BIN_DIR/GWToolbox.exe" "$BIN_DIR/GWToolboxdll.dll" GWToolboxdll.pdb.gz

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,9 +8,9 @@ project(gwtoolbox)
 
 set(GWTOOLBOXEXE_VERSION "4.8")
 set(GWTOOLBOXEXE_MODULE_VERSION "4,8,0,0") # used for exe module info. See GWToolbox/GWToolbox.rc
-set(GWTOOLBOXDLL_VERSION "8.33")
-set(GWTOOLBOXDLL_VERSION_BETA "") # can be anything. Marks beta version if not empty.
-set(GWTOOLBOX_MODULE_VERSION "8,33,0,0") # used for Dll module info. See GWToolboxdll/GWToolbox.rc
+set(GWTOOLBOXDLL_VERSION "8.34")
+set(GWTOOLBOXDLL_VERSION_BETA "Beta1") # can be anything. Marks beta version if not empty.
+set(GWTOOLBOX_MODULE_VERSION "8,34,0,0") # used for Dll module info. See GWToolboxdll/GWToolbox.rc
 
 
 # Everything below this point (toolset/arch checks, MSVC-only flags, native-only


### PR DESCRIPTION
Prepares the 8.34 Beta1 dev prerelease.\n\n- Publishes beta-marked dev builds as GitHub prereleases\n- Uses the 8.34 history entry as the release body\n- Leaves non-beta dev builds as validation-only