### PR TITLE
ci: allow release after signing cleanup failure

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -207,6 +207,7 @@ jobs:
 
     - name: Disconnect Certum SimplySign
       if: always() && steps.version.outputs.should_release == 'true' && env.HAS_CERTUM_CREDENTIALS == 'true'
+      continue-on-error: true
       shell: pwsh
       run: ./.github/scripts/disconnect-simplysign.ps1
 


### PR DESCRIPTION
The Certum disconnect cleanup failed after a successful signed build, preventing the release step from running. Keep cleanup attempted, but do not let its failure block publishing the release.